### PR TITLE
GH-473: Add differential tests for echo and ts; promote ts to rel05.5

### DIFF
--- a/cmd/echo/echo_test.go
+++ b/cmd/echo/echo_test.go
@@ -1,0 +1,68 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+// Differential tests for cmd/echo against gecho reference binary.
+// Implements prd020-echo R1-R3.
+package main
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/petar-djukic/go-unix-utils/pkg/testutils"
+)
+
+func TestDiff(t *testing.T) {
+	t.Parallel()
+
+	goBin := testutils.BuildBinary(t, ".")
+	refBin, err := exec.LookPath("gecho")
+	if err != nil {
+		t.Skipf("reference binary gecho not in PATH: %v", err)
+	}
+
+	tests := []testutils.DiffTest{
+		// R1.1: Arguments joined with spaces, followed by newline.
+		{
+			Name: "default_output",
+			Args: []string{"hello", "world"},
+		},
+		// R1.2: No arguments outputs only a newline.
+		{
+			Name: "no_args",
+			Args: []string{},
+		},
+		// R1.3: -n suppresses trailing newline.
+		{
+			Name: "suppress_newline",
+			Args: []string{"-n", "hello"},
+		},
+		// R2.1: -e interprets \t as horizontal tab.
+		{
+			Name: "escape_tab",
+			Args: []string{"-e", `col1\tcol2`},
+		},
+		// R2.1: -e interprets \n as embedded newline.
+		{
+			Name: "escape_newline",
+			Args: []string{"-e", `line1\nline2`},
+		},
+		// R2.2: -e with \c terminates output; no trailing newline.
+		{
+			Name: "escape_c_terminates",
+			Args: []string{"-e", `before\cafter`},
+		},
+		// R2.3: Without -e, backslash sequences are literal.
+		{
+			Name: "no_escape_default",
+			Args: []string{`a\tb`},
+		},
+		// R1.3, R2.1: -n -e combined.
+		{
+			Name: "combined_n_e",
+			Args: []string{"-n", "-e", `x\ty`},
+		},
+	}
+
+	testutils.RunDiffTests(t, goBin, refBin, tests)
+}

--- a/cmd/ts/ts_test.go
+++ b/cmd/ts/ts_test.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+// Differential tests for cmd/ts against ts reference binary (moreutils).
+// Implements prd004-ts R1-R5, R7-R8.
+package main
+
+import (
+	"bytes"
+	"os/exec"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/petar-djukic/go-unix-utils/pkg/testutils"
+)
+
+// subsecondNormalizer replaces SS.USEC patterns (e.g., "41.191463") that
+// TimestampNormalizer does not cover.
+var subsecondNormalizer testutils.NormalizeFunc = func(b []byte) []byte {
+	re := regexp.MustCompile(`\d{2}\.\d{6}`)
+	return re.ReplaceAll(b, []byte("<SUBSEC>"))
+}
+
+func TestDiff(t *testing.T) {
+	t.Parallel()
+
+	goBin := testutils.BuildBinary(t, ".")
+	refBin, err := exec.LookPath("ts")
+	if err != nil {
+		t.Skipf("reference binary ts not in PATH: %v", err)
+	}
+
+	tsNorm := []testutils.NormalizeFunc{testutils.TimestampNormalizer}
+
+	tests := []testutils.DiffTest{
+		// R1.1, R1.2, R1.4: Default format with three-line stdin.
+		{
+			Name:      "default_format_three_lines",
+			Args:      []string{},
+			Stdin:     []byte("line1\nline2\nline3\n"),
+			Normalize: tsNorm,
+		},
+		// R1.6: Empty stdin produces no output.
+		{
+			Name:  "default_format_empty_stdin",
+			Args:  []string{},
+			Stdin: []byte(""),
+		},
+		// R1.5: Partial last line (no trailing newline) is timestamped.
+		{
+			Name:      "default_format_partial_last_line",
+			Args:      []string{},
+			Stdin:     []byte("partial"),
+			Normalize: tsNorm,
+		},
+		// R2.1, R2.2: Custom strftime format string.
+		{
+			Name:      "custom_strftime_format",
+			Args:      []string{"%Y-%m-%dT%H:%M:%S"},
+			Stdin:     []byte("hello\nworld\n"),
+			Normalize: tsNorm,
+		},
+		// R2.3: Subsecond extension %.S.
+		{
+			Name:      "subsecond_format_dotS",
+			Args:      []string{"%.S"},
+			Stdin:     []byte("test\n"),
+			Normalize: []testutils.NormalizeFunc{subsecondNormalizer},
+		},
+		// R4.1, R4.2: -s mode elapsed since start.
+		{
+			Name:      "elapsed_since_start_mode",
+			Args:      []string{"-s"},
+			Stdin:     []byte("a\nb\nc\n"),
+			Normalize: tsNorm,
+		},
+		// R3.1, R3.2: -i mode incremental timestamps.
+		{
+			Name:      "incremental_mode",
+			Args:      []string{"-i"},
+			Stdin:     []byte("first\nsecond\nthird\n"),
+			Normalize: tsNorm,
+		},
+		// R5.1: -m mode with default format.
+		{
+			Name:      "monotonic_clock_mode",
+			Args:      []string{"-m"},
+			Stdin:     []byte("tick\n"),
+			Normalize: tsNorm,
+		},
+		// R8.1: TZ=UTC respected in wall-clock timestamps.
+		{
+			Name:      "tz_environment_respected",
+			Args:      []string{"%H:%M:%S"},
+			Stdin:     []byte("event\n"),
+			Env:       []string{"TZ=UTC"},
+			Normalize: tsNorm,
+		},
+	}
+
+	testutils.RunDiffTests(t, goBin, refBin, tests)
+}
+
+// TestErrorCases tests error handling independently since the reference ts (Perl)
+// uses different exit codes (255) and error message formats than our Go implementation.
+// R3.4, R7.2.
+func TestErrorCases(t *testing.T) {
+	t.Parallel()
+
+	goBin := testutils.BuildBinary(t, ".")
+
+	t.Run("incremental_and_elapsed_mutually_exclusive", func(t *testing.T) {
+		t.Parallel()
+		cmd := exec.Command(goBin, "-i", "-s")
+		cmd.Stdin = bytes.NewReader([]byte(""))
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+		if err == nil {
+			t.Fatal("expected non-zero exit, got 0")
+		}
+		if !strings.Contains(stderr.String(), "usage") {
+			t.Errorf("expected stderr to contain 'usage', got: %q", stderr.String())
+		}
+	})
+
+	t.Run("invalid_flag", func(t *testing.T) {
+		t.Parallel()
+		cmd := exec.Command(goBin, "-z")
+		cmd.Stdin = bytes.NewReader([]byte(""))
+		var stderr bytes.Buffer
+		cmd.Stderr = &stderr
+		err := cmd.Run()
+		if err == nil {
+			t.Fatal("expected non-zero exit, got 0")
+		}
+		if !strings.Contains(stderr.String(), "usage") {
+			t.Errorf("expected stderr to contain 'usage', got: %q", stderr.String())
+		}
+	})
+}

--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -222,14 +222,16 @@ releases:
       - id: rel05.4-uc004-sha512sum
         status: implemented
 
-  - version: "99.2"
-    name: "Deferred — ts specification and differential test"
+  - version: "05.5"
+    name: "Batch 5.5 — ts timestamp stdin lines"
     status: implemented
     description: |
-      Implement ts for prepending timestamps to stdin lines. Deferred from rel01.0 because
-      ts has failed in multiple generation runs due to task complexity from subrequirements
-      (R1-R8) and rate-limit constraints. Moved to deferred status pending cobbler-scaffold
-      improvements to subrequirement handling.
+      Implement ts for prepending timestamps to stdin lines. ts reads from stdin and
+      prepends a strftime-formatted timestamp to each line. Supports wall-clock (default),
+      elapsed (-s), and incremental (-i) modes, monotonic clock (-m), and subsecond
+      extensions (%.S, %.s, %.T). Originally deferred to rel99.2 due to task complexity;
+      promoted after successful generation in run 19. Use case and spec files retain
+      the rel99.2 prefix for traceability to earlier generation runs.
     use_cases:
       - id: rel99.2-uc001-ts
         status: implemented


### PR DESCRIPTION
## Summary

Add missing differential tests for cmd/echo (8 tests) and cmd/ts (11 tests), and promote ts from deferred rel99.2 to rel05.5 in the road map.

## Changes

- `cmd/echo/echo_test.go`: 8 differential tests against `gecho` covering R1-R3 (default output, no args, -n, -e escapes, \c termination, combined flags)
- `cmd/ts/ts_test.go`: 9 differential tests against `ts` (moreutils) + 2 standalone error tests covering R1-R5, R7-R8
- `docs/road-map.yaml`: ts moved from rel99.2 to rel05.5; use case ID preserved for traceability

## Notes

- ts error cases tested standalone (not differential) because reference ts (Perl) exits 255 vs Go exit 1
- Custom `subsecondNormalizer` for `%.S` format since `TimestampNormalizer` only covers `HH:MM:SS`
- R6 (`-r` relative mode) tests omitted — Go ts does not implement `-r`

## Test plan

- [x] `go test ./cmd/echo/...` — 8/8 pass
- [x] `go test ./cmd/ts/...` — 11/11 pass

Closes #473