### PR TITLE
Upgrade cobbler-scaffold to v0.20260302.0 (GH-150)

### DIFF
--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260301.2
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260302.0
 )
 
 require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260301.2 h1:6j5wFHijduATyvYZYUe7VnrKlXvnXhEEREtb9iCs2eI=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260301.2/go.mod h1:Gckwhzbo48sx2lNxv46vZCHIZRm+8GMffFJrvK0ZMqM=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260302.0 h1:rTFzTTBjeFfGDfnSqGbDKl1Yb9S8VRuxWrhY8D6/nqM=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260302.0/go.mod h1:Gckwhzbo48sx2lNxv46vZCHIZRm+8GMffFJrvK0ZMqM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Summary

Upgrades cobbler-scaffold from v0.20260301.2 to v0.20260302.0, picking up fixes for the
issues JSON parsing bug (#453) and binary artifact commit (#456) discovered during run 10.

## Changes

- Updated magefiles/go.mod: cobbler-scaffold v0.20260301.2 → v0.20260302.0
- Updated magefiles/go.sum with new checksums

## Test plan

- [x] `mage analyze` passes
- [ ] Next generation run verifies measure agent sees existing issues (issues=N where N>0)
- [ ] Next generation run verifies no compiled binaries committed to generation branch

Closes #150