### PR TITLE
GH-528: Specify rel07.0 (sort, tr, tail) and rel07.1 (cp, mv, rm)

### DIFF
--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -296,3 +296,38 @@ releases:
           status: spec_complete
         - id: rel06.1-uc005-groups
           status: spec_complete
+
+    - version: "07.0"
+      name: "Batch 7.0 — text processing pipeline (sort, tr, tail)"
+      status: spec_complete
+      description: |
+        Implement three text processing utilities that complete the stream processing
+        toolkit. sort orders lines with configurable keys, numeric modes, and field
+        delimiters. tr translates, deletes, or squeezes characters using SET specifications
+        and POSIX character classes. tail prints the last N lines or bytes of files, the
+        complement to head (rel02.2). All are verified by differential testing against GNU
+        coreutils reference binaries.
+      use_cases:
+        - id: rel07.0-uc001-sort
+          status: spec_complete
+        - id: rel07.0-uc002-tr
+          status: spec_complete
+        - id: rel07.0-uc003-tail
+          status: spec_complete
+
+    - version: "07.1"
+      name: "Batch 7.1 — file operations (cp, mv, rm)"
+      status: spec_complete
+      description: |
+        Implement three fundamental file operation utilities. cp copies files and directories
+        with attribute preservation, recursive mode, and symlink handling. mv moves or renames
+        files within and across filesystems. rm removes files and directories with recursive,
+        force, and interactive modes. All are verified by differential testing against GNU
+        coreutils reference binaries, comparing exit codes and resulting file system state.
+      use_cases:
+        - id: rel07.1-uc001-cp
+          status: spec_complete
+        - id: rel07.1-uc002-mv
+          status: spec_complete
+        - id: rel07.1-uc003-rm
+          status: spec_complete

--- a/docs/specs/product-requirements/prd053-sort.yaml
+++ b/docs/specs/product-requirements/prd053-sort.yaml
@@ -1,0 +1,68 @@
+id: prd053-sort
+title: "cmd/sort: Sort Lines of Text Files"
+
+problem: |
+  Sort is a foundational text processing utility used in virtually every Unix pipeline
+  that requires ordered data. The macOS BSD sort differs from GNU sort in collation
+  behavior, numeric parsing, and key field syntax. The Go implementation must match the
+  Homebrew GNU reference binary (gsort, installed by coreutils) byte-for-byte on all
+  flag combinations, verified by differential testing via pkg/testutils. All tests use
+  LC_ALL=C to eliminate locale-dependent divergence.
+
+goals:
+  - G1: Sort input lines lexicographically by default, with configurable key fields and ordering.
+  - G2: Support numeric, human-numeric, month, version, and random sort modes.
+  - G3: Support field-based sorting with key specifications (-k) and field separators (-t).
+  - G4: Verify functional parity against gsort via differential testing.
+
+requirements:
+  R1:
+    title: Basic sorting and output control
+    items:
+      - R1.1: When no flags are given, must sort all input lines lexicographically using byte values (LC_ALL=C).
+      - R1.2: Must read from stdin when no file arguments are given or when a file argument is "-".
+      - R1.3: Must accept multiple input files and sort their combined lines as a single stream.
+      - R1.4: "-r or --reverse must reverse the sort order."
+      - R1.5: "-u or --unique must output only the first of an equal run (based on the active sort key)."
+      - R1.6: "-o FILE or --output=FILE must write output to FILE. FILE may be the same as an input file."
+      - R1.7: "-s or --stable must preserve the input order of lines that compare equal."
+
+  R2:
+    title: Sort modes
+    items:
+      - R2.1: "-n or --numeric-sort must sort by numeric value, parsing leading whitespace and optional sign."
+      - R2.2: "-h or --human-numeric-sort must sort by numeric value with SI suffixes (K, M, G, T, P, E, Z, Y)."
+      - R2.3: "-M or --month-sort must sort by month name abbreviation (JAN < FEB < ... < DEC). Unknown strings sort before JAN."
+      - R2.4: "-V or --version-sort must sort by version number segments (natural sort)."
+
+  R3:
+    title: Key fields and delimiters
+    items:
+      - R3.1: "-t CHAR or --field-separator=CHAR must use CHAR as the field delimiter instead of the default blank-to-non-blank transition."
+      - R3.2: "-k KEYDEF or --key=KEYDEF must sort by the specified key field. KEYDEF format is F[.C][OPTS][,F[.C][OPTS]] where F is field number, C is character position, and OPTS are modifier letters (n, r, h, M, V, b, d, f, i)."
+      - R3.3: Must support multiple -k options. Earlier keys take precedence; later keys break ties.
+      - R3.4: "-b or --ignore-leading-blanks must ignore leading blanks when finding sort keys."
+
+  R4:
+    title: Exit codes and differential testing
+    items:
+      - R4.1: Must exit 0 when input is sorted successfully.
+      - R4.2: "-c or --check must check whether input is sorted. Exit 0 if sorted, exit 1 if not. With -C or --check=quiet, suppress the diagnostic message."
+      - R4.3: Must exit 2 on usage errors (invalid flags, conflicting options).
+      - R4.4: "Differential tests must compare stdout output and exit codes between the Go binary and the reference binary via pkg/testutils. Tests must cover: default sort, -r, -n, -h, -M, -V, -u, -s, -k with field specs, -t delimiter, -b, -c check mode, multi-file input, and stdin."
+
+non_goals:
+  - cmd/sort does not implement --parallel (threaded merge sort). Single-threaded sorting is sufficient for correctness verification.
+  - cmd/sort does not implement --compress-program for external merge with compression.
+  - cmd/sort does not implement -R (random sort with hash). Random output cannot be verified by differential testing.
+  - cmd/sort does not implement --files0-from for reading file lists from NUL-delimited input.
+  - cmd/sort does not implement external merge sort for inputs larger than available memory.
+
+acceptance_criteria:
+  - "AC1: printf 'banana\\napple\\ncherry\\n' | go run ./cmd/sort produces apple, banana, cherry, matching gsort."
+  - "AC2: printf '10\\n2\\n1\\n' | go run ./cmd/sort -n produces 1, 2, 10, matching gsort."
+  - "AC3: sort -k2,2 -t: on colon-delimited input produces correct field-based ordering, matching gsort."
+  - "AC4: sort -c on unsorted input exits 1, matching gsort."
+  - "AC5: sort -u removes duplicate lines based on the active key, matching gsort."
+  - "AC6: Differential test against gsort passes for all flag combinations listed in R4.4."
+  - "AC7: cmd/sort compiles with no warnings under golangci-lint."

--- a/docs/specs/product-requirements/prd054-tr.yaml
+++ b/docs/specs/product-requirements/prd054-tr.yaml
@@ -1,0 +1,60 @@
+id: prd054-tr
+title: "cmd/tr: Translate or Delete Characters"
+
+problem: |
+  tr is a character-level stream transform used for case conversion, character deletion,
+  and whitespace normalization in Unix pipelines. The macOS BSD tr differs from GNU tr
+  in character class support, octal escape handling, and squeeze behavior with complement
+  mode. The Go implementation must match the Homebrew GNU reference binary (gtr, installed
+  by coreutils) byte-for-byte on all flag combinations, verified by differential testing
+  via pkg/testutils.
+
+goals:
+  - G1: Translate characters from SET1 to corresponding characters in SET2.
+  - G2: Delete characters in SET1 with -d, squeeze repeated characters with -s.
+  - G3: Support character classes, ranges, and escape sequences in SET specifications.
+  - G4: Verify functional parity against gtr via differential testing.
+
+requirements:
+  R1:
+    title: Character translation
+    items:
+      - R1.1: "When two SETs are given without flags, must translate each character in SET1 to the corresponding character in SET2. If SET2 is shorter than SET1, the last character of SET2 is repeated to match SET1's length."
+      - R1.2: Must read from stdin and write translated output to stdout. tr does not accept file arguments.
+      - R1.3: "SET specifications must support: individual characters, ranges (a-z), octal escapes (\\NNN), backslash escapes (\\n, \\t, \\\\, \\a, \\b, \\f, \\r, \\v), and repetition (CHAR*N, CHAR*)."
+      - R1.4: "SET specifications must support POSIX character classes: [:alnum:], [:alpha:], [:blank:], [:cntrl:], [:digit:], [:graph:], [:lower:], [:print:], [:punct:], [:space:], [:upper:], [:xdigit:]."
+
+  R2:
+    title: Delete and squeeze modes
+    items:
+      - R2.1: "-d or --delete must delete all characters in SET1 from the input. SET2 is not used with -d alone."
+      - R2.2: "-s or --squeeze-repeats must replace each run of repeated characters listed in the last SET with a single occurrence of that character."
+      - R2.3: "When -d and -s are used together, must delete characters in SET1 and squeeze characters in SET2."
+      - R2.4: "-c or -C or --complement must complement SET1, operating on all characters not in SET1."
+
+  R3:
+    title: Character class translation pairs
+    items:
+      - R3.1: "[:lower:] to [:upper:] must translate lowercase to uppercase. [:upper:] to [:lower:] must translate uppercase to lowercase."
+      - R3.2: "When translating (not deleting), SET2 must not be empty. If SET2 is omitted, must print a usage error."
+      - R3.3: "Equivalence classes [=CHAR=] must be supported in SET2 for specifying characters that sort identically."
+
+  R4:
+    title: Exit codes and differential testing
+    items:
+      - R4.1: Must exit 0 when translation or deletion completes successfully.
+      - R4.2: Must exit 1 on usage errors (missing SET, invalid class, conflicting flags).
+      - R4.3: "Differential tests must compare stdout output and exit codes between the Go binary and the reference binary via pkg/testutils. Tests must cover: basic translation, -d delete, -s squeeze, -c complement, -ds combined, character ranges, POSIX classes, case conversion, octal escapes, and error cases."
+
+non_goals:
+  - cmd/tr does not implement multibyte character support beyond single-byte encodings. All tests use LC_ALL=C.
+  - cmd/tr does not accept file arguments; it reads exclusively from stdin per the POSIX specification.
+
+acceptance_criteria:
+  - "AC1: echo 'hello' | go run ./cmd/tr 'a-z' 'A-Z' produces HELLO, matching gtr."
+  - "AC2: echo 'hello' | go run ./cmd/tr -d 'l' produces heo, matching gtr."
+  - "AC3: echo 'aabbcc' | go run ./cmd/tr -s 'a-c' produces abc, matching gtr."
+  - "AC4: echo 'hello world' | go run ./cmd/tr -c 'a-z\\n' '*' replaces non-alpha characters with *, matching gtr."
+  - "AC5: echo 'hello 123' | go run ./cmd/tr -d '[:digit:]' produces 'hello ', matching gtr."
+  - "AC6: Differential test against gtr passes for all flag combinations listed in R4.3."
+  - "AC7: cmd/tr compiles with no warnings under golangci-lint."

--- a/docs/specs/product-requirements/prd055-tail.yaml
+++ b/docs/specs/product-requirements/prd055-tail.yaml
@@ -1,0 +1,63 @@
+id: prd055-tail
+title: "cmd/tail: Print the Last Lines or Bytes of Files"
+
+problem: |
+  tail is the complement to head: it extracts the end of files or follows growing files
+  in real time. The macOS BSD tail differs from GNU tail in byte-mode support, plus-prefix
+  semantics, and multi-file header formatting. The Go implementation must match the
+  Homebrew GNU reference binary (gtail, installed by coreutils) byte-for-byte on all
+  static flag combinations, verified by differential testing via pkg/testutils. Follow
+  mode (-f) is excluded from differential testing because its output is non-deterministic.
+
+goals:
+  - G1: Print the last N lines of each input file, defaulting to 10 lines.
+  - G2: Support byte-count mode (-c) as an alternative to line-count mode (-n).
+  - G3: Support starting from a given line or byte offset with the + prefix.
+  - G4: Verify functional parity against gtail via differential testing on static modes.
+
+requirements:
+  R1:
+    title: Line-count mode (default and -n)
+    items:
+      - R1.1: When no flags are given, must print the last 10 lines of each input file.
+      - R1.2: "-n NUM or --lines=NUM must print the last NUM lines. NUM must be a positive integer or prefixed with '+' to start from line NUM."
+      - R1.3: "When NUM is prefixed with '+' (e.g., -n +5), must print starting from line NUM to the end of the file. Line numbering starts at 1."
+      - R1.4: Must read from stdin when no file arguments are given or when a file argument is "-".
+
+  R2:
+    title: Byte-count mode (-c)
+    items:
+      - R2.1: "-c NUM or --bytes=NUM must print the last NUM bytes of each input. -c and -n are mutually exclusive; the last one given takes precedence."
+      - R2.2: "When NUM is prefixed with '+' (e.g., -c +100), must print starting from byte NUM to the end. Byte numbering starts at 1."
+      - R2.3: NUM may use multiplier suffixes as defined by GNU coreutils (b, K/KiB, M/MiB, G/GiB).
+
+  R3:
+    title: Multi-file output and headers
+    items:
+      - R3.1: "When multiple files are given, must precede each file's output with a header in the format '==> FILENAME <==' followed by a newline. A blank line separates each file's header from the previous file's output."
+      - R3.2: When a single file is given, must not print a header by default.
+      - R3.3: -q or --quiet or --silent must suppress all headers, even for multiple files.
+      - R3.4: -v or --verbose must print headers even for a single file.
+
+  R4:
+    title: Exit codes and differential testing
+    items:
+      - R4.1: Must exit 0 when all input files are processed successfully.
+      - R4.2: Must exit 1 when any input file cannot be opened or read. Must still process and output content for the files that were successfully read.
+      - R4.3: "Differential tests must compare stdout output and exit codes between the Go binary and the reference binary via pkg/testutils. Tests must cover: default 10 lines, explicit -n count, -c byte count, +N offset (lines and bytes), multi-file headers, -q, -v, stdin input, and error on non-existent file."
+      - R4.4: "When a named file cannot be opened, must print an error message to stderr and continue processing remaining files."
+
+non_goals:
+  - "cmd/tail does not implement -f or --follow (follow mode). Follow mode output is non-deterministic and cannot be verified by differential testing."
+  - "cmd/tail does not implement --pid (terminate after process dies). This flag is only meaningful with -f."
+  - "cmd/tail does not implement --retry (keep trying to open a file). This flag is only meaningful with -f."
+  - cmd/tail does not implement -F (equivalent to --follow=name --retry).
+
+acceptance_criteria:
+  - "AC1: seq 1 20 | go run ./cmd/tail produces lines 11 through 20, matching gtail."
+  - "AC2: seq 1 20 | go run ./cmd/tail -n 5 produces lines 16 through 20, matching gtail."
+  - "AC3: seq 1 20 | go run ./cmd/tail -n +5 produces lines 5 through 20, matching gtail."
+  - "AC4: printf 'abcdefghij' | go run ./cmd/tail -c 5 produces 'fghij', matching gtail."
+  - "AC5: go run ./cmd/tail file1.txt file2.txt prints headers and correct tail content, matching gtail."
+  - "AC6: Differential test against gtail passes for all static flag combinations listed in R4.3."
+  - "AC7: cmd/tail compiles with no warnings under golangci-lint."

--- a/docs/specs/product-requirements/prd056-cp.yaml
+++ b/docs/specs/product-requirements/prd056-cp.yaml
@@ -1,0 +1,65 @@
+id: prd056-cp
+title: "cmd/cp: Copy Files and Directories"
+
+problem: |
+  cp is a fundamental file operation utility used for duplicating files and directory
+  trees. The macOS BSD cp differs from GNU cp in attribute preservation semantics,
+  reflink support, and sparse file handling. The Go implementation must match the
+  Homebrew GNU reference binary (gcp, installed by coreutils) on exit codes and
+  observable file system state for all supported flag combinations, verified by
+  differential testing via pkg/testutils.
+
+goals:
+  - G1: Copy files and directories with configurable attribute preservation.
+  - G2: Support recursive directory copying with symlink and special file handling.
+  - G3: Support interactive, force, and no-clobber modes for destination conflict resolution.
+  - G4: Verify functional parity against gcp via differential testing.
+
+requirements:
+  R1:
+    title: Basic file copying
+    items:
+      - R1.1: "When given SOURCE DEST, must copy SOURCE to DEST. When given multiple SOURCE arguments and a DEST directory, must copy each SOURCE into DEST."
+      - R1.2: "-i or --interactive must prompt before overwriting an existing destination file."
+      - R1.3: "-f or --force must remove an existing destination file if it cannot be opened for writing, then retry the copy."
+      - R1.4: "-n or --no-clobber must not overwrite an existing destination file. When combined with -i, -n takes precedence."
+
+  R2:
+    title: Recursive copying and symlinks
+    items:
+      - R2.1: "-r or -R or --recursive must copy directories recursively, preserving the directory structure."
+      - R2.2: "Without -r, must refuse to copy a directory and print an error to stderr."
+      - R2.3: "-L or --dereference must follow symlinks in SOURCE, copying the file they point to."
+      - R2.4: "-P or --no-dereference must preserve symlinks, copying them as symlinks rather than following them. This is the default with -r."
+
+  R3:
+    title: Attribute preservation
+    items:
+      - R3.1: "-p or --preserve=mode,ownership,timestamps must preserve file mode, ownership, and modification timestamps on the copy."
+      - R3.2: "-a or --archive is equivalent to -dR --preserve=all. It preserves all attributes and copies recursively without following symlinks."
+      - R3.3: "--preserve=ATTR_LIST must accept a comma-separated list of attributes to preserve. Supported attributes are mode, ownership, timestamps, and links."
+      - R3.4: "-v or --verbose must print the name of each file as it is copied."
+
+  R4:
+    title: Exit codes and differential testing
+    items:
+      - R4.1: Must exit 0 when all files are copied successfully.
+      - R4.2: Must exit 1 when any copy operation fails (permission denied, source not found, destination is a directory without -r).
+      - R4.3: "-t DIRECTORY or --target-directory=DIRECTORY must copy all SOURCE arguments into DIRECTORY."
+      - R4.4: "Differential tests must compare exit codes and resulting file system state between the Go binary and the reference binary via pkg/testutils. Tests must cover: single file copy, multi-file copy into directory, -r recursive, -i interactive (via stdin), -f force, -n no-clobber, -p preserve, -a archive, -v verbose, symlink handling, and error cases."
+
+non_goals:
+  - "cmd/cp does not implement --reflink (copy-on-write clones). Reflink support is filesystem-dependent and not available on all platforms."
+  - cmd/cp does not implement --sparse (sparse file detection and reproduction).
+  - cmd/cp does not implement -u (copy only when source is newer).
+  - cmd/cp does not implement --backup (make backups of existing destination files).
+  - cmd/cp does not implement SELinux context preservation (--context).
+
+acceptance_criteria:
+  - "AC1: go run ./cmd/cp file1.txt file2.txt creates an identical copy, matching gcp."
+  - "AC2: go run ./cmd/cp -r dir1/ dir2/ recursively copies the directory tree, matching gcp."
+  - "AC3: go run ./cmd/cp -p file1.txt file2.txt preserves mode and timestamps, matching gcp."
+  - "AC4: go run ./cmd/cp -n existing.txt target.txt does not overwrite target, matching gcp."
+  - "AC5: go run ./cmd/cp nonexistent.txt target.txt exits 1 with error on stderr, matching gcp."
+  - "AC6: Differential test against gcp passes for all flag combinations listed in R4.4."
+  - "AC7: cmd/cp compiles with no warnings under golangci-lint."

--- a/docs/specs/product-requirements/prd057-mv.yaml
+++ b/docs/specs/product-requirements/prd057-mv.yaml
@@ -1,0 +1,62 @@
+id: prd057-mv
+title: "cmd/mv: Move or Rename Files"
+
+problem: |
+  mv renames files within the same filesystem or copies and deletes across filesystems.
+  The macOS BSD mv differs from GNU mv in cross-device fallback behavior and verbose
+  output formatting. The Go implementation must match the Homebrew GNU reference binary
+  (gmv, installed by coreutils) on exit codes and observable file system state for all
+  supported flag combinations, verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Move or rename files and directories within and across filesystems.
+  - G2: Support interactive, force, and no-clobber modes for destination conflict resolution.
+  - G3: Support verbose output and target directory specification.
+  - G4: Verify functional parity against gmv via differential testing.
+
+requirements:
+  R1:
+    title: Basic move and rename
+    items:
+      - R1.1: "When given SOURCE DEST, must rename SOURCE to DEST if on the same filesystem, or copy and delete if on different filesystems."
+      - R1.2: "When given multiple SOURCE arguments and a DEST directory, must move each SOURCE into DEST."
+      - R1.3: Must move directories without requiring a recursive flag (unlike cp).
+      - R1.4: "When DEST exists and is a directory, must move SOURCE into DEST as DEST/SOURCE."
+
+  R2:
+    title: Overwrite control
+    items:
+      - R2.1: "-i or --interactive must prompt before overwriting an existing destination file."
+      - R2.2: "-f or --force must not prompt before overwriting. When combined with -i, the last flag given takes precedence."
+      - R2.3: "-n or --no-clobber must not overwrite an existing destination file."
+      - R2.4: "When the destination cannot be overwritten due to permissions, must print an error to stderr."
+
+  R3:
+    title: Output control and target directory
+    items:
+      - R3.1: "-v or --verbose must print the name of each file as it is moved, in the format 'SOURCE -> DEST' or 'renamed SOURCE -> DEST'."
+      - R3.2: "-t DIRECTORY or --target-directory=DIRECTORY must move all SOURCE arguments into DIRECTORY."
+      - R3.3: "-T or --no-target-directory must treat DEST as a normal file, not a directory."
+
+  R4:
+    title: Exit codes and differential testing
+    items:
+      - R4.1: Must exit 0 when all files are moved successfully.
+      - R4.2: Must exit 1 when any move operation fails (permission denied, source not found).
+      - R4.3: "When moving multiple files and one fails, must continue moving remaining files and exit 1."
+      - R4.4: "Differential tests must compare exit codes and resulting file system state between the Go binary and the reference binary via pkg/testutils. Tests must cover: single file rename, move into directory, multi-file move, -i interactive, -f force, -n no-clobber, -v verbose, -t target directory, directory move, and error cases."
+
+non_goals:
+  - cmd/mv does not implement --backup (make backups of existing destination files).
+  - cmd/mv does not implement --suffix (override backup suffix).
+  - cmd/mv does not implement -u (move only when source is newer).
+  - cmd/mv does not implement SELinux context preservation (--context).
+
+acceptance_criteria:
+  - "AC1: go run ./cmd/mv file1.txt file2.txt renames the file, matching gmv."
+  - "AC2: go run ./cmd/mv file1.txt dir/ moves file into directory, matching gmv."
+  - "AC3: go run ./cmd/mv -n existing.txt target.txt does not overwrite target, matching gmv."
+  - "AC4: go run ./cmd/mv -v file1.txt file2.txt prints the move operation, matching gmv."
+  - "AC5: go run ./cmd/mv nonexistent.txt target.txt exits 1 with error on stderr, matching gmv."
+  - "AC6: Differential test against gmv passes for all flag combinations listed in R4.4."
+  - "AC7: cmd/mv compiles with no warnings under golangci-lint."

--- a/docs/specs/product-requirements/prd058-rm.yaml
+++ b/docs/specs/product-requirements/prd058-rm.yaml
@@ -1,0 +1,62 @@
+id: prd058-rm
+title: "cmd/rm: Remove Files or Directories"
+
+problem: |
+  rm removes files and directories from the filesystem. The macOS BSD rm differs from
+  GNU rm in interactive prompt formatting, --one-file-system behavior, and verbose output.
+  The Go implementation must match the Homebrew GNU reference binary (grm, installed by
+  coreutils) on exit codes and observable file system state for all supported flag
+  combinations, verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Remove files and directories with configurable safety controls.
+  - G2: Support recursive directory removal and interactive confirmation modes.
+  - G3: Support force mode to suppress errors on non-existent files.
+  - G4: Verify functional parity against grm via differential testing.
+
+requirements:
+  R1:
+    title: Basic file removal
+    items:
+      - R1.1: "When given one or more FILE arguments, must remove each file using unlink(2)."
+      - R1.2: "Without -r, must refuse to remove a directory and print an error to stderr."
+      - R1.3: "Must not remove '.' or '..' to prevent accidental directory tree destruction. Must print an error if either is specified."
+      - R1.4: "When a file cannot be removed (permission denied, in use), must print an error to stderr and continue with remaining files."
+
+  R2:
+    title: Recursive removal and force mode
+    items:
+      - R2.1: "-r or -R or --recursive must remove directories and their contents recursively."
+      - R2.2: "-f or --force must ignore non-existent files and never prompt. Overrides -i and -I."
+      - R2.3: "When -r and -f are combined, must silently remove directory trees without prompting."
+      - R2.4: "-d or --dir must remove empty directories. Without -d or -r, directory removal fails."
+
+  R3:
+    title: Interactive modes and verbose output
+    items:
+      - R3.1: "-i must prompt before every removal."
+      - R3.2: "-I must prompt once before removing more than three files or when removing recursively."
+      - R3.3: "-v or --verbose must print the name of each file as it is removed."
+      - R3.4: "--interactive=WHEN must control prompting. WHEN is 'never' (like -f), 'once' (like -I), or 'always' (like -i)."
+
+  R4:
+    title: Exit codes and differential testing
+    items:
+      - R4.1: Must exit 0 when all files are removed successfully.
+      - R4.2: Must exit 1 when any removal fails. Must continue removing remaining files.
+      - R4.3: "With -f, must exit 0 even when specified files do not exist."
+      - R4.4: "Differential tests must compare exit codes and resulting file system state between the Go binary and the reference binary via pkg/testutils. Tests must cover: single file removal, multi-file removal, -r recursive, -f force on non-existent, -d empty directory, -v verbose, error on directory without -r, error on permission denied, and refusing to remove '.' or '..'."
+
+non_goals:
+  - cmd/rm does not implement --one-file-system (skip directories on different filesystems during recursive removal).
+  - cmd/rm does not implement --preserve-root and --no-preserve-root. The default behavior refuses to remove root.
+  - cmd/rm does not implement shred-on-delete or secure deletion.
+
+acceptance_criteria:
+  - "AC1: touch f && go run ./cmd/rm f removes the file, matching grm."
+  - "AC2: mkdir -p d/sub && go run ./cmd/rm -r d removes the directory tree, matching grm."
+  - "AC3: go run ./cmd/rm -f nonexistent exits 0 silently, matching grm."
+  - "AC4: go run ./cmd/rm -v f prints the removal, matching grm."
+  - "AC5: go run ./cmd/rm dir without -r exits 1 with error, matching grm."
+  - "AC6: Differential test against grm passes for all flag combinations listed in R4.4."
+  - "AC7: cmd/rm compiles with no warnings under golangci-lint."

--- a/docs/specs/test-suites/test-rel-07.0.yaml
+++ b/docs/specs/test-suites/test-rel-07.0.yaml
@@ -1,0 +1,301 @@
+id: test-rel07.0
+title: "Test Suite: rel07.0 — sort, tr, tail"
+release: rel07.0
+
+traces:
+  - rel07.0-uc001-sort
+  - rel07.0-uc002-tr
+  - rel07.0-uc003-tail
+  - prd053-sort R1
+  - prd053-sort R2
+  - prd053-sort R3
+  - prd053-sort R4
+  - prd054-tr R1
+  - prd054-tr R2
+  - prd054-tr R3
+  - prd054-tr R4
+  - prd055-tail R1
+  - prd055-tail R2
+  - prd055-tail R3
+  - prd055-tail R4
+
+preconditions:
+  - ./bin/sort, ./bin/tr, and ./bin/tail exist (built via mage build).
+  - Reference binaries gsort, gtr, and gtail are installed via Homebrew (coreutils) and on PATH.
+  - Tests are run via go test ./cmd/<utility>/... which invokes RunDiffTests from pkg/testutils.
+  - All tests use LC_ALL=C to eliminate locale-dependent divergence.
+  - "sort: no output normalization is needed; sort output is deterministic under LC_ALL=C."
+  - "tr: no output normalization is needed; tr output is deterministic."
+  - "tail: no output normalization is needed; tail static mode output is deterministic."
+
+test_cases:
+  # --- sort: default lexicographic ---
+  - name: sort_default_lexicographic
+    description: "sort with no flags orders lines lexicographically by byte value."
+    inputs:
+      args: []
+      stdin: "banana\napple\ncherry\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "apple\nbanana\ncherry\n"
+      stderr: ""
+    traces:
+      - prd053-sort R1.1
+
+  # --- sort: numeric ---
+  - name: sort_numeric
+    description: "sort -n orders lines by numeric value."
+    inputs:
+      args: ["-n"]
+      stdin: "10\n2\n1\n20\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "1\n2\n10\n20\n"
+      stderr: ""
+    traces:
+      - prd053-sort R2.1
+
+  # --- sort: reverse ---
+  - name: sort_reverse
+    description: "sort -r reverses the sort order."
+    inputs:
+      args: ["-r"]
+      stdin: "apple\nbanana\ncherry\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "cherry\nbanana\napple\n"
+      stderr: ""
+    traces:
+      - prd053-sort R1.4
+
+  # --- sort: unique ---
+  - name: sort_unique
+    description: "sort -u outputs only the first of equal runs."
+    inputs:
+      args: ["-u"]
+      stdin: "apple\nbanana\napple\ncherry\nbanana\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "apple\nbanana\ncherry\n"
+      stderr: ""
+    traces:
+      - prd053-sort R1.5
+
+  # --- sort: key field with delimiter ---
+  - name: sort_key_field_delimiter
+    description: "sort -k2,2 -t: sorts by the second colon-delimited field."
+    inputs:
+      args: ["-k2,2", "-t:"]
+      stdin: "c:banana\na:cherry\nb:apple\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "b:apple\nc:banana\na:cherry\n"
+      stderr: ""
+    traces:
+      - prd053-sort R3.1
+      - prd053-sort R3.2
+
+  # --- sort: check sorted ---
+  - name: sort_check_sorted
+    description: "sort -c on sorted input exits 0."
+    inputs:
+      args: ["-c"]
+      stdin: "apple\nbanana\ncherry\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd053-sort R4.2
+
+  # --- sort: check unsorted ---
+  - name: sort_check_unsorted
+    description: "sort -c on unsorted input exits 1."
+    inputs:
+      args: ["-c"]
+      stdin: "banana\napple\ncherry\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 1
+      stdout: ""
+      stderr_contains: "disorder"
+    traces:
+      - prd053-sort R4.2
+
+  # --- tr: basic translation ---
+  - name: tr_basic_translate
+    description: "tr translates lowercase to uppercase."
+    inputs:
+      args: ["a-z", "A-Z"]
+      stdin: "hello world\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "HELLO WORLD\n"
+      stderr: ""
+    traces:
+      - prd054-tr R1.1
+
+  # --- tr: delete ---
+  - name: tr_delete
+    description: "tr -d deletes characters in SET1."
+    inputs:
+      args: ["-d", "l"]
+      stdin: "hello\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "heo\n"
+      stderr: ""
+    traces:
+      - prd054-tr R2.1
+
+  # --- tr: squeeze ---
+  - name: tr_squeeze
+    description: "tr -s squeezes repeated characters."
+    inputs:
+      args: ["-s", "a-c"]
+      stdin: "aabbcc\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "abc\n"
+      stderr: ""
+    traces:
+      - prd054-tr R2.2
+
+  # --- tr: complement delete ---
+  - name: tr_complement_delete
+    description: "tr -cd deletes all characters not in SET1."
+    inputs:
+      args: ["-cd", "a-z\n"]
+      stdin: "hello 123 world\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "helloworld\n"
+      stderr: ""
+    traces:
+      - prd054-tr R2.4
+
+  # --- tr: character class ---
+  - name: tr_character_class_digit_delete
+    description: "tr -d [:digit:] deletes all digits."
+    inputs:
+      args: ["-d", "[:digit:]"]
+      stdin: "abc123def456\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "abcdef\n"
+      stderr: ""
+    traces:
+      - prd054-tr R1.4
+
+  # --- tail: default 10 lines ---
+  - name: tail_default_10_lines
+    description: "tail with no flags prints the last 10 lines of stdin."
+    inputs:
+      args: []
+      stdin: "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n"
+      stderr: ""
+    traces:
+      - prd055-tail R1.1
+
+  # --- tail: explicit line count ---
+  - name: tail_n_5
+    description: "tail -n 5 prints the last 5 lines."
+    inputs:
+      args: ["-n", "5"]
+      stdin: "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "6\n7\n8\n9\n10\n"
+      stderr: ""
+    traces:
+      - prd055-tail R1.2
+
+  # --- tail: plus offset ---
+  - name: tail_n_plus_5
+    description: "tail -n +5 prints starting from line 5 to the end."
+    inputs:
+      args: ["-n", "+5"]
+      stdin: "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "5\n6\n7\n8\n9\n10\n"
+      stderr: ""
+    traces:
+      - prd055-tail R1.3
+
+  # --- tail: byte count ---
+  - name: tail_c_5
+    description: "tail -c 5 prints the last 5 bytes."
+    inputs:
+      args: ["-c", "5"]
+      stdin: "abcdefghij"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "fghij"
+      stderr: ""
+    traces:
+      - prd055-tail R2.1
+
+  # --- tail: multi-file headers ---
+  - name: tail_multi_file_headers
+    description: "tail with two files prints headers '==> FILENAME <==' before each file's output. Setup: file1.txt contains lines 1-12, file2.txt contains lines 1-12."
+    inputs:
+      args: ["file1.txt", "file2.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout_contains: "==> file1.txt <=="
+      stderr: ""
+    traces:
+      - prd055-tail R3.1
+
+  # --- tail: missing file error ---
+  - name: tail_missing_file
+    description: "tail with a non-existent file prints error to stderr and exits 1."
+    inputs:
+      args: ["missing.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 1
+      stderr_contains: "missing.txt"
+    traces:
+      - prd055-tail R4.2
+      - prd055-tail R4.4

--- a/docs/specs/test-suites/test-rel-07.1.yaml
+++ b/docs/specs/test-suites/test-rel-07.1.yaml
@@ -1,0 +1,245 @@
+id: test-rel07.1
+title: "Test Suite: rel07.1 — cp, mv, rm"
+release: rel07.1
+
+traces:
+  - rel07.1-uc001-cp
+  - rel07.1-uc002-mv
+  - rel07.1-uc003-rm
+  - prd056-cp R1
+  - prd056-cp R2
+  - prd056-cp R3
+  - prd056-cp R4
+  - prd057-mv R1
+  - prd057-mv R2
+  - prd057-mv R3
+  - prd057-mv R4
+  - prd058-rm R1
+  - prd058-rm R2
+  - prd058-rm R3
+  - prd058-rm R4
+
+preconditions:
+  - ./bin/cp, ./bin/mv, and ./bin/rm exist (built via mage build).
+  - Reference binaries gcp, gmv, and grm are installed via Homebrew (coreutils) and on PATH.
+  - Tests are run via go test ./cmd/<utility>/... which invokes RunDiffTests from pkg/testutils.
+  - All tests use LC_ALL=C to eliminate locale-dependent divergence.
+  - "All file operation tests create temporary directories to isolate side effects."
+  - "Tests compare exit codes and resulting file system state (file existence, content, permissions)."
+
+test_cases:
+  # --- cp: single file copy ---
+  - name: cp_single_file
+    description: "cp copies a single file to a new destination. Setup: source.txt contains 'hello'."
+    inputs:
+      args: ["source.txt", "dest.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      file_exists: "dest.txt"
+      file_content: "hello"
+    traces:
+      - prd056-cp R1.1
+
+  # --- cp: copy into directory ---
+  - name: cp_into_directory
+    description: "cp copies a file into an existing directory. Setup: source.txt exists, destdir/ exists."
+    inputs:
+      args: ["source.txt", "destdir/"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      file_exists: "destdir/source.txt"
+    traces:
+      - prd056-cp R1.1
+
+  # --- cp: recursive directory copy ---
+  - name: cp_recursive
+    description: "cp -r copies a directory tree recursively. Setup: srcdir/sub/file.txt exists."
+    inputs:
+      args: ["-r", "srcdir", "destdir"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      file_exists: "destdir/sub/file.txt"
+    traces:
+      - prd056-cp R2.1
+
+  # --- cp: no-clobber ---
+  - name: cp_no_clobber
+    description: "cp -n does not overwrite an existing file. Setup: source.txt contains 'new', target.txt contains 'old'."
+    inputs:
+      args: ["-n", "source.txt", "target.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      file_content_target: "old"
+    traces:
+      - prd056-cp R1.4
+
+  # --- cp: directory without -r fails ---
+  - name: cp_directory_without_recursive
+    description: "cp without -r on a directory argument prints an error and exits 1."
+    inputs:
+      args: ["srcdir", "destdir"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 1
+      stderr_contains: "directory"
+    traces:
+      - prd056-cp R2.2
+
+  # --- cp: missing source ---
+  - name: cp_missing_source
+    description: "cp with a non-existent source exits 1 with error on stderr."
+    inputs:
+      args: ["nonexistent.txt", "dest.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 1
+      stderr_contains: "nonexistent.txt"
+    traces:
+      - prd056-cp R4.2
+
+  # --- mv: rename file ---
+  - name: mv_rename
+    description: "mv renames a file. Setup: source.txt exists."
+    inputs:
+      args: ["source.txt", "dest.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      file_exists: "dest.txt"
+      file_not_exists: "source.txt"
+    traces:
+      - prd057-mv R1.1
+
+  # --- mv: move into directory ---
+  - name: mv_into_directory
+    description: "mv moves a file into an existing directory. Setup: file.txt exists, destdir/ exists."
+    inputs:
+      args: ["file.txt", "destdir/"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      file_exists: "destdir/file.txt"
+      file_not_exists: "file.txt"
+    traces:
+      - prd057-mv R1.2
+      - prd057-mv R1.4
+
+  # --- mv: no-clobber ---
+  - name: mv_no_clobber
+    description: "mv -n does not overwrite an existing file. Setup: source.txt contains 'new', target.txt contains 'old'."
+    inputs:
+      args: ["-n", "source.txt", "target.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      file_content_target: "old"
+    traces:
+      - prd057-mv R2.3
+
+  # --- mv: missing source ---
+  - name: mv_missing_source
+    description: "mv with a non-existent source exits 1 with error on stderr."
+    inputs:
+      args: ["nonexistent.txt", "dest.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 1
+      stderr_contains: "nonexistent.txt"
+    traces:
+      - prd057-mv R4.2
+
+  # --- rm: single file removal ---
+  - name: rm_single_file
+    description: "rm removes a single file. Setup: target.txt exists."
+    inputs:
+      args: ["target.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      file_not_exists: "target.txt"
+    traces:
+      - prd058-rm R1.1
+
+  # --- rm: recursive directory removal ---
+  - name: rm_recursive
+    description: "rm -r removes a directory tree. Setup: dir/sub/file.txt exists."
+    inputs:
+      args: ["-r", "dir"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      file_not_exists: "dir"
+    traces:
+      - prd058-rm R2.1
+
+  # --- rm: force on non-existent ---
+  - name: rm_force_nonexistent
+    description: "rm -f on a non-existent file exits 0 silently."
+    inputs:
+      args: ["-f", "nonexistent.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd058-rm R2.2
+      - prd058-rm R4.3
+
+  # --- rm: directory without -r fails ---
+  - name: rm_directory_without_recursive
+    description: "rm without -r on a directory argument prints an error and exits 1."
+    inputs:
+      args: ["dir"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 1
+      stderr_contains: "directory"
+    traces:
+      - prd058-rm R1.2
+
+  # --- rm: refuse dot and dotdot ---
+  - name: rm_refuse_dot
+    description: "rm -r refuses to remove '.' and prints an error."
+    inputs:
+      args: ["-r", "."]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 1
+      stderr_contains: "."
+    traces:
+      - prd058-rm R1.3

--- a/docs/specs/use-cases/rel07.0-uc001-sort.yaml
+++ b/docs/specs/use-cases/rel07.0-uc001-sort.yaml
@@ -1,0 +1,79 @@
+id: rel07.0-uc001-sort
+title: "Sort lines of text files via sort"
+
+summary: |
+  The operator invokes the Go sort binary to order lines from files or pipeline input.
+  The differential testing harness runs both the Go binary and the Homebrew reference
+  binary (gsort from coreutils) with the same arguments, stdin, and environment, then
+  compares stdout byte-for-byte.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd053-sort.yaml) and invokes do-work to
+  produce a passing differential test for cmd/sort.
+
+flow:
+  - id: F1
+    step: |
+      The operator runs "printf 'banana\napple\ncherry\n' | ./bin/sort". sort prints
+      the lines in lexicographic order: apple, banana, cherry.
+  - id: F2
+    step: |
+      The operator runs "printf '10\n2\n1\n' | ./bin/sort -n" to sort numerically,
+      producing 1, 2, 10.
+  - id: F3
+    step: |
+      The operator runs "./bin/sort -k2,2 -t: input.txt" to sort by the second
+      colon-delimited field.
+  - id: F4
+    step: |
+      The operator runs "./bin/sort -u input.txt" to output only unique lines based
+      on the sort key.
+  - id: F5
+    step: |
+      The operator runs "./bin/sort -c input.txt" to check whether input is already
+      sorted, receiving exit 0 if sorted and exit 1 if not.
+  - id: F6
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/sort and
+      gsort with the same arguments and environment.
+  - id: F7
+    step: |
+      The harness compares stdout byte-for-byte and exit codes. Both binaries must
+      produce identical output.
+
+touchpoints:
+  - T1: "cmd/sort — lexicographic, numeric, human-numeric, month, version sort, key fields, delimiters, reverse, unique, stable, check mode (prd053-sort R1, R2, R3, R4)"
+  - T2: "pkg/testutils — RunDiffTests, stdout comparison"
+
+success_criteria:
+  - id: S1
+    criterion: cmd/sort compiles and ./bin/sort exists after mage build.
+  - id: S2
+    criterion: |
+      Default lexicographic sort produces correctly ordered output, matching gsort.
+  - id: S3
+    criterion: |
+      Numeric sort (-n) orders by numeric value, not lexicographic order.
+  - id: S4
+    criterion: |
+      Key field sort (-k with -t) correctly extracts and sorts by the specified field.
+  - id: S5
+    criterion: |
+      Unique mode (-u) outputs only the first of each equal run.
+  - id: S6
+    criterion: |
+      Check mode (-c) exits 0 for sorted input and 1 for unsorted input.
+  - id: S7
+    criterion: |
+      Reverse (-r) and stable (-s) modes produce correct output.
+  - id: S8
+    criterion: |
+      The differential test passes for all flag combinations listed in the PRD.
+
+out_of_scope:
+  - Parallel sort (--parallel) is excluded per the PRD.
+  - Random sort (-R) is excluded per the PRD.
+
+test_suite: test-rel07.0

--- a/docs/specs/use-cases/rel07.0-uc002-tr.yaml
+++ b/docs/specs/use-cases/rel07.0-uc002-tr.yaml
@@ -1,0 +1,75 @@
+id: rel07.0-uc002-tr
+title: "Translate or delete characters via tr"
+
+summary: |
+  The operator invokes the Go tr binary to translate, delete, or squeeze characters
+  from stdin. The differential testing harness runs both the Go binary and the Homebrew
+  reference binary (gtr from coreutils) with the same arguments, stdin, and environment,
+  then compares stdout byte-for-byte.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd054-tr.yaml) and invokes do-work to
+  produce a passing differential test for cmd/tr.
+
+flow:
+  - id: F1
+    step: |
+      The operator runs "echo 'hello' | ./bin/tr 'a-z' 'A-Z'". tr translates all
+      lowercase letters to uppercase, producing HELLO.
+  - id: F2
+    step: |
+      The operator runs "echo 'hello' | ./bin/tr -d 'l'" to delete all occurrences
+      of 'l', producing heo.
+  - id: F3
+    step: |
+      The operator runs "echo 'aabbcc' | ./bin/tr -s 'a-c'" to squeeze repeated
+      characters, producing abc.
+  - id: F4
+    step: |
+      The operator runs "echo 'hello 123' | ./bin/tr -d '[:digit:]'" to delete all
+      digits using a POSIX character class.
+  - id: F5
+    step: |
+      The operator runs "echo 'hello world' | ./bin/tr -c 'a-z\n' '*'" to complement
+      the set, replacing non-alpha characters with asterisks.
+  - id: F6
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/tr and
+      gtr with the same arguments and environment.
+  - id: F7
+    step: |
+      The harness compares stdout byte-for-byte and exit codes. Both binaries must
+      produce identical output.
+
+touchpoints:
+  - T1: "cmd/tr — character translation, deletion, squeezing, complement, character classes, ranges, escapes (prd054-tr R1, R2, R3, R4)"
+  - T2: "pkg/testutils — RunDiffTests, stdout comparison"
+
+success_criteria:
+  - id: S1
+    criterion: cmd/tr compiles and ./bin/tr exists after mage build.
+  - id: S2
+    criterion: |
+      Basic character translation (SET1 to SET2) produces correct output, matching gtr.
+  - id: S3
+    criterion: |
+      Delete mode (-d) removes all characters in SET1 from the input.
+  - id: S4
+    criterion: |
+      Squeeze mode (-s) replaces runs of repeated characters with a single occurrence.
+  - id: S5
+    criterion: |
+      Complement mode (-c) operates on characters not in SET1.
+  - id: S6
+    criterion: |
+      POSIX character classes ([:lower:], [:upper:], [:digit:], etc.) work correctly.
+  - id: S7
+    criterion: |
+      The differential test passes for all flag combinations listed in the PRD.
+
+out_of_scope:
+  - Multibyte character support is excluded per the PRD.
+
+test_suite: test-rel07.0

--- a/docs/specs/use-cases/rel07.0-uc003-tail.yaml
+++ b/docs/specs/use-cases/rel07.0-uc003-tail.yaml
@@ -1,0 +1,78 @@
+id: rel07.0-uc003-tail
+title: "Print the last lines or bytes of files via tail"
+
+summary: |
+  The operator invokes the Go tail binary to extract the end of files or pipeline
+  output. The differential testing harness runs both the Go binary and the Homebrew
+  reference binary (gtail from coreutils) with the same arguments, stdin, and
+  environment, then compares stdout byte-for-byte. Follow mode (-f) is excluded
+  from testing because its output is non-deterministic.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd055-tail.yaml) and invokes do-work to
+  produce a passing differential test for cmd/tail.
+
+flow:
+  - id: F1
+    step: |
+      The operator runs "seq 1 20 | ./bin/tail". tail prints the last 10 lines
+      (lines 11 through 20) to stdout.
+  - id: F2
+    step: |
+      The operator runs "seq 1 20 | ./bin/tail -n 5" to print only the last 5 lines.
+  - id: F3
+    step: |
+      The operator runs "seq 1 20 | ./bin/tail -n +5" to print starting from line 5
+      to the end of input.
+  - id: F4
+    step: |
+      The operator runs "printf 'abcdefghij' | ./bin/tail -c 5" to print the last
+      5 bytes.
+  - id: F5
+    step: |
+      The operator runs "./bin/tail file1.txt file2.txt" to test multi-file output
+      with headers in the format "==> FILENAME <==".
+  - id: F6
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/tail and
+      gtail with the same arguments and environment.
+  - id: F7
+    step: |
+      The harness compares stdout byte-for-byte and exit codes. Both binaries must
+      produce identical output.
+
+touchpoints:
+  - T1: "cmd/tail — line-count, byte-count, plus-offset, multi-file headers, quiet/verbose (prd055-tail R1, R2, R3, R4)"
+  - T2: "pkg/testutils — RunDiffTests, stdout comparison"
+
+success_criteria:
+  - id: S1
+    criterion: cmd/tail compiles and ./bin/tail exists after mage build.
+  - id: S2
+    criterion: |
+      "seq 1 20 | ./bin/tail" produces lines 11 through 20, matching gtail.
+  - id: S3
+    criterion: |
+      Explicit line count works: "tail -n 5" produces the last 5 lines.
+  - id: S4
+    criterion: |
+      Plus-offset works: "tail -n +5" prints from line 5 onward.
+  - id: S5
+    criterion: |
+      Byte count works: "tail -c 5" prints the last 5 bytes.
+  - id: S6
+    criterion: |
+      Multi-file headers are printed in the format "==> FILENAME <==", matching gtail.
+  - id: S7
+    criterion: |
+      Header suppression (-q) and forced headers (-v) work correctly.
+  - id: S8
+    criterion: |
+      The differential test passes for all static flag combinations listed in the PRD.
+
+out_of_scope:
+  - Follow mode (-f) is excluded per the PRD.
+
+test_suite: test-rel07.0

--- a/docs/specs/use-cases/rel07.1-uc001-cp.yaml
+++ b/docs/specs/use-cases/rel07.1-uc001-cp.yaml
@@ -1,0 +1,78 @@
+id: rel07.1-uc001-cp
+title: "Copy files and directories via cp"
+
+summary: |
+  The operator invokes the Go cp binary to duplicate files and directory trees. The
+  differential testing harness runs both the Go binary and the Homebrew reference
+  binary (gcp from coreutils) with the same arguments and environment, then compares
+  exit codes and the resulting file system state.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd056-cp.yaml) and invokes do-work to
+  produce a passing differential test for cmd/cp.
+
+flow:
+  - id: F1
+    step: |
+      The operator runs "./bin/cp file1.txt file2.txt" to copy a single file.
+      The destination file is created with the same content as the source.
+  - id: F2
+    step: |
+      The operator runs "./bin/cp -r dir1/ dir2/" to recursively copy a directory
+      tree, preserving the structure.
+  - id: F3
+    step: |
+      The operator runs "./bin/cp -p file1.txt file2.txt" to copy with attribute
+      preservation (mode, ownership, timestamps).
+  - id: F4
+    step: |
+      The operator runs "./bin/cp -n existing.txt target.txt" to verify no-clobber
+      mode does not overwrite the existing target.
+  - id: F5
+    step: |
+      The operator runs "./bin/cp -a dir1/ dir2/" to archive-copy a directory tree
+      with all attributes preserved.
+  - id: F6
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/cp and
+      gcp with the same arguments and environment.
+  - id: F7
+    step: |
+      The harness compares exit codes and verifies the resulting file system state
+      (file existence, content, permissions) matches between both binaries.
+
+touchpoints:
+  - T1: "cmd/cp — single copy, multi-file, recursive, preserve, archive, force, no-clobber, interactive, symlinks, verbose (prd056-cp R1, R2, R3, R4)"
+  - T2: "pkg/testutils — RunDiffTests, exit code and file system comparison"
+
+success_criteria:
+  - id: S1
+    criterion: cmd/cp compiles and ./bin/cp exists after mage build.
+  - id: S2
+    criterion: |
+      Single file copy creates an identical destination file, matching gcp.
+  - id: S3
+    criterion: |
+      Recursive copy (-r) duplicates the full directory tree.
+  - id: S4
+    criterion: |
+      Preserve mode (-p) retains file mode and timestamps on the copy.
+  - id: S5
+    criterion: |
+      No-clobber (-n) does not overwrite existing files.
+  - id: S6
+    criterion: |
+      Archive mode (-a) preserves all attributes and copies recursively.
+  - id: S7
+    criterion: |
+      Error cases (missing source, directory without -r) produce correct exit codes.
+  - id: S8
+    criterion: |
+      The differential test passes for all flag combinations listed in the PRD.
+
+out_of_scope:
+  - Reflink and sparse file support are excluded per the PRD.
+
+test_suite: test-rel07.1

--- a/docs/specs/use-cases/rel07.1-uc002-mv.yaml
+++ b/docs/specs/use-cases/rel07.1-uc002-mv.yaml
@@ -1,0 +1,76 @@
+id: rel07.1-uc002-mv
+title: "Move or rename files via mv"
+
+summary: |
+  The operator invokes the Go mv binary to move or rename files and directories. The
+  differential testing harness runs both the Go binary and the Homebrew reference
+  binary (gmv from coreutils) with the same arguments and environment, then compares
+  exit codes and the resulting file system state.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd057-mv.yaml) and invokes do-work to
+  produce a passing differential test for cmd/mv.
+
+flow:
+  - id: F1
+    step: |
+      The operator runs "./bin/mv file1.txt file2.txt" to rename a file. The source
+      no longer exists and the destination contains its content.
+  - id: F2
+    step: |
+      The operator runs "./bin/mv file1.txt dir/" to move a file into a directory.
+  - id: F3
+    step: |
+      The operator runs "./bin/mv -n existing.txt target.txt" to verify no-clobber
+      mode does not overwrite the existing target.
+  - id: F4
+    step: |
+      The operator runs "./bin/mv -v file1.txt file2.txt" to see verbose output
+      showing the move operation.
+  - id: F5
+    step: |
+      The operator runs "./bin/mv dir1/ dir2/" to move an entire directory.
+  - id: F6
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/mv and
+      gmv with the same arguments and environment.
+  - id: F7
+    step: |
+      The harness compares exit codes and verifies the resulting file system state
+      (file existence, content, location) matches between both binaries.
+
+touchpoints:
+  - T1: "cmd/mv — rename, move into directory, multi-file, interactive, force, no-clobber, verbose, target directory (prd057-mv R1, R2, R3, R4)"
+  - T2: "pkg/testutils — RunDiffTests, exit code and file system comparison"
+
+success_criteria:
+  - id: S1
+    criterion: cmd/mv compiles and ./bin/mv exists after mage build.
+  - id: S2
+    criterion: |
+      Single file rename removes source and creates destination, matching gmv.
+  - id: S3
+    criterion: |
+      Move into directory places the file inside the target directory.
+  - id: S4
+    criterion: |
+      No-clobber (-n) does not overwrite existing files.
+  - id: S5
+    criterion: |
+      Verbose mode (-v) prints the move operation.
+  - id: S6
+    criterion: |
+      Directory move works without requiring -r.
+  - id: S7
+    criterion: |
+      Error cases (missing source, permission denied) produce correct exit codes.
+  - id: S8
+    criterion: |
+      The differential test passes for all flag combinations listed in the PRD.
+
+out_of_scope:
+  - Backup mode (--backup) is excluded per the PRD.
+
+test_suite: test-rel07.1

--- a/docs/specs/use-cases/rel07.1-uc003-rm.yaml
+++ b/docs/specs/use-cases/rel07.1-uc003-rm.yaml
@@ -1,0 +1,78 @@
+id: rel07.1-uc003-rm
+title: "Remove files or directories via rm"
+
+summary: |
+  The operator invokes the Go rm binary to delete files and directory trees. The
+  differential testing harness runs both the Go binary and the Homebrew reference
+  binary (grm from coreutils) with the same arguments and environment, then compares
+  exit codes and the resulting file system state.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd058-rm.yaml) and invokes do-work to
+  produce a passing differential test for cmd/rm.
+
+flow:
+  - id: F1
+    step: |
+      The operator creates a test file and runs "./bin/rm testfile". The file is
+      removed from the filesystem.
+  - id: F2
+    step: |
+      The operator creates a directory tree and runs "./bin/rm -r dir/" to
+      recursively remove it.
+  - id: F3
+    step: |
+      The operator runs "./bin/rm -f nonexistent" to verify force mode exits 0
+      silently when the file does not exist.
+  - id: F4
+    step: |
+      The operator runs "./bin/rm -v testfile" to see verbose output showing
+      the removal.
+  - id: F5
+    step: |
+      The operator runs "./bin/rm dir/" without -r to verify it fails with an
+      error on stderr.
+  - id: F6
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/rm and
+      grm with the same arguments and environment.
+  - id: F7
+    step: |
+      The harness compares exit codes and verifies the resulting file system state
+      (file existence) matches between both binaries.
+
+touchpoints:
+  - T1: "cmd/rm — single removal, multi-file, recursive, force, interactive, verbose, empty directory (prd058-rm R1, R2, R3, R4)"
+  - T2: "pkg/testutils — RunDiffTests, exit code and file system comparison"
+
+success_criteria:
+  - id: S1
+    criterion: cmd/rm compiles and ./bin/rm exists after mage build.
+  - id: S2
+    criterion: |
+      Single file removal deletes the file from the filesystem, matching grm.
+  - id: S3
+    criterion: |
+      Recursive removal (-r) deletes the entire directory tree.
+  - id: S4
+    criterion: |
+      Force mode (-f) exits 0 silently for non-existent files.
+  - id: S5
+    criterion: |
+      Verbose mode (-v) prints each file as it is removed.
+  - id: S6
+    criterion: |
+      Attempting to remove a directory without -r fails with exit 1.
+  - id: S7
+    criterion: |
+      Refusing to remove '.' or '..' prints an error.
+  - id: S8
+    criterion: |
+      The differential test passes for all flag combinations listed in the PRD.
+
+out_of_scope:
+  - One-file-system mode is excluded per the PRD.
+
+test_suite: test-rel07.1


### PR DESCRIPTION
## Summary

Specified 6 new utilities across 2 releases. rel07.0 adds sort, tr, and tail (text processing pipeline). rel07.1 adds cp, mv, and rm (file operations). All specs pass mage analyze.

## Changes

- 6 PRDs: prd053-sort, prd054-tr, prd055-tail, prd056-cp, prd057-mv, prd058-rm
- 6 use cases: rel07.0-uc001 through uc003, rel07.1-uc001 through uc003
- 2 test suites: test-rel-07.0, test-rel-07.1
- Road-map updated with rel07.0 and rel07.1 (spec_complete)
- Recurring issue re-created as #554

## Stats

- spec_words: prd 40,097 (+3,733) / use_case 24,075 (+2,371) / test_suite 18,203 (+1,619)
- go_loc: 0 (specs only)

## Test plan

- [x] `mage analyze` passes (58 PRDs, 59 use cases, 22 test suites, 0 errors)
- [x] No implementation code modified

Closes #528