### PR TITLE
GH-599: Upgrade cobbler-scaffold v0.20260309.0 → v0.20260309.3

### DIFF
--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260309.0
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260309.3
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260309.0 h1:bvDCaB38k/pS/CrvW5bCAKSvTY6TZCQGnmm/uPv00Rg=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260309.0/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260309.3 h1:i7P5rFr8FYaO2wiFi0G7RicB1IUI5frxB6Dxqy0TatI=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260309.3/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Summary

Upgrade cobbler-scaffold from v0.20260309.0 to v0.20260309.3. Includes all 5 audit
fixes from the #1378 review plus E2E tests for requirement tracking.

## Changes

- magefiles/go.mod: cobbler-scaffold v0.20260309.0 → v0.20260309.3
- magefiles/go.sum: updated checksums

## Included upstream fixes

- #1373: File-based dedup in measure
- #1375: Consistent issue number formatting in stats
- #1378: End-to-end requirement tracking (5 sub-issues)
- #1385: Commit requirements.yaml after stitch updates
- #1386: Programmatic validation of completed R-items in measure
- #1387: Fix greedy prefix matching in findPRDRequirements
- #1388: Gate R-item completion on test results
- #1389: Preserve requirement states across runs
- #1394: E2E tests for requirement tracking

## Test plan

- [x] `mage analyze` passes
- [x] No Go source present to test

Closes #599