### PR TITLE
GH-566: Upgrade cobbler-scaffold v0.20260308.4 → v0.20260308.5

### DIFF
--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -22,6 +22,7 @@ releases:
     - version: "01.1"
       name: "Batch 1.1 — cat specification and differential test"
       status: spec_complete
+      depends_on: ["00.0"]
       description: |
         Implement cat for file concatenation and display. cat depends on pkg/testutils from
         rel00.0 for differential testing and does not require pkg/sys or pkg/format.
@@ -31,6 +32,7 @@ releases:
     - version: "01.2"
       name: "Batch 1.2 — sponge specification and differential test"
       status: spec_complete
+      depends_on: ["00.0"]
       description: |
         Implement sponge for soak-before-write stdin buffering. sponge depends on
         pkg/testutils from rel00.0 for differential testing and does not require pkg/sys
@@ -41,6 +43,7 @@ releases:
     - version: "01.3"
       name: "Batch 1.3 — du specification and differential test"
       status: spec_complete
+      depends_on: ["00.0"]
       description: |
         Implement du for recursive directory disk usage reporting. du depends on
         pkg/testutils from rel00.0 for differential testing and requires pkg/sys and
@@ -51,6 +54,7 @@ releases:
     - version: "02.0"
       name: "Batch 2 — trivial utilities (true, false, yes, basename, dirname)"
       status: spec_complete
+      depends_on: ["00.0"]
       description: |
         Implement five trivial utilities that require minimal logic and no shared library
         dependencies beyond pkg/testutils. true and false are exit-code-only programs. yes
@@ -70,6 +74,7 @@ releases:
     - version: "02.1"
       name: "Batch 2.1 — tee specification and differential test"
       status: spec_complete
+      depends_on: ["00.0"]
       description: |
         Implement tee for copying stdin to stdout and one or more output files simultaneously.
         tee depends on pkg/testutils from rel00.0 for differential testing. Supports append
@@ -80,6 +85,7 @@ releases:
     - version: "02.2"
       name: "Batch 2.2 — head and seq specification and differential test"
       status: spec_complete
+      depends_on: ["00.0"]
       description: |
         Implement head for printing the first N lines or bytes of files, and seq for
         generating number sequences. Both depend on pkg/testutils from rel00.0 for
@@ -94,6 +100,7 @@ releases:
     - version: "03.0"
       name: "Batch 3 — wc specification and differential test"
       status: spec_complete
+      depends_on: ["00.0"]
       description: |
         Implement the wc word, line, and byte counter. wc depends on pkg/testutils from
         rel00.0 for differential testing and does not require pkg/sys or pkg/format.
@@ -105,6 +112,7 @@ releases:
     - version: "03.1"
       name: "Batch 3.1 — system information (uname, arch, nproc, hostname, hostid)"
       status: spec_complete
+      depends_on: ["00.0"]
       description: |
         Implement five trivial system information utilities that wrap OS queries and print
         results. uname prints kernel name, version, machine architecture, and other system
@@ -127,6 +135,7 @@ releases:
     - version: "04.0"
       name: "Batch 4 — ls specification and differential test"
       status: spec_complete
+      depends_on: ["00.0"]
       description: |
         Full ls implementation covering all flags: default, -1, -l, -a, -A, -d, --color, -h
         (core), plus -C, -x, sort flags (-t, -S, -r, -U, -v), metadata display (-i, -s, -n),
@@ -140,6 +149,7 @@ releases:
     - version: "04.1"
       name: "Batch 4.1 — path and terminal utilities (realpath, readlink, pwd, tty, logname)"
       status: spec_complete
+      depends_on: ["00.0"]
       description: |
         Implement five path resolution and terminal utilities. realpath prints the resolved
         absolute path for each argument with existence modes (-e, -m), symlink control (-s),
@@ -163,6 +173,7 @@ releases:
     - version: "05.0"
       name: "Batch 5 — text stream transforms (echo, tac, nl, fold)"
       status: spec_complete
+      depends_on: ["00.0"]
       description: |
         Implement four easy stream-transform utilities that depend only on pkg/testutils and
         pkg/sys. echo outputs arguments with optional escape interpretation. tac reverses
@@ -181,6 +192,7 @@ releases:
     - version: "05.1"
       name: "Batch 5.1 — tab conversion pair (expand, unexpand)"
       status: spec_complete
+      depends_on: ["00.0"]
       description: |
         Implement expand (tabs to spaces) and unexpand (spaces to tabs). Both utilities share
         the same internal expand_common code in the C source and are natural inverses of each
@@ -196,6 +208,7 @@ releases:
     - version: "05.2"
       name: "Batch 5.2 — columnar operations pair (cut, paste)"
       status: spec_complete
+      depends_on: ["00.0"]
       description: |
         Implement cut (extract fields/bytes from lines) and paste (merge file lines side
         by side). cut and paste are complementary: cut removes columns and paste adds them.
@@ -211,6 +224,7 @@ releases:
     - version: "05.3"
       name: "Batch 5.3 — sorted-stream comparison pair (uniq, comm)"
       status: spec_complete
+      depends_on: ["00.0"]
       description: |
         Implement uniq (filter adjacent duplicate lines) and comm (compare two sorted files).
         Both utilities operate on sorted or adjacently-ordered input. uniq uses windowed
@@ -226,6 +240,7 @@ releases:
     - version: "05.4"
       name: "Batch 5.4 — checksum quartet (md5sum, sha1sum, sha256sum, sha512sum)"
       status: spec_complete
+      depends_on: ["00.0"]
       description: |
         Implement md5sum, sha1sum, sha256sum, and sha512sum. All four share the same
         protocol: GNU two-space format for text mode, asterisk format for binary mode,
@@ -245,6 +260,7 @@ releases:
     - version: "05.5"
       name: "Batch 5.5 — ts timestamp stdin lines"
       status: spec_complete
+      depends_on: ["00.0"]
       description: |
         Implement ts for prepending timestamps to stdin lines. ts reads from stdin and
         prepends a strftime-formatted timestamp to each line. Supports wall-clock (default),
@@ -257,6 +273,7 @@ releases:
     - version: "06.0"
       name: "Batch 6.0 — file/directory creation and removal (mkdir, rmdir, mktemp, ln, unlink)"
       status: spec_complete
+      depends_on: ["00.0"]
       description: |
         Implement five file and directory manipulation utilities. mkdir creates directories
         with optional parent creation (-p) and mode setting (-m). rmdir removes empty
@@ -278,6 +295,7 @@ releases:
     - version: "06.1"
       name: "Batch 6.1 — environment and identity (env, printenv, id, whoami, groups)"
       status: spec_complete
+      depends_on: ["00.0"]
       description: |
         Implement five environment and identity utilities. env runs a command in a modified
         environment with variable setting, unsetting, and clean-environment support. printenv
@@ -300,6 +318,7 @@ releases:
     - version: "07.0"
       name: "Batch 7.0 — text processing pipeline (sort, tr, tail)"
       status: spec_complete
+      depends_on: ["00.0"]
       description: |
         Implement three text processing utilities that complete the stream processing
         toolkit. sort orders lines with configurable keys, numeric modes, and field
@@ -318,6 +337,7 @@ releases:
     - version: "07.1"
       name: "Batch 7.1 — file operations (cp, mv, rm)"
       status: spec_complete
+      depends_on: ["00.0"]
       description: |
         Implement three fundamental file operation utilities. cp copies files and directories
         with attribute preservation, recursive mode, and symlink handling. mv moves or renames

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260308.4
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260308.5
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260308.4 h1:wov7r8qqD9P82ehLBsMJY26P6HvhOPB5En7J3KJ7M5A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260308.4/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260308.5 h1:BIF8emTDbuHurxHrKOx5lBwrcvtlfsg1DjD4yf5RqXk=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260308.5/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Summary

Upgrades cobbler-scaffold to v0.20260308.5 which adds the DependsOn field to RoadmapRelease. Adds `depends_on: ["00.0"]` to all 20 non-foundational releases in road-map.yaml for machine-readable dependency graphs.

## Changes

- Bumped cobbler-scaffold v0.20260308.4 → v0.20260308.5 in magefiles/go.mod
- Added `depends_on: ["00.0"]` to 20 releases in docs/road-map.yaml

## Stats

- Lines of code (Go, production): 0 (+0)
- Lines of code (Go, tests): 0 (+0)
- Words (documentation): 17,826 (+0)

## Test plan

- [x] `mage analyze` passes (0 errors, 0 depends_on violations)
- [x] Schema validation passes

Closes #566