### PR TITLE
GH-559: Upgrade cobbler-scaffold v0.20260308.2 → v0.20260308.4

### DIFF
--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260308.2
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260308.4
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260308.2 h1:tl6q5Uww1wUkH5t/CaUcmrFSgC6DcWKpnOU+xEkQW9E=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260308.2/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260308.4 h1:wov7r8qqD9P82ehLBsMJY26P6HvhOPB5En7J3KJ7M5A=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260308.4/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Summary

Upgrades cobbler-scaffold from v0.20260308.2 to v0.20260308.4. Internal test:usecase fix (GH-1316) only — no scaffolded file changes in this release.

## Changes

- Bumped `github.com/mesh-intelligence/cobbler-scaffold` in magefiles/go.mod
- Updated magefiles/go.sum

## Stats

- Lines of code (Go, production): 0 (+0)
- Lines of code (Go, tests): 0 (+0)
- Words (documentation): 17,826 (+0)

## Test plan

- [x] `mage analyze` passes
- [x] No scaffolded file changes to review

Closes #559