### PR TITLE
GH-74: Upgrade to latest cobbler-scaffold

### DIFF
--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260227.3
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260301.2
 )
 
 require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260227.3 h1:9y+zGcWoQibt+oIOnf1SaxYmKfmvCiUq7llG112NLMo=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260227.3/go.mod h1:Gckwhzbo48sx2lNxv46vZCHIZRm+8GMffFJrvK0ZMqM=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260301.2 h1:6j5wFHijduATyvYZYUe7VnrKlXvnXhEEREtb9iCs2eI=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260301.2/go.mod h1:Gckwhzbo48sx2lNxv46vZCHIZRm+8GMffFJrvK0ZMqM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/magefiles/orchestrator.go
+++ b/magefiles/orchestrator.go
@@ -114,7 +114,8 @@ func (Cobbler) Reset() error { return newOrch().CobblerReset() }
 func (Generator) Start() error { return newOrch().GeneratorStart() }
 
 // Run executes N cycles of measure + stitch within the current generation.
-func (Generator) Run() error { return newOrch().GeneratorRun() }
+// Pass 0 to use the configured cycle count from configuration.yaml.
+func (Generator) Run(cycles int) error { return newOrch().GeneratorRun(cycles) }
 
 // Resume recovers from an interrupted run and continues.
 func (Generator) Resume() error { return newOrch().GeneratorResume() }


### PR DESCRIPTION
## Summary

Upgrade cobbler-scaffold from v0.20260227.3 to v0.20260301.2. This brings in beads-to-GitHub-Issues migration, several bug fixes (subrequirement counting, stale generation issues, ready-label lag), and the GeneratorRun cycle count argument.

## Changes

- Bumped `magefiles/go.mod` dependency to `v0.20260301.2`
- Updated `magefiles/go.sum` with new checksums
- Updated `magefiles/orchestrator.go`: `Generator.Run` now accepts a `cycles int` parameter

## Stats

- 3 files changed, 5 insertions, 4 deletions
- `mage analyze` passes clean
- `mage stats:loc`: 0 Go LOC (spec-only branch), 14,172 PRD words, 6,367 test suite words

## Test plan

- [x] `mage -l` lists all 24 targets
- [x] `mage analyze` passes
- [x] `mage stats:loc` works
- [x] No compilation errors

Closes #74