### PR TITLE
Fix rel00.0 release status after specs-only reset

### DIFF
--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -3,7 +3,7 @@ title: "go-unix-utils Release Road Map"
 releases:
     - version: "00.0"
       name: "Batch 0 — foundational infrastructure"
-      status: implemented
+      status: spec_complete
       description: |
         Specify and verify the build lifecycle and shared library infrastructure that all
         subsequent releases depend on. This release covers magefiles/ (build, lint, clean,


### PR DESCRIPTION
## Summary

Fixes rel00.0 showing `implemented` when no code exists on main. Root cause: `generator:stop`'s `resetImplementedReleases` only resets UC statuses, not the parent release status.

## Changes

- Set rel00.0 release status from `implemented` to `spec_complete`
- Filed cobbler-scaffold#1189 for the underlying bug

## Test plan

- [x] All 21 releases now show `spec_complete`