### PR TITLE
GH-220: Move wc to rel03.0, ls to rel04.0, add to generation

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -19,7 +19,7 @@ project:
       docs/SPECIFICATIONS.yaml
       docs/road-map.yaml
     release: ""
-    releases: ["00.0", "01.0", "01.1", "01.2", "01.3", "02.0", "02.1", "02.2"]
+    releases: ["00.0", "01.1", "01.2", "01.3", "02.0", "02.1", "02.2", "03.0", "04.0", "04.1"]
     seed_files: {}
 generation:
     prefix: generation-

--- a/docs/SPECIFICATIONS.yaml
+++ b/docs/SPECIFICATIONS.yaml
@@ -13,11 +13,6 @@ roadmap_summary:
     use_cases_done: 4
     use_cases_total: 4
     status: spec_complete
-  - version: rel01.0
-    name: "Batch 1 — wc specification and differential test"
-    use_cases_done: 1
-    use_cases_total: 1
-    status: spec_complete
   - version: rel01.1
     name: "Batch 1.1 — cat specification and differential test"
     use_cases_done: 1
@@ -48,13 +43,18 @@ roadmap_summary:
     use_cases_done: 1
     use_cases_total: 1
     status: pending
-  - version: rel99.0
-    name: "Deferred — ls core specification and differential test"
+  - version: rel03.0
+    name: "Batch 3 — wc specification and differential test"
     use_cases_done: 1
     use_cases_total: 1
     status: spec_complete
-  - version: rel99.1
-    name: "Deferred — ls extended specification and differential test"
+  - version: rel04.0
+    name: "Batch 4 — ls core specification and differential test"
+    use_cases_done: 1
+    use_cases_total: 1
+    status: spec_complete
+  - version: rel04.1
+    name: "Batch 4.1 — ls extended specification and differential test"
     use_cases_done: 1
     use_cases_total: 1
     status: spec_complete
@@ -136,12 +136,12 @@ prd_index:
     path: docs/specs/product-requirements/prd018-head.yaml
 
 use_case_index:
-  - id: rel01.0-uc001-wc
+  - id: rel03.0-uc001-wc
     title: "Count lines, words, and bytes via wc"
-    release: rel01.0
+    release: rel03.0
     status: spec_complete
-    test_suite: test-rel01.0
-    path: docs/specs/use-cases/rel01.0-uc001-wc.yaml
+    test_suite: test-rel03.0
+    path: docs/specs/use-cases/rel03.0-uc001-wc.yaml
   - id: rel01.1-uc001-cat
     title: "Concatenate and display files via cat"
     release: rel01.1
@@ -160,18 +160,18 @@ use_case_index:
     status: spec_complete
     test_suite: test-rel01.3
     path: docs/specs/use-cases/rel01.3-uc001-du.yaml
-  - id: rel99.0-uc001-ls
+  - id: rel04.0-uc001-ls
     title: "List directory contents via ls (core flags)"
-    release: rel99.0
+    release: rel04.0
     status: spec_complete
-    test_suite: test-rel99.0
-    path: docs/specs/use-cases/rel99.0-uc001-ls.yaml
-  - id: rel99.1-uc001-ls-extended
+    test_suite: test-rel04.0
+    path: docs/specs/use-cases/rel04.0-uc001-ls.yaml
+  - id: rel04.1-uc001-ls-extended
     title: "List directory contents via ls (extended flags)"
-    release: rel99.1
+    release: rel04.1
     status: spec_complete
-    test_suite: test-rel99.1
-    path: docs/specs/use-cases/rel99.1-uc001-ls-extended.yaml
+    test_suite: test-rel04.1
+    path: docs/specs/use-cases/rel04.1-uc001-ls-extended.yaml
   - id: rel99.2-uc001-ts
     title: "Timestamp stdin lines via ts"
     release: rel99.2
@@ -223,12 +223,12 @@ use_case_index:
     path: docs/specs/use-cases/rel02.2-uc001-head.yaml
 
 test_suite_index:
-  - id: test-rel01.0
-    title: "Test Suite: rel01.0 — wc specification and differential test"
+  - id: test-rel03.0
+    title: "Test Suite: rel03.0 — wc specification and differential test"
     traces:
-      - rel01.0-uc001-wc
+      - rel03.0-uc001-wc
     test_case_count: 13
-    path: docs/specs/test-suites/test-rel01.0.yaml
+    path: docs/specs/test-suites/test-rel03.0.yaml
   - id: test-rel01.1
     title: "Test Suite: rel01.1 — cat specification and differential test"
     traces:
@@ -247,18 +247,18 @@ test_suite_index:
       - rel01.3-uc001-du
     test_case_count: 11
     path: docs/specs/test-suites/test-rel01.3.yaml
-  - id: test-rel99.0
-    title: "Test Suite: rel99.0 — ls core flag listing"
+  - id: test-rel04.0
+    title: "Test Suite: rel04.0 — ls core flag listing"
     traces:
-      - rel99.0-uc001-ls
+      - rel04.0-uc001-ls
     test_case_count: 13
-    path: docs/specs/test-suites/test-rel99.0.yaml
-  - id: test-rel99.1
-    title: "Test Suite: rel99.1 — ls extended flag listing"
+    path: docs/specs/test-suites/test-rel04.0.yaml
+  - id: test-rel04.1
+    title: "Test Suite: rel04.1 — ls extended flag listing"
     traces:
-      - rel99.1-uc001-ls-extended
+      - rel04.1-uc001-ls-extended
     test_case_count: 14
-    path: docs/specs/test-suites/test-rel99.1.yaml
+    path: docs/specs/test-suites/test-rel04.1.yaml
   - id: test-rel99.2
     title: "Test Suite: rel99.2 — ts timestamp stdin lines"
     traces:
@@ -290,7 +290,7 @@ test_suite_index:
     path: docs/specs/test-suites/test-rel02.2.yaml
 
 prd_to_use_case_mapping:
-  - use_case: rel01.0-uc001-wc
+  - use_case: rel03.0-uc001-wc
     prd: prd005-wc
     why_required: wc exercises multi-file output, column alignment, and locale handling.
     coverage: Full — all prd005-wc requirement groups (R1-R6) are traced from the test suite.
@@ -306,11 +306,11 @@ prd_to_use_case_mapping:
     prd: prd009-du
     why_required: du exercises hard-link deduplication and recursive block accumulation.
     coverage: Full — all prd009-du requirement groups (R1-R5) are traced from the test suite.
-  - use_case: rel99.0-uc001-ls
+  - use_case: rel04.0-uc001-ls
     prd: prd008-ls
     why_required: ls core exercises pkg/sys and pkg/format for the first time in the pipeline.
     coverage: Full — all prd008-ls requirement groups (R1-R7) are traced from the test suite.
-  - use_case: rel99.1-uc001-ls-extended
+  - use_case: rel04.1-uc001-ls-extended
     prd: prd010-ls-extended
     why_required: ls extended exercises sort modes, metadata display, classification, and recursive listing.
     coverage: Full — all prd010-ls-extended requirement groups (R1-R6) are traced from the test suite.
@@ -353,11 +353,9 @@ coverage_gaps: |
   and test suites in rel00.0 (foundational infrastructure). They are also exercised indirectly
   through the utility use cases that depend on them.
 
-  prd019-seq has no use case yet; it is planned for rel03.0. prd011-magefiles is an
-  infrastructure PRD covered indirectly by rel00.0 use cases.
+  prd011-magefiles is an infrastructure PRD covered indirectly by rel00.0 use cases.
 
-  ls (prd008-ls, prd010-ls-extended) is deferred to rel99.0/rel99.1 and ts (prd004-ts)
-  is deferred to rel99.2, but all retain full specification coverage.
+  ts (prd004-ts) is deferred to rel99.2 but retains full specification coverage.
 
 traceability_diagram: |
   ```mermaid
@@ -370,14 +368,14 @@ traceability_diagram: |
     P12["prd012-yes"] & P13["prd013-true"] & P14["prd014-false"]
     P15["prd015-basename"] & P16["prd016-dirname"]
     P17["prd017-tee"] & P18["prd018-head"]
-    UC1["rel01.0-uc001-wc"] & UC2["rel01.1-uc001-cat"] & UC3["rel01.2-uc001-sponge"]
-    UC4["rel01.3-uc001-du"] & UC5["rel99.0-uc001-ls"] & UC6["rel99.1-uc001-ls-extended"]
+    UC1["rel03.0-uc001-wc"] & UC2["rel01.1-uc001-cat"] & UC3["rel01.2-uc001-sponge"]
+    UC4["rel01.3-uc001-du"] & UC5["rel04.0-uc001-ls"] & UC6["rel04.1-uc001-ls-extended"]
     UC7["rel99.2-uc001-ts"]
     UC8["rel02.0-uc001-true"] & UC9["rel02.0-uc002-false"] & UC10["rel02.0-uc003-yes"]
     UC11["rel02.0-uc004-basename"] & UC12["rel02.0-uc005-dirname"]
     UC13["rel02.1-uc001-tee"] & UC14["rel02.2-uc001-head"]
-    TS1["test-rel01.0"] & TS2["test-rel01.1"] & TS3["test-rel01.2"]
-    TS4["test-rel01.3"] & TS5["test-rel99.0"] & TS6["test-rel99.1"] & TS7["test-rel99.2"]
+    TS1["test-rel03.0"] & TS2["test-rel01.1"] & TS3["test-rel01.2"]
+    TS4["test-rel01.3"] & TS5["test-rel04.0"] & TS6["test-rel04.1"] & TS7["test-rel99.2"]
     TS8["test-rel02.0"] & TS9["test-rel02.1"] & TS10["test-rel02.2"]
     V --> A
     A --> P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9 & P10

--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -21,16 +21,6 @@ releases:
       - id: rel00.0-uc004-testutils
         status: spec_complete
 
-  - version: "01.0"
-    name: "Batch 1 — wc specification and differential test"
-    status: spec_complete
-    description: |
-      Implement the wc word, line, and byte counter. wc depends on pkg/testutils from
-      rel00.0 for differential testing and does not require pkg/sys or pkg/format.
-    use_cases:
-      - id: rel01.0-uc001-wc
-        status: spec_complete
-
   - version: "01.1"
     name: "Batch 1.1 — cat specification and differential test"
     status: spec_complete
@@ -109,28 +99,40 @@ releases:
       - id: rel02.2-uc002-seq
         status: pending
 
-  - version: "99.0"
-    name: "Deferred — ls core specification and differential test"
+  - version: "03.0"
+    name: "Batch 3 — wc specification and differential test"
+    status: spec_complete
+    description: |
+      Implement the wc word, line, and byte counter. wc depends on pkg/testutils from
+      rel00.0 for differential testing and does not require pkg/sys or pkg/format.
+      Moved from rel01.0 because wc has repeatedly timed out during generation runs
+      due to task complexity from expanded sub-requirements.
+    use_cases:
+      - id: rel03.0-uc001-wc
+        status: spec_complete
+
+  - version: "04.0"
+    name: "Batch 4 — ls core specification and differential test"
     status: spec_complete
     description: |
       ls core covers the most common flags (default, -1, -l, -a, -A, -d, --color, -h).
-      Deferred from rel02.0 because ls has blocked every generation run due to task
-      complexity and rate-limit constraints. The dependency chain shows ls is not required
-      by other utilities in rel00.0 through rel02.0.
+      Previously deferred to rel99.0 because ls blocked generation runs due to task
+      complexity. Now scheduled as rel04.0 after cobbler-scaffold improvements to
+      sub-requirement counting.
     use_cases:
-      - id: rel99.0-uc001-ls
+      - id: rel04.0-uc001-ls
         status: spec_complete
 
-  - version: "99.1"
-    name: "Deferred — ls extended specification and differential test"
+  - version: "04.1"
+    name: "Batch 4.1 — ls extended specification and differential test"
     status: spec_complete
     description: |
       Extend ls with flags requiring heavier normalization or more complex layout logic:
       -C (forced multi-column), -x (horizontal), sort flags (-t, -S, -r, -U, -v),
       metadata display (-i inode, -s blocks, -n numeric IDs), -F classify, -R recursive.
-      Depends on rel99.0.
+      Depends on rel04.0.
     use_cases:
-      - id: rel99.1-uc001-ls-extended
+      - id: rel04.1-uc001-ls-extended
         status: spec_complete
 
   - version: "99.2"

--- a/docs/specs/test-suites/test-rel03.0.yaml
+++ b/docs/specs/test-suites/test-rel03.0.yaml
@@ -1,9 +1,9 @@
-id: test-rel01.0
-title: "Test Suite: rel01.0 — wc specification and differential test"
-release: rel01.0
+id: test-rel03.0
+title: "Test Suite: rel03.0 — wc specification and differential test"
+release: rel03.0
 
 traces:
-  - rel01.0-uc001-wc
+  - rel03.0-uc001-wc
   - prd005-wc R1
   - prd005-wc R2
   - prd005-wc R3

--- a/docs/specs/test-suites/test-rel04.0.yaml
+++ b/docs/specs/test-suites/test-rel04.0.yaml
@@ -1,9 +1,9 @@
-id: test-rel99.0
-title: "Test Suite: rel99.0 — ls core flag listing"
-release: rel99.0
+id: test-rel04.0
+title: "Test Suite: rel04.0 — ls core flag listing"
+release: rel04.0
 
 traces:
-  - rel99.0-uc001-ls
+  - rel04.0-uc001-ls
   - prd008-ls R1
   - prd008-ls R2
   - prd008-ls R3

--- a/docs/specs/test-suites/test-rel04.1.yaml
+++ b/docs/specs/test-suites/test-rel04.1.yaml
@@ -1,9 +1,9 @@
-id: test-rel99.1
-title: "Test Suite: rel99.1 — ls extended flag listing"
-release: rel99.1
+id: test-rel04.1
+title: "Test Suite: rel04.1 — ls extended flag listing"
+release: rel04.1
 
 traces:
-  - rel99.1-uc001-ls-extended
+  - rel04.1-uc001-ls-extended
   - prd010-ls-extended R1
   - prd010-ls-extended R2
   - prd010-ls-extended R3

--- a/docs/specs/use-cases/rel03.0-uc001-wc.yaml
+++ b/docs/specs/use-cases/rel03.0-uc001-wc.yaml
@@ -1,4 +1,4 @@
-id: rel01.0-uc001-wc
+id: rel03.0-uc001-wc
 title: "Count lines, words, and bytes via wc"
 
 summary: |
@@ -88,4 +88,4 @@ out_of_scope:
   - --total=always and --total=only are covered in the test suite but are not part of the primary flow.
   - Binary input edge cases are covered in the test suite but are not the primary flow.
 
-test_suite: test-rel01.0
+test_suite: test-rel03.0

--- a/docs/specs/use-cases/rel04.0-uc001-ls.yaml
+++ b/docs/specs/use-cases/rel04.0-uc001-ls.yaml
@@ -1,4 +1,4 @@
-id: rel99.0-uc001-ls
+id: rel04.0-uc001-ls
 title: "List directory contents via ls (core flags)"
 
 summary: |
@@ -86,10 +86,10 @@ success_criteria:
 
 out_of_scope:
   - Default multi-column mode on a real TTY is difficult to test deterministically in the
-    harness; we test -C explicitly in the ls extended use case (rel02.1).
+    harness; we test -C explicitly in the ls extended use case (rel04.1).
   - Owner/group name normalization is not applied; tests use a fixture where files are owned
     by the test runner's UID/GID, ensuring consistency.
   - SIGWINCH behavior is specified in prd008-ls R7.2 but is not directly testable in the
     differential harness.
 
-test_suite: test-rel99.0
+test_suite: test-rel04.0

--- a/docs/specs/use-cases/rel04.1-uc001-ls-extended.yaml
+++ b/docs/specs/use-cases/rel04.1-uc001-ls-extended.yaml
@@ -1,4 +1,4 @@
-id: rel99.1-uc001-ls-extended
+id: rel04.1-uc001-ls-extended
 title: "List directory contents via ls (extended flags)"
 
 summary: |
@@ -108,4 +108,4 @@ out_of_scope:
   - SIGWINCH and terminal resize behavior during -R recursive listing is not testable in the
     differential harness.
 
-test_suite: test-rel99.1
+test_suite: test-rel04.1


### PR DESCRIPTION
## Summary

Restructure release road map: move wc from rel01.0 to rel03.0 (due to repeated timeout failures from expanded sub-requirements), move ls core/extended from deferred rel99.0/99.1 to concrete rel04.0/04.1. Add all three releases to the generation configuration.

## Changes

- Removed rel01.0 (wc) from road-map, created rel03.0 with wc
- Moved rel99.0 (ls core) to rel04.0
- Moved rel99.1 (ls extended) to rel04.1
- Added 03.0, 04.0, 04.1 to configuration.yaml releases list
- Renamed 3 use case files and 3 test suite files
- Updated all IDs in road-map.yaml, SPECIFICATIONS.yaml (index, mappings, diagram)

## Stats

go_loc_prod: 0 (+0)
go_loc_test: 0 (+0)
spec_words: 37,476 (+0)

## Test plan

- [x] `mage analyze` passes
- [x] All use case and test suite IDs consistent
- [x] SPECIFICATIONS.yaml traceability diagram updated

Closes #220