### PR TITLE
GH-180: Upgrade cobbler-scaffold v0.20260302.0 → v0.20260303.0

### DIFF
--- a/.cobbler/measure_context.yaml
+++ b/.cobbler/measure_context.yaml
@@ -1,0 +1,17 @@
+# Phase context for the measure workflow.
+# Fields override the corresponding configuration.yaml settings when present.
+# Remove or leave fields empty to use configuration.yaml defaults.
+# See docs/engineering/eng08-phase-context-files.yaml for schema details.
+
+# include: |
+#   docs/VISION.yaml
+#   docs/ARCHITECTURE.yaml
+#   docs/specs/**/*.yaml
+
+# exclude: |
+#   docs/engineering/*
+
+# sources: |
+#   docs/constitutions/*.yaml
+
+# release: "01.0"

--- a/.cobbler/stitch_context.yaml
+++ b/.cobbler/stitch_context.yaml
@@ -1,0 +1,16 @@
+# Phase context for the stitch workflow.
+# Fields override the corresponding configuration.yaml settings when present.
+# Remove or leave fields empty to use configuration.yaml defaults.
+# See docs/engineering/eng08-phase-context-files.yaml for schema details.
+
+# include: |
+#   docs/ARCHITECTURE.yaml
+#   docs/specs/product-requirements/prd*.yaml
+
+# exclude: |
+#   docs/engineering/*
+
+# sources: |
+#   docs/constitutions/*.yaml
+
+# release: "01.0"

--- a/docs/constitutions/design.yaml
+++ b/docs/constitutions/design.yaml
@@ -107,7 +107,7 @@ document_types:
       - title
       - overview (summary, lifecycle, coordination_pattern)
       - interfaces (data_structures, operations, announcements)
-      - components (name, responsibility, capabilities, references)
+      - components (name, provided_by, responsibility, capabilities, references)
       - design_decisions (id, title, decision, benefits, alternatives_rejected)
       - technology_choices
       - project_structure

--- a/docs/constitutions/execution.yaml
+++ b/docs/constitutions/execution.yaml
@@ -155,7 +155,7 @@ session_completion:
     - Do NOT run any git commands (add, commit, status, init, rm .git)
     - Git is managed externally by the orchestrator
     - Your job is to write code and verify it works
-    - Do NOT use cupboard commands
+    - Do NOT use bd or cupboard commands
 
 technology:
   primary_language: Go
@@ -198,8 +198,7 @@ sections:
     title: Technology Stack
     content: |
       The project uses Go with mage for build automation, cobra for CLI, viper
-      for configuration, yaml.v3 for YAML parsing, and cupboard for issue
-      tracking.
+      for configuration, yaml.v3 for YAML parsing, and cupboard for issue tracking.
   - tag: git_conventions
     title: Git Conventions
     content: |

--- a/docs/constitutions/testing.yaml
+++ b/docs/constitutions/testing.yaml
@@ -1,0 +1,81 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+#
+# Testing Constitution
+#
+# Rules for test naming, organization, and traceability. Scaffolded into
+# consuming projects so Claude and contributors follow a consistent
+# test structure.
+
+articles:
+  - id: T1
+    title: Hierarchical test naming
+    rule: |
+      Encode the test suite and use case into every test function name using
+      a fixed prefix: Test{Suite}_UC{NNN}_DescriptiveName.
+
+      {Suite} identifies the test suite (e.g., Rel01, Alpha, Smoke).
+      UC{NNN} is the zero-padded use case number from the spec.
+      DescriptiveName is CamelCase and describes the behavior under test
+      in action-outcome form (e.g., CreateReturnsID, StartFailsWhenLocked).
+
+      The prefix hierarchy enables filtering at any granularity:
+
+        go test -run TestRel01             # entire suite
+        go test -run TestRel01_UC003       # one use case
+        go test -run TestRel01_UC003_Create  # one test
+
+  - id: T2
+    title: One file per use case
+    rule: |
+      Group tests into one file per use case, named uc{NNN}_{slug}_test.go.
+      Shared test infrastructure (setup, helpers, TestMain) lives in a
+      dedicated helpers file (e.g., helpers_test.go). Do not mix tests from
+      different use cases in the same file.
+
+  - id: T3
+    title: Spec-to-code traceability
+    rule: |
+      Every test case entry in the test suite spec must reference the test
+      function that implements it. Every test function must appear in the
+      spec. No orphans in either direction.
+
+      When one test function covers multiple spec entries, each entry
+      references the same function. The entry with the closest name match
+      is the primary; others note the shared coverage.
+
+  - id: T4
+    title: Test count invariant
+    rule: |
+      The number of test functions in a suite must be greater than or equal
+      to the number of test case entries in the corresponding spec. Tests
+      may exceed the spec count (edge cases, performance tests) but must
+      never fall below it. Reorganizing tests must not reduce the total.
+
+  - id: T5
+    title: Mage target naming
+    rule: |
+      Expose each use case as a mage target under the Test namespace:
+
+        (Test) Uc{NNN}{UseCaseSlug}()
+
+      {NNN} is the zero-padded use case number. {UseCaseSlug} is the
+      CamelCase form of the use case slug from the spec (e.g.,
+      OrchestratorInitialization, MeasureWorkflow, BuildTooling).
+
+      Additionally provide test:usecase (all use-case tests), test:unit (package
+      tests), and test:all (both). Examples:
+
+        mage test:uc001OrchestratorInitialization
+        mage test:uc003MeasureWorkflow
+        mage test:usecase
+
+sections:
+  - tag: articles
+    title: Testing Principles
+    content: |
+      Five principles govern the testing phase: hierarchical test naming
+      (Test{Suite}_UC{NNN}_DescriptiveName), one file per use case,
+      bidirectional spec-to-code traceability, a test count invariant that
+      never allows fewer tests than spec entries, and mage test:uc{NNN} targets
+      for each use case.

--- a/docs/prompts/measure.yaml
+++ b/docs/prompts/measure.yaml
@@ -25,10 +25,10 @@ task: |
 constraints: |
   - Do NOT use any tools. Do NOT explore the filesystem, read files, or run commands. All project information is in the project_context above. Your response must be text only with zero tool calls.
   - Do NOT interact with the issue tracker directly.
-  - Do NOT propose tasks for paths excluded by ARCHITECTURE.yaml design decision DD7 (generation scope). The excluded paths are: magefiles/, configuration.yaml, .cobbler/, .claude/, docs/. The pipeline targets only cmd/ and pkg/ directories.
   - Do NOT duplicate existing issues. Review the issues in the project_context above before proposing.
   - Issues with status "closed" represent COMPLETED work. Do not re-propose work that a closed issue already covers, even under a different title or framing. The completed_work field in project_context lists all finished tasks — treat every entry as work that must not be repeated.
   - When source_code contains .go files for a package, that package already exists. Do not propose creating or reimplementing it. Trust the source code over prose descriptions in documentation (e.g., implementation_status sections in ARCHITECTURE.yaml may be stale).
+  - Components with a provided_by field in ARCHITECTURE.yaml are external infrastructure. Do NOT propose tasks that create or modify files in those components.
   - Do NOT exceed {limit} tasks. If more work is needed, create additional tasks in a future session.
   - Do NOT create tasks larger than {lines_max} lines of production code. Target {lines_min}-{lines_max} lines per task, touching 5-7 files. Split aggressively: a task that creates a struct and implements its methods is two tasks.
   - Each task must contain at most {max_requirements} requirements. Split any task that would exceed this limit.
@@ -36,7 +36,7 @@ constraints: |
   - Do NOT assume the stitch agent has access to your analysis, the existing issues list, or any context from this conversation.
   - Do NOT propose tasks that require human judgment or manual testing. Each task must have checkable acceptance criteria.
   - Anchor every task to specific PRD requirement IDs (e.g., prd001 R1.1). Include the requirement ID in the task title. Given the same PRD and release, the same tasks should be proposed regardless of how many times this prompt is run.
-  - Order tasks canonically using the following deterministic sequence. Given the same project state, two runs of this prompt must produce tasks in the same order. (1) All pkg/ implementation tasks, sorted alphabetically by primary file path. (2) All pkg/ test tasks, sorted alphabetically by the package under test. (3) All cmd/ implementation tasks, sorted by release number then alphabetically by command name. (4) All cmd/ test tasks, sorted by release number then alphabetically by command name. Within each group, documentation before code, types before implementations, libraries before consumers.
+  - Order tasks canonically: documentation before code, types before implementations, libraries before consumers, implementation before tests. Break ties by primary file path alphabetically.
   - Derive file names from PRD/architecture names, not invented names. If the architecture calls a component "crumb", the file is crumb.go.
   - Do NOT invent design decisions not derived from the PRD or architecture. Derive struct shapes, timeout strategies, file names, and naming conventions from the PRD rather than making arbitrary choices. If the PRD does not specify a detail, omit it from design decisions rather than inventing one.
   - When a PRD specifies a concrete design choice (e.g., "use a FileExpectation struct", "the main file is difftest.go", "timeout is configurable via context"), copy that choice verbatim into the task's design_decisions. Do not rephrase, generalize, or substitute alternatives. The PRD is the single source of truth for implementation details.

--- a/docs/prompts/stitch.yaml
+++ b/docs/prompts/stitch.yaml
@@ -19,7 +19,8 @@ constraints: |
   - Do NOT read files already provided in project_context. They are already inline above.
   - Do NOT explore the filesystem. Do NOT run ls, find, tree, or similar commands.
   - Do NOT modify files outside the Files to Create/Modify list unless a requirement explicitly demands it.
-  - Do NOT use cupboard commands. Task tracking is handled externally.
+  - Do NOT use bd or cupboard commands. Task tracking is handled externally.
   - Do NOT invent interfaces, types, or patterns not described in the source code, Required Reading, or PRDs.
   - Do NOT add features, refactoring, or improvements beyond what the requirements specify.
   - Do NOT run any git commands. No git add, git commit, git init, git status, rm .git, or any other git operation. Git is managed externally by the orchestrator. Just write code and verify it compiles and passes tests.
+  - When building cmd/ binaries to verify compilation, use `go build -o bin/<name> ./cmd/<name>/` so outputs land in bin/ (which is git-ignored) rather than in the working directory.

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260302.0
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260303.0
 )
 
 require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260302.0 h1:rTFzTTBjeFfGDfnSqGbDKl1Yb9S8VRuxWrhY8D6/nqM=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260302.0/go.mod h1:Gckwhzbo48sx2lNxv46vZCHIZRm+8GMffFJrvK0ZMqM=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260303.0 h1:ACyMCRwBDBwFzYlyBdS6uZrEmqN/kea3FATj8+vIIUc=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260303.0/go.mod h1:Gckwhzbo48sx2lNxv46vZCHIZRm+8GMffFJrvK0ZMqM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/magefiles/orchestrator.go
+++ b/magefiles/orchestrator.go
@@ -66,7 +66,7 @@ func logf(format string, args ...any) {
 // Init initializes the project.
 func Init() error { return newOrch().Init() }
 
-// Reset performs a full reset: cobbler, generator.
+// Reset performs a full reset: cobbler and generator.
 func Reset() error { return newOrch().FullReset() }
 
 // Build compiles the project binary.
@@ -113,9 +113,13 @@ func (Cobbler) Reset() error { return newOrch().CobblerReset() }
 // Start begins a new generation trail.
 func (Generator) Start() error { return newOrch().GeneratorStart() }
 
-// Run executes N cycles of measure + stitch within the current generation.
-// Pass 0 to use the configured cycle count from configuration.yaml.
-func (Generator) Run(cycles int) error { return newOrch().GeneratorRun(cycles) }
+// Run executes measure + stitch cycles using the generation.cycles value in configuration.yaml.
+// Use RunN to override the cycle count for a single invocation.
+func (Generator) Run() error { return newOrch().GeneratorRun(0) }
+
+// RunN executes exactly n cycles of measure + stitch within the current generation.
+// Pass n > 0 to override generation.cycles in configuration.yaml for this run only.
+func (Generator) RunN(n int) error { return newOrch().GeneratorRun(n) }
 
 // Resume recovers from an interrupted run and continues.
 func (Generator) Resume() error { return newOrch().GeneratorResume() }


### PR DESCRIPTION
## Summary

Upgraded cobbler-scaffold from v0.20260302.0 to v0.20260303.0 (24 upstream commits). Notable additions: idle-output watchdog for hung stitch sessions, history preservation across resume cycles, beads removal, multi-cmd build with bin/ gitignore.

## Changes

- Updated magefiles/orchestrator.go (Generator.Run split into Run/RunN)
- Updated docs/constitutions/design.yaml, execution.yaml
- Added docs/constitutions/testing.yaml (new)
- Updated docs/prompts/measure.yaml, stitch.yaml
- Updated magefiles/go.mod, go.sum
- Added .cobbler/measure_context.yaml, stitch_context.yaml (new)

## Stats

```
scaffold: v0.20260302.0 → v0.20260303.0
files changed: 7 modified, 3 new
mage analyze: 0 schema errors, 0 constitution drift
```

## Test plan

- [x] `mage analyze` passes (0 new errors)
- [x] `mage -l` shows all targets including new RunN
- [x] Local configuration.yaml preserved (skipped by scaffold)

Closes #180