### PR TITLE
GH-792: Fix releases order and add context_exclude entries

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -11,7 +11,12 @@ project:
     context_exclude: |
         docs/SPECIFICATIONS.yaml
         docs/road-map.yaml
+        docs/reports/
+        docs/engineering/
+        docs/prompts/
+        cmd/
     releases:
+        - "00.0"
         - "01.1"
         - "01.2"
         - "01.3"
@@ -30,7 +35,6 @@ project:
         - "05.5"
         - "06.0"
         - "06.1"
-        - "00.0"
 generation:
     prefix: generation-
     cycles: 6


### PR DESCRIPTION
## Summary

Fixes two issues in \`configuration.yaml\` that affected generation run 29.

## Changes

- Move \`00.0\` to first in \`releases\` list — it is the foundational release that all others depend on
- Add \`docs/reports/\`, \`docs/engineering/\`, \`docs/prompts/\`, \`cmd/\` to \`context_exclude\` — removes ~370KB of irrelevant content from stitch prompts, reducing input tokens from ~428K to ~105K per task at 0 LOC

## Test Plan

- [ ] \`mage analyze\` passes
- [ ] First measure cycle proposes a \`00.0\` task
- [ ] Stitch prompt bytes in \`.cobbler/history/\` under 150KB at 0 LOC

Closes #792