### PR TITLE
GH-545: Remove cmd from go_source_dirs to prevent stitch prompt growth

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -4,7 +4,6 @@ project:
     module_path: github.com/petar-djukic/go-unix-utils
     go_source_dirs:
         - pkg
-        - cmd
     magefiles_dir: magefiles
     context_include: |
         docs/VISION.yaml


### PR DESCRIPTION
## Summary

Removes \`cmd\` from \`go_source_dirs\` in \`configuration.yaml\`. Each \`cmd/<name>/\` package is independent — the stitch agent reads command files on demand in CLI mode. Including \`cmd\` causes stitch prompt size to grow by ~8KB per source file with every new command generated, compounding across all tasks in a run.

## Changes

- \`configuration.yaml\`: remove \`cmd\` from \`go_source_dirs\`

## Stats

Observed in generation run 28 (2026-03-10):

| | Tokens in per stitch task |
|--|--|
| Before (cmd + pkg + tests) | 600K–2.4M |
| After (pkg only, no tests) | 125K–135K |

~12x reduction at ~4K LOC. Savings compound as more code is generated.

## Test plan

- [ ] `mage analyze` passes
- [ ] Next generation run: verify stitch token counts stay flat as codebase grows

Closes #545