### PR TITLE
GH-337: Recurring: Upgrade to latest cobbler-scaffold

### DIFF
--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260306.5
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260306.8
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260306.5 h1:nIsgN8OYO6hl/JQODt82L0hEc0Kowntw55OxOpJb2j4=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260306.5/go.mod h1:YVc2XV4LdKH9+yIdAJlsYdOXxOI/rEs+bP0buLyjVXI=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260306.8 h1:7bFtyGwn9nlfIEbPH1BeIPCfzkHWP1ACjy7+UiPF0co=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260306.8/go.mod h1:YVc2XV4LdKH9+yIdAJlsYdOXxOI/rEs+bP0buLyjVXI=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/magefiles/orchestrator.go
+++ b/magefiles/orchestrator.go
@@ -144,6 +144,9 @@ func (Stats) Loc() error { return newOrch().Stats() }
 // Tokens enumerates prompt-attached files and counts tokens via the Anthropic API.
 func (Stats) Tokens() error { return newOrch().TokenStats() }
 
+// Generator prints a status report for the current generation run.
+func (Stats) Generator() error { return newOrch().GeneratorStats() }
+
 // --- Prompt targets ---
 
 // Measure prints the assembled measure prompt to stdout.


### PR DESCRIPTION
## Summary

Upgrades cobbler-scaffold from v0.20260306.5 to v0.20260306.8. The main addition is the `mage stats:generator` command (GH-859), which was previously missing from the orchestrator template, plus SDK metadata capture improvements (GH-846).

## Changes

- `magefiles/orchestrator.go` — added `Stats.Generator()` target (mage stats:generator)
- `magefiles/go.mod` + `go.sum` — bumped cobbler-scaffold to v0.20260306.8

## Stats

No Go source changes (specs-only repo after generator:stop).

## Test plan

- [x] `mage analyze` passes
- [x] `mage -l` shows `stats:generator` in target list

Closes #337