### PR TITLE
GH-477: Upgrade cobbler-scaffold v0.20260307.0 → v0.20260307.1

### DIFF
--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260307.0
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260307.1
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260307.0 h1:Gq4X9KoR/LQ92vJaUmMtF1GSsImCQvfd8UeXBkU6Vm4=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260307.0/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260307.1 h1:uKu1bSF2mftz05TFdRrPYu5vdgRuTvIlXaVjii3BrmA=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260307.1/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Summary

Upgrades cobbler-scaffold from v0.20260307.0 to v0.20260307.1. Notable upstream fixes include measure dedup against closed issues, stitch prompt size blowup fix, and stats:generator improvements.

## Changes

- Upgraded `magefiles/go.mod` and `magefiles/go.sum` to cobbler-scaffold v0.20260307.1
- Recurring issue re-created as #546

## Stats

- go_loc: 0 (no cmd/ in this branch, code is regenerated)
- spec_words: prd 36,364 / use_case 21,704 / test_suite 16,584

## Test plan

- [x] `mage analyze` passes
- [x] No Go source to test (cmd/ regenerated during generation runs)

Closes #477