### PR TITLE
GH-222: Upgrade cobbler-scaffold v0.20260303.2 → v0.20260303.4

### DIFF
--- a/docs/constitutions/design.yaml
+++ b/docs/constitutions/design.yaml
@@ -133,6 +133,7 @@ document_types:
       goals: "G1, G2, G3, ..."
       requirement_groups: "R1, R2, R3, ..."
       requirement_items: "R1.1, R1.2, R2.1, ..."
+      requirement_id_format: "R{group}.{item} — numeric dotted only (e.g., R1.1, R2.3). Letter suffixes (R2a) are not valid and are flagged by mage analyze."
     purpose: |
       Defines product requirements with numbered goals and requirements. Each
       requirement starts with "must" or "must not" or a concrete verb. No scope

--- a/docs/prompts/measure.yaml
+++ b/docs/prompts/measure.yaml
@@ -31,7 +31,7 @@ constraints: |
   - Components with a provided_by field in ARCHITECTURE.yaml are external infrastructure. Do NOT propose tasks that create or modify files in those components.
   - Do NOT exceed {limit} tasks. If more work is needed, create additional tasks in a future session.
   - Do NOT create tasks larger than {lines_max} lines of production code. Target {lines_min}-{lines_max} lines per task, touching 5-7 files. Split aggressively: a task that creates a struct and implements its methods is two tasks.
-  - Each task must contain at most {max_requirements} requirements. Split any task that would exceed this limit.
+  - Each task must contain at most {max_requirements} PRD sub-requirements (e.g., R1.1, R2.3), not requirement groups. Split any task that would exceed this limit.
   - Each task MUST be independently executable by an agent that has no context beyond the task description and the execution constitution.
   - Do NOT assume the stitch agent has access to your analysis, the existing issues list, or any context from this conversation.
   - Do NOT propose tasks that require human judgment or manual testing. Each task must have checkable acceptance criteria.

--- a/docs/specs/product-requirements/prd008-ls.yaml
+++ b/docs/specs/product-requirements/prd008-ls.yaml
@@ -36,7 +36,7 @@ requirements:
     title: Single-column mode (-1) and long format (-l)
     items:
       - R2.1: -1 must produce single-column output with one entry per line regardless of whether stdout is a TTY. This overrides the default multi-column layout.
-      - R2a: |
+      - R2.2: |
           -l flag skeleton and permission string. When -l is given, produce long-format output. Field order (left to right): permissions (10 chars), nlink, owner, group, size, mtime, name. Fields separated by a single space. Numeric fields (nlink, size) are right-aligned in columns wide enough for the largest value in the listing.
 
           Permission string algorithm (10 characters):
@@ -44,7 +44,7 @@ requirements:
           - Positions 1-3 (owner rwx): 'r'/'- ' for bit 0o400, 'w'/'-' for 0o200, 'x'/'-' for 0o100. If setuid (fi.Mode&os.ModeSetuid != 0): replace 'x' with 's', or replace '-' with 'S'.
           - Positions 4-6 (group rwx): bits 0o040, 0o020, 0o010. If setgid (fi.Mode&os.ModeSetgid != 0): replace 'x' with 's', or replace '-' with 'S'.
           - Positions 7-9 (other rwx): bits 0o004, 0o002, 0o001. If sticky (fi.Mode&os.ModeSticky != 0): replace 'x' with 't', or replace '-' with 'T'.
-      - R2b: |
+      - R2.3: |
           File metadata via pkg/sys.Lstat. Obtain metadata for each listed entry by calling pkg/sys.Lstat(path string) (*sys.FileInfo, error) — does not follow symbolic links; returns the symlink's own metadata when path is a symlink.
 
           sys.FileInfo struct (embedded here for reference):
@@ -64,11 +64,11 @@ requirements:
             }
 
           In long format: print fi.Nlink (uint64) right-aligned; print fi.Size (int64, bytes) right-aligned. Both columns sized to the widest value across all listed entries.
-      - R2c: |
+      - R2.4: |
           Owner and group name resolution in long format. Resolve owner name by calling os/user.LookupId(strconv.Itoa(int(fi.Uid))); on success use u.Username; on error (user not found or lookup fails) fall back to strconv.FormatUint(uint64(fi.Uid), 10). Resolve group name by calling os/user.LookupGroupId(strconv.Itoa(int(fi.Gid))); on success use g.Name; on error fall back to strconv.FormatUint(uint64(fi.Gid), 10). Owner and group fields are left-padded to column width for alignment.
-      - R2d: |
+      - R2.5: |
           Modification time formatting in long format. Use fi.ModTime (time.Time from sys.FileInfo). If time.Since(fi.ModTime) < 6*30*24*time.Hour (approximately six months), format as fi.ModTime.Format("Jan _2 15:04"). Otherwise format as fi.ModTime.Format("Jan _2  2006"). Both patterns produce a 12-character field.
-      - R2e: |
+      - R2.6: |
           Total block count line and symlink display. Before the directory listing, print "total N\n" where N = sum(fi.Blocks for all listed entries) / 2. The division converts 512-byte st_blocks units to 1K-block units matching GNU ls. N is a plain integer (no trailing suffix) unless -h is active (see R5).
 
           Symlink display: when fi.Mode&os.ModeSymlink != 0, read the link target with os.Readlink(path) and append " -> " + target to the entry name field. Use Lstat (not Stat) so the symlink's own fi.Size and fi.Nlink are used, not the target's.

--- a/docs/specs/test-suites/test-rel04.0.yaml
+++ b/docs/specs/test-suites/test-rel04.0.yaml
@@ -85,8 +85,6 @@ test_cases:
       - prd008-ls R2.4
       - prd008-ls R2.5
       - prd008-ls R2.6
-      - prd008-ls R2.7
-      - prd008-ls R2.9
 
   - name: ls_long_format_symlink
     description: -l on a directory containing a symlink shows "name -> target".
@@ -100,7 +98,7 @@ test_cases:
       stdout_structure: 'output contains " -> "'
       stderr: ""
     traces:
-      - prd008-ls R2.8
+      - prd008-ls R2.6
 
   - name: ls_long_human
     description: -lh displays human-readable file sizes matching gls -lh.

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260303.2
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260303.4
 )
 
 require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260303.2 h1:DcilDZE0l5utOwyOdzALN4B7vjuBNSmOC9/8LxCthbA=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260303.2/go.mod h1:Gckwhzbo48sx2lNxv46vZCHIZRm+8GMffFJrvK0ZMqM=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260303.4 h1:QZjKnjbfWaB8KWWbRjRFiQTjmdFT6LWNDzvKnY3XCMQ=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260303.4/go.mod h1:Gckwhzbo48sx2lNxv46vZCHIZRm+8GMffFJrvK0ZMqM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Summary

Upgrade cobbler-scaffold to v0.20260303.4, bringing in the expanded sub-item counting fix (#535) and numeric dotted requirement ID enforcement (#536). Also fixes prd008-ls letter-suffix requirement IDs that the new analyze check would flag.

## Changes

- magefiles/go.mod: cobbler-scaffold v0.20260303.2 → v0.20260303.4
- docs/constitutions/design.yaml: added requirement_id_format rule
- docs/prompts/measure.yaml: clarified sub-requirements vs groups in max_requirements constraint
- docs/specs/product-requirements/prd008-ls.yaml: R2a-R2e → R2.2-R2.6
- docs/specs/test-suites/test-rel04.0.yaml: removed stale R2.7-R2.9 traces

## Stats

go_loc_prod: 0 (+0)
go_loc_test: 0 (+0)
spec_words: 37,470 (-6)

## Test plan

- [x] `mage analyze` passes
- [x] No broken citations
- [x] Constitution drift check clean

Closes #222