### PR TITLE
GH-595: Upgrade cobbler-scaffold v0.20260308.8 → v0.20260309.0

### DIFF
--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260308.8
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260309.0
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260308.8 h1:7P+Efj10haqB2oUrLm1550RrJFo5CSaliywCXGV3yRo=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260308.8/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260309.0 h1:bvDCaB38k/pS/CrvW5bCAKSvTY6TZCQGnmm/uPv00Rg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260309.0/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Summary

Upgrade cobbler-scaffold to v0.20260309.0 with four fixes that unblock generation runs: roadmap reset at generator:start, separate measure/stitch issues, unified history data sources, and in-progress measure visibility.

## Changes

- Updated magefiles/go.mod and magefiles/go.sum to v0.20260309.0

## Stats

- Lines of code (Go, production): 795 (+0)
- Lines of code (Go, tests): 81 (+0)
- Words (documentation): 81640 (+0)

## Test plan

- [x] `mage analyze` passes
- [x] No scaffolded file changes beyond go.mod/go.sum

Closes #595