### PR TITLE
GH-328: Upgrade cobbler-scaffold v0.20260306.3 → v0.20260306.5

### DIFF
--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260306.3
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260306.5
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260306.3 h1:WfM97Ui4jXWK1FCcoqOhBgdKoCMGX39xQAMA4/+KMa0=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260306.3/go.mod h1:xFuIzON+/BqFbFCdpI26RqigNcaLuWACZIj7wT6T2QI=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260306.5 h1:nIsgN8OYO6hl/JQODt82L0hEc0Kowntw55OxOpJb2j4=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260306.5/go.mod h1:YVc2XV4LdKH9+yIdAJlsYdOXxOI/rEs+bP0buLyjVXI=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Summary

Upgrades cobbler-scaffold from v0.20260306.3 to v0.20260306.5, picking up fixes for both
issues filed during generation run 16 (GH-847 and GH-849) plus SDK unit tests and use-case
test runner improvements.

## Changes

- `magefiles/go.mod`: v0.20260306.3 → v0.20260306.5 (via `GOPROXY=direct` since .5 not yet on module proxy)
- `magefiles/go.sum`: updated checksums

## What's new in v0.20260306.4–v0.20260306.5

- GH-847: `selectNextPendingUseCase` now skips releases with `status: implemented` — prevents measure from re-proposing already-implemented releases when `releases` config is stale
- GH-849: Fix `Loc-Prod-After` always 0 in CLI mode stitch commit trailers
- GH-844: Unit tests for `runClaudeSDK` execution path
- GH-825: `mage test:usecase` target added and passing

## Stats

```
go_loc_prod: 0
go_loc_test: 0
spec_words: prd=27594 use_case=15073 test_suite=12716
```

## Test plan

- [x] `mage analyze` passes
- [x] `mage -l` compiles and shows all targets
- [x] Local customizations (configuration.yaml, mode=cli) preserved

Closes #328