### PR TITLE
GH-223: Upgrade cobbler-scaffold v0.20260303.4 → v0.20260304.0

### DIFF
--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260303.4
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260304.0
 )
 
 require gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260303.4 h1:QZjKnjbfWaB8KWWbRjRFiQTjmdFT6LWNDzvKnY3XCMQ=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260303.4/go.mod h1:Gckwhzbo48sx2lNxv46vZCHIZRm+8GMffFJrvK0ZMqM=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260304.0 h1:gtI7CP4o/jjNK+H7dTSF7+XOEdVsvPzQQzEaHZOmFXQ=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260304.0/go.mod h1:Gckwhzbo48sx2lNxv46vZCHIZRm+8GMffFJrvK0ZMqM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Summary

Upgrades cobbler-scaffold from v0.20260303.4 to v0.20260304.0. This release includes test file exclusion from measure prompts (57% source reduction), source summarization modes, task sub-issue linking, progress comments, and several other improvements filed during generation run 14.

## Changes

- Updated magefiles/go.mod and go.sum to cobbler-scaffold v0.20260304.0
- New features available: measure_exclude_tests, measure_source_mode, stats:generator, sub-issue linking, progress comments

## Test plan

- [ ] `mage analyze` passes (pre-existing orphaned PRD warning only)
- [ ] `mage -l` shows all targets including new ones

Closes #223