### PR TITLE
GH-681: Upgrade cobbler-scaffold v0.20260309.4 → v0.20260310.0

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -53,6 +53,7 @@ cobbler:
     idle_timeout_seconds: 900
     measure_source_mode: headers
     measure_roadmap_source: true
+    stitch_exclude_tests: true
     mode: cli
 claude:
     silence_agent: true

--- a/docs/constitutions/design.yaml
+++ b/docs/constitutions/design.yaml
@@ -128,12 +128,28 @@ document_types:
       - goals (G1, G2, ...)
       - requirements (R1.1, R1.2, ..., grouped by R1, R2, ...)
       - non_goals
-      - acceptance_criteria
+      - acceptance_criteria (list of objects with id, criterion, traces)
     numbering:
       goals: "G1, G2, G3, ..."
       requirement_groups: "R1, R2, R3, ..."
       requirement_items: "R1.1, R1.2, R2.1, ..."
       requirement_id_format: "R{group}.{item} — numeric dotted only (e.g., R1.1, R2.3). Letter suffixes (R2a) are not valid and are flagged by mage analyze."
+      acceptance_criteria_ids: "AC1, AC2, AC3, ... (sequential within each PRD)"
+    acceptance_criteria_schema:
+      description: |
+        Each acceptance criterion is a structured object linking a checkable
+        statement to the requirement items it validates. Every R-item in the
+        PRD must appear in at least one AC's traces list.
+      fields:
+        - id: "AC1, AC2, ... (sequential)"
+        - criterion: "Checkable statement (the prose text)"
+        - traces: "List of R-item IDs this AC validates (e.g., [R1.1, R1.2])"
+      example: |
+        acceptance_criteria:
+          - id: AC1
+            criterion: Config struct includes all fields listed in R1 with YAML struct tags
+            traces: [R1.1, R1.2, R1.3]
+      completeness_rule: "Every R-item must appear in at least one AC's traces list"
     purpose: |
       Defines product requirements with numbered goals and requirements. Each
       requirement starts with "must" or "must not" or a concrete verb. No scope
@@ -150,12 +166,27 @@ document_types:
       - trigger
       - flow (F1, F2, ..., end-to-end steps)
       - touchpoints (T1, T2, ..., architecture elements exercised)
-      - success_criteria (S1, S2, ..., checkable outcomes)
+      - success_criteria (list of objects with id, criterion, traces)
       - out_of_scope
     numbering:
       flow_steps: "F1, F2, F3, ..."
       touchpoints: "T1, T2, T3, ..."
       success_criteria: "S1, S2, S3, ..."
+    success_criteria_schema:
+      description: |
+        Each success criterion is a structured object linking a checkable
+        outcome to the PRD acceptance criteria it exercises. The traces field
+        references PRD AC IDs using the format prdNNN-name ACN.
+      fields:
+        - id: "S1, S2, ... (sequential)"
+        - criterion: "Checkable outcome statement"
+        - traces: "List of PRD AC IDs (e.g., [prd001-orchestrator-core AC1])"
+      example: |
+        success_criteria:
+          - id: S1
+            criterion: New(config) returns a non-nil *Orchestrator
+            traces:
+              - prd001-orchestrator-core AC2
     purpose: |
       Describes a concrete usage of the architecture. One end-to-end path
       (tracer bullet) through the system. Leads to a proof-of-concept or demo.
@@ -170,6 +201,11 @@ document_types:
       - release (release ID this suite covers)
       - traces (list of use case IDs covered by this suite)
       - test_cases (list organized by use case sub-sections, each with name, inputs, expected outputs)
+    traces_format: |
+      The traces field in test_cases can reference three kinds of IDs:
+        - PRD R-item IDs: prdNNN-name RN.N (e.g., prd001-orchestrator-core R1.1)
+        - PRD AC IDs: prdNNN-name ACN (e.g., prd001-orchestrator-core AC1)
+        - UC S-item IDs: relNN.N-ucNNN-name SN (e.g., rel01.0-uc001-orchestrator-initialization S1)
     purpose: |
       Groups test cases for a full release. Each use case in the release appears
       as a sub-section within the suite. The YAML provides quick human/Claude
@@ -301,14 +337,15 @@ completeness_checklists:
     - requirements are grouped (R1, R2, ...) with numbered items (R1.1, R1.2, ...)
     - Each requirement is specific and actionable
     - non_goals define what is out of scope
-    - acceptance_criteria are checkable without ambiguity
+    - acceptance_criteria are structured objects with id, criterion, and traces
+    - Every R-item appears in at least one AC's traces list
     - File saved as prd[NNN]-[feature-name].yaml
 
   use_case:
     - id matches filename without extension
     - flow steps are numbered (F1, F2, ...), end-to-end, map to real components
     - touchpoints are numbered (T1, T2, ...) and list interfaces, components, protocols
-    - success_criteria are numbered (S1, S2, ...) and checkable without ambiguity
+    - success_criteria are structured objects with id, criterion, and traces to PRD AC IDs
     - test_suite references a corresponding test suite ID
     - Test suite YAML exists and traces back to this use case
     - Use case added to appropriate release in road-map.yaml

--- a/docs/constitutions/go-style.yaml
+++ b/docs/constitutions/go-style.yaml
@@ -92,12 +92,15 @@ design_patterns:
       callback registration when the producer should not know about its consumers.
 
 interfaces: |
-  Introduce an interface when you have two concrete implementations or when you
-  need to mock a dependency in tests. Do not create an interface for a single
-  implementation "just in case." Accept interfaces as parameters; return concrete
-  structs. Keep interfaces small: one to three methods. A large interface is a
-  sign that the abstraction is wrong. Split it into focused interfaces and compose
-  them.
+  Every boundary between a parent package and its internal sub-packages must be
+  defined by an interface. The parent package declares the interface; the internal
+  sub-package provides a concrete type that satisfies it. This applies even when
+  only one implementation exists today. The purpose is testability and explicit
+  contracts at every package boundary, not speculative abstraction.
+
+  Accept interfaces as parameters; return concrete structs. Keep interfaces small:
+  one to three methods. A large interface is a sign that the abstraction is wrong.
+  Split it into focused interfaces and compose them.
 
   Do not use interface{} or any as function parameters, return types, or struct
   fields. Every value must have a concrete type or a named interface. If a
@@ -193,19 +196,21 @@ project_structure: |
   cmd/: Entry points. Minimal: parse flags, wire dependencies, start.
   internal/: Private implementation. Not importable outside this module. One
   package per component.
-  pkg/: Shared public types and interfaces. No implementation. The contract layer
-  between libraries.
+  pkg/: Public API surface. Exports types and delegates to internal sub-packages.
   tests/: Integration tests.
   magefiles/: Build tooling. Flat directory (mage constraint). One file per
   concern.
 
+  Every package organizes its implementation into internal/ sub-packages grouped
+  by domain concept. The parent package is the public API surface: it exports
+  types, defines interfaces, and delegates to internal sub-packages that provide
+  the implementation. Internal sub-packages are not importable outside the parent,
+  enforced by Go's internal/ directory convention. This rule applies uniformly to
+  packages under pkg/ and to top-level internal/ packages alike.
+
   Align package structure to PRD component structure. Each major component maps
   to one package. Avoid package names like util, common, helpers. Name packages
   by domain: storage, auth, config.
-
-  Define interfaces between major components. The pkg/ directory holds shared
-  types and interface contracts. The internal/ directory holds implementations
-  that satisfy those contracts.
 
 file_organization: |
   Name files by the concern or feature they implement: scaffold.go, stitch.go,
@@ -342,7 +347,7 @@ code_review_checklist:
   - "Every error is handled or explicitly discarded with a comment."
   - "Every struct has a single, nameable responsibility."
   - "No function exceeds 200 lines without a strong reason."
-  - "Interfaces are small (one to three methods) and have at least two implementations or a testing need."
+  - "Every sub-package boundary has an interface. Interfaces are small (one to three methods)."
   - "No boolean parameters toggle behavior that should be a Strategy or Decorator."
   - "Config structs embed shared fields rather than duplicating them."
   - "context.Context is threaded through I/O paths."
@@ -378,9 +383,10 @@ sections:
   - tag: interfaces
     title: Interfaces
     content: |
-      Introduce an interface only when two concrete implementations exist or a
-      dependency must be mocked in tests. Accept interfaces as parameters;
-      return concrete structs. Keep interfaces small: one to three methods.
+      Every boundary between a parent package and its internal sub-packages
+      must be defined by an interface, even when only one implementation exists.
+      Accept interfaces as parameters; return concrete structs. Keep interfaces
+      small: one to three methods.
   - tag: struct_and_function_design
     title: Struct and Function Design
     content: |
@@ -435,8 +441,10 @@ sections:
     title: Project Structure
     content: |
       cmd/ for entry points, internal/ for private implementation, pkg/ for
-      public shared types, tests/ for integration tests, magefiles/ for build
-      tooling. Align package structure to PRD component structure.
+      public API surface, tests/ for integration tests, magefiles/ for build
+      tooling. Every package organizes implementation into internal/
+      sub-packages by domain concept. The parent package exports types and
+      delegates; internal sub-packages provide the implementation.
   - tag: file_organization
     title: File Organization
     content: |

--- a/docs/prompts/measure.yaml
+++ b/docs/prompts/measure.yaml
@@ -37,6 +37,7 @@ constraints: |
   - Do NOT assume the stitch agent has access to your analysis, the existing issues list, or any context from this conversation.
   - Do NOT propose tasks that require human judgment or manual testing. Each task must have checkable acceptance criteria.
   - Anchor every task to specific PRD requirement IDs (e.g., prd001 R1.1). Include the requirement ID in the task title. Given the same PRD and release, the same tasks should be proposed regardless of how many times this prompt is run.
+  - When requirement_states is present in project_context, only propose tasks for R-items with status "ready". R-items with status "complete" have already been implemented and must not be re-proposed. If all R-items for the current release are complete, return an empty list.
   - Order tasks canonically: documentation before code, types before implementations, libraries before consumers, implementation before tests. Break ties by primary file path alphabetically.
   - Derive file names from PRD/architecture names, not invented names. If the architecture calls a component "crumb", the file is crumb.go.
   - Do NOT invent design decisions not derived from the PRD or architecture. Derive struct shapes, timeout strategies, file names, and naming conventions from the PRD rather than making arbitrary choices. If the PRD does not specify a detail, omit it from design decisions rather than inventing one.

--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/petar-djukic/go-unix-utils
 go 1.26.1
 
 replace github.com/petar-djukic/go-unix-utils => ./
+
+require github.com/mesh-intelligence/cobbler-scaffold v0.20260310.0 // indirect

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260309.4
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260310.0
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260309.4 h1:3KLWj/cSjAno/d7W59SyxAERCNtH8XiUk+JIYrdVkgs=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260309.4/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260310.0 h1:AsYcuVZpVUCI9ODtXr5CxheQjbRgGsDgp2Y1C3xwsDU=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260310.0/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Summary

Upgrades cobbler-scaffold to v0.20260310.0, which includes three fixes filed during generation run 28. Also adds `stitch_exclude_tests: true` to `configuration.yaml`, making the run 28 prompt-reduction workaround permanent.

## Changes

- `magefiles/go.mod` / `magefiles/go.sum`: bump to v0.20260310.0
- `docs/constitutions/design.yaml`, `go-style.yaml`: upstream updates
- `docs/prompts/measure.yaml`: upstream update
- `magefiles/orchestrator.go`: upstream update
- `configuration.yaml`: add `stitch_exclude_tests: true`

## Fixes included in v0.20260310.0

- **cobbler-scaffold#1437**: `stats:generator` requirements count was inflated (counted all R-items in any touched PRD instead of per-R-item completion)
- **cobbler-scaffold#1438**: placeholder failure wrote `task_id: "0"` to stats; stderr now captured
- **cobbler-scaffold#1440**: `stitch_exclude_tests` config option added — mirrors `measure_exclude_tests`

## Stats

No Go source on main (specs-only). `mage analyze` passes: 59 PRDs, 59 use cases, 22 test suites, 0 errors.

## Test plan

- [x] `mage analyze` passes
- [x] `mage -l` shows all expected targets

Closes #681