### PR TITLE
GH-383: Upgrade cobbler-scaffold v0.20260306.8 → v0.20260306.9

### DIFF
--- a/docs/prompts/measure.yaml
+++ b/docs/prompts/measure.yaml
@@ -28,6 +28,7 @@ constraints: |
   - Do NOT duplicate existing issues. Review the issues in the project_context above before proposing.
   - Issues with status "closed" represent COMPLETED work. Do not re-propose work that a closed issue already covers, even under a different title or framing. The completed_work field in project_context lists all finished tasks — treat every entry as work that must not be repeated.
   - When source_code contains .go files for a package, that package already exists. Do not propose creating or reimplementing it. Trust the source code over prose descriptions in documentation (e.g., implementation_status sections in ARCHITECTURE.yaml may be stale).
+  - If the source code already fully implements all requirements for the current release and no meaningful implementation work remains, return an empty YAML list: ```yaml\n[]\n```. An empty list is the correct and expected output when the spec is complete. Do NOT propose verification tasks, clean-up tasks, or minor follow-ups just to produce output — return `[]` instead.
   - Components with a provided_by field in ARCHITECTURE.yaml are external infrastructure. Do NOT propose tasks that create or modify files in those components.
   - Do NOT exceed {limit} tasks. If more work is needed, create additional tasks in a future session.
   - Do NOT create tasks larger than {lines_max} lines of production code. Target {lines_min}-{lines_max} lines per task, touching 5-7 files. Split aggressively: a task that creates a struct and implements its methods is two tasks.

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260306.8
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260306.9
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260306.8 h1:7bFtyGwn9nlfIEbPH1BeIPCfzkHWP1ACjy7+UiPF0co=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260306.8/go.mod h1:YVc2XV4LdKH9+yIdAJlsYdOXxOI/rEs+bP0buLyjVXI=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260306.9 h1:LbFBJVyXSlun5R52OVMnnVDO2Lfi7Vluz+/R78GjEoU=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260306.9/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Summary

Upgrades cobbler-scaffold from v0.20260306.8 to v0.20260306.9. The new version adds a measure empty-list constraint for complete specs (GH-889), SDK rate_limit_event filtering (GH-886), usecase coverage tests (GH-892), and a gitignore cmd/ directory fix (GH-876).

## Changes

- Updated `magefiles/go.mod` and `magefiles/go.sum` to v0.20260306.9
- Updated `docs/prompts/measure.yaml` with empty-list constraint for complete specs

## Test plan

- [x] `mage analyze` passes
- [x] Local customizations (configuration.yaml) preserved

Closes #383