### PR TITLE
GH-385: Clean up configuration.yaml and switch cobbler.mode to sdk

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -3,71 +3,42 @@
 
 project:
     module_path: github.com/petar-djukic/go-unix-utils
-    binary_name: go-unix-utils
-    binary_dir: bin
-    main_package: ""
     go_source_dirs:
         - pkg
         - cmd
-    version_file: ""
     magefiles_dir: magefiles
-    context_sources: ""
     context_include: |
       docs/VISION.yaml
       docs/ARCHITECTURE.yaml
     context_exclude: |
       docs/SPECIFICATIONS.yaml
       docs/road-map.yaml
-    release: ""
     releases: []
-    seed_files: {}
 generation:
     prefix: generation-
     cycles: 6
-    branch: ""
-    cleanup_dirs: []
 cobbler:
     dir: .cobbler/
-    max_stitch_issues: 0
     max_stitch_issues_per_cycle: 1
     max_measure_issues: 1
-    user_prompt: ""
     measure_prompt: docs/prompts/measure.yaml
     stitch_prompt: docs/prompts/stitch.yaml
     planning_constitution: docs/constitutions/planning.yaml
     execution_constitution: docs/constitutions/execution.yaml
     design_constitution: docs/constitutions/design.yaml
     go_style_constitution: docs/constitutions/go-style.yaml
-    estimated_lines_min: 150
-    estimated_lines_max: 250
-    golden_example: ""
-    max_context_bytes: 0
-    enforce_measure_validation: false
-    max_measure_retries: 0
+    estimated_lines_min: 300
+    estimated_lines_max: 500
     max_requirements_per_task: 4
     history_dir: history
     doc_tag_prefix: v0.
     base_branch: main
-    idle_timeout_seconds: 600
+    idle_timeout_seconds: 900
     measure_source_mode: headers
     measure_roadmap_source: true
-    mode: cli
-podman:
-    image: claude-cli
-    args:
-        - -e
-        - CLAUDE_CODE_MAX_OUTPUT_TOKENS=128000
+    mode: sdk
 claude:
-    args:
-        - --dangerously-skip-permissions
-        - -p
-        - --verbose
-        - --output-format
-        - stream-json
     silence_agent: true
     secrets_dir: .secrets
     default_token_file: claude.json
-    token_file: ""
     max_time_sec: 900
-    container_credentials_path: /home/crumbs/.claude/.credentials.json
-    temperature: 0


### PR DESCRIPTION
## Summary

Switches cobbler.mode from cli to sdk and removes 29 lines of stale fields. Also bumps estimated_lines and idle_timeout in preparation for rel99.2 (ts), the only remaining pending release.

## Changes

- `cobbler.mode: sdk` — use Go Agent SDK (DangerouslySkipPermissions hardcoded, no CLI flags needed)
- Removed `podman` block — not used in sdk mode
- Removed `claude.args` — CLI flags (--verbose, --output-format stream-json, -p) not applicable to SDK
- Removed `claude.container_credentials_path`, `temperature` — container-specific / ignored
- Removed empty-default fields: `binary_name`, `binary_dir`, `main_package`, `version_file`, `golden_example`, `max_context_bytes`, `enforce_measure_validation`, `max_measure_retries`, `max_stitch_issues`, `user_prompt`, `token_file`
- `estimated_lines_min/max`: 150/250 → 300/500 (sized for ts complexity)
- `idle_timeout_seconds`: 600 → 900

## Test plan

- [x] `mage analyze` passes
- [x] `mage -l` shows all expected targets

Closes #385