### PR TITLE
GH-315: Upgrade cobbler-scaffold v0.20260305.3 → v0.20260306.3

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -51,6 +51,7 @@ cobbler:
     idle_timeout_seconds: 600
     measure_source_mode: headers
     measure_roadmap_source: true
+    mode: cli
 podman:
     image: claude-cli
     args:

--- a/docs/constitutions/design.yaml
+++ b/docs/constitutions/design.yaml
@@ -192,57 +192,6 @@ document_types:
       architecture. Not PRDs (no numbered requirements). Not architecture (no
       component descriptions).
 
-  generation_run_report:
-    location: "docs/engineering/eng[NN]-generation-run-[N]-results.yaml"
-    format_rule: engineering-guideline-format
-    required_fields:
-      - id
-      - "title (include total LOC, total cost, and run number)"
-      - "introduction (multi-line: branch, sessions, tasks, LOC, cost, $/KLOC, key findings)"
-      - sections (list with title and content)
-    optional_fields:
-      - references
-    purpose: |
-      Records the full results of a cobbler generation run. Every generation
-      run must produce one of these. The report must include six required
-      sections populated from per-cycle data in the generation tag.
-
-      Before writing the report, read all stats files from the generation tag
-      (named <generation-branch>-merged) using:
-        git show <tag>:.cobbler/history/<timestamp>-stitch-stats.yaml
-        git show <tag>:.cobbler/history/<timestamp>-measure-stats.yaml
-        git show <tag>:.cobbler/history/<timestamp>-stitch-report.yaml
-
-      Required sections:
-
-      1. Configuration — table of generation parameters: generation branch,
-         scaffold version, model, temperature, max_time_sec, measure_source_mode,
-         releases list, seeded LOC, budgeted and actual cycles, successful tasks,
-         rate-limit interruptions.
-
-      2. Cycle-by-cycle results — table of every successful stitch task: issue
-         number, description, stitch time (duration from stitch-stats.yaml),
-         input tokens, output tokens, cost_usd, LOC added prod and test. Include
-         a note on failed attempts.
-
-      3. Measure cycles — table of every measure cycle (success and fail):
-         timestamp, duration, status, input tokens, output tokens, cache read
-         tokens, cost_usd, prod LOC at cycle start.
-
-      4. Cost analysis — totals table (measure cost, stitch cost, total),
-         token totals table (input, output, cache_creation, cache_read, cost
-         for measure and stitch separately), cost per KLOC, and a comparison
-         table against prior runs from previous engineering reports.
-
-      5. Generated packages — table of packages produced: package path,
-         prod LOC, test LOC, release. Derive LOC from loc_before/loc_after
-         deltas in stitch-stats.yaml files.
-
-      6. Failures and restarts — table of every failure: timestamp, type
-         (measure or stitch), cause, cost wasted, resolution. Include both
-         rate-limit stalls and logic failures (e.g., Claude attempting
-         disallowed actions).
-
   specification:
     location: docs/SPECIFICATIONS.yaml
     format_rule: specification-format
@@ -270,6 +219,36 @@ document_types:
       Defines releases with version, name, focus, and list of use cases with
       status. Use cases are assigned to releases. Release numbering: rel[NN].[N]
       (major.minor). Minor releases validate completed major releases.
+
+  generation_run_report:
+    location: "docs/reports/generation-run-[N].md (e.g., generation-run-15.md)"
+    format_rule: generation-run-report-format
+    required_fields:
+      - "title: 'Generation Run [N]: [total LOC] LOC, $[total cost] — [one-line summary]'"
+      - "Configuration section: generation branch name, base branch, cobbler version,
+          model, max_turns, preserve_sources flag, issues_repo"
+      - "Cycle-by-cycle results section: table with columns cycle, issue title, status
+          (pass/fail/restart), stitch turns used, input tokens, output tokens,
+          cost USD, LOC delta"
+      - "Measure cycles section: table with columns cycle, issues proposed, input
+          tokens, output tokens, cost USD"
+      - "Cost analysis section: total input tokens, total output tokens, total cost USD,
+          total LOC produced, cost per KLOC; comparison table against prior runs
+          (run number, date, total LOC, total cost, cost/KLOC)"
+      - "Generated packages section: list of packages or modules produced with their LOC"
+      - "Failures and restarts section: for each failed stitch, the issue title, error
+          summary, and whether it was retried or abandoned"
+    purpose: |
+      Captures the full accounting of a completed generation run so that cost
+      trends, failure patterns, and per-package productivity can be tracked
+      across runs. Written once per generation after generator:stop completes.
+
+      Data source: before writing the report, read all history files from the
+      generation branch's merged tag (.cobbler/history/ under the
+      <generation-branch>-merged git tag): *-stitch-stats.yaml,
+      *-measure-stats.yaml, and *-stitch-report.yaml. These files contain
+      per-cycle token counts, costs, LOC deltas, and failure records.
+      Do not estimate; read the files.
 
 naming_conventions:
   prd: "prd[NNN]-[feature-name].yaml (e.g., prd001-cupboard-core.yaml)"

--- a/docs/constitutions/go-style.yaml
+++ b/docs/constitutions/go-style.yaml
@@ -162,6 +162,23 @@ no_magic_strings: |
   new external command or path, define the constant first, then use it. Never
   scatter raw string literals across files.
 
+configuration_via_yaml: |
+  All configuration must flow through configuration.yaml, loaded into the Config
+  struct by LoadConfig(). Do not read os.Getenv() to control orchestrator
+  behaviour, select execution modes, set file paths, or pass any option that a
+  user would otherwise set in configuration.yaml. Environment variables are not
+  a configuration channel in this project.
+
+  os.Getenv() is permitted only for two purposes: reading platform context
+  provided by the operating system (HOME, PATH, TMPDIR) and, in test code only,
+  reading variables that the test harness itself sets to override behaviour for
+  the test process. In both cases, the env var must be documented at the call
+  site with a comment explaining why it cannot come from Config.
+
+  The concrete consequence: if you find yourself writing os.Getenv("SOME_MODE")
+  or os.LookupEnv("SOME_FLAG") outside of those two narrow contexts, stop and
+  add a field to the relevant Config sub-struct instead.
+
 constants: |
   Prefer typed constants over bare string or integer literals for values that
   form a fixed set. Give the type a name: type totalMode int, then define the
@@ -336,6 +353,7 @@ code_review_checklist:
   - "All receiver names are one- or two-letter abbreviations, consistent across all methods of the type."
   - "Imports are grouped: stdlib, external, internal — each group separated by a blank line."
   - "Every exported symbol has a godoc comment starting with the symbol name."
+  - "No os.Getenv() call controls orchestrator behaviour, execution mode, file paths, or any option that belongs in configuration.yaml."
   - "No init() function performs I/O or returns an error."
   - "No panic() is reachable from a runtime condition or user-provided input."
   - "Typed iota enums are used for any fixed set of integer values."
@@ -398,6 +416,15 @@ sections:
     content: |
       Centralize all string literals for binary names, file paths, URLs, and
       repeated text as named constants. Never scatter raw string literals.
+  - tag: configuration_via_yaml
+    title: Configuration via YAML Only
+    content: |
+      All configuration flows through configuration.yaml and the Config struct.
+      Do not use os.Getenv() to control orchestrator behaviour, execution modes,
+      or any option that belongs in configuration.yaml. os.Getenv() is
+      permitted only for platform context (HOME, PATH) and, in test code, for
+      variables the test harness itself sets.
+
   - tag: constants
     title: Constants and Iota
     content: |

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,10 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260305.3
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260306.3
 )
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require (
+	github.com/schlunsen/claude-agent-sdk-go v0.5.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,9 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260305.3 h1:KV6Rit4OkewA9xqaMkXRf5D1TkBlqWNn7tMM/xJ0vzU=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260305.3/go.mod h1:Gckwhzbo48sx2lNxv46vZCHIZRm+8GMffFJrvK0ZMqM=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260306.3 h1:WfM97Ui4jXWK1FCcoqOhBgdKoCMGX39xQAMA4/+KMa0=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260306.3/go.mod h1:xFuIzON+/BqFbFCdpI26RqigNcaLuWACZIj7wT6T2QI=
+github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
+github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=


### PR DESCRIPTION
## Summary

Upgrades cobbler-scaffold from v0.20260305.3 to v0.20260306.3 and switches the execution mode to CLI (direct host invocation, no podman container). The upgrade brings Agent SDK support, orphaned placeholder cleanup, a new configuration-via-YAML go-style rule, and an updated generation_run_report format.

## Changes

- **magefiles/go.mod**: cobbler-scaffold v0.20260305.3 → v0.20260306.3; added github.com/schlunsen/claude-agent-sdk-go v0.5.1 indirect dep
- **magefiles/orchestrator.go**: updated (Agent SDK mode, orphaned [measuring] placeholder cleanup on Claude failure, snapshot mode bug fix)
- **docs/constitutions/go-style.yaml**: added `configuration_via_yaml` rule — all config via configuration.yaml; no os.Getenv() for options
- **docs/constitutions/design.yaml**: `generation_run_report` format relocated to `docs/reports/generation-run-[N].md`, fields streamlined
- **configuration.yaml**: added `cobbler.mode: cli` — claude binary invoked directly on host

## Stats

  Lines of code (Go, production): 0 (+0)
  Lines of code (Go, tests):      0 (+0)
  Words (documentation):          prd 27594, use_case 15073, test_suite 12716

## Test plan

- [x] `mage analyze` passes (0 errors)
- [x] No Go source to test
- [x] Local customizations (configuration.yaml, prompts) preserved

Closes #315