### PR TITLE
GH-1401: Specify rel08.0 — date, sleep, touch, timeout, shuf, factor, expr

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -37,6 +37,7 @@ project:
         - "06.1"
         - "07.0"
         - "07.1"
+        - "08.0"
 generation:
     prefix: generation-
     cycles: 6

--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -349,3 +349,30 @@ releases:
           status: spec_complete
         - id: rel07.1-uc003-rm
           status: spec_complete
+    - version: "08.0"
+      name: "Batch 8.0 — time, randomness, and expression utilities (date, sleep, touch, timeout, shuf, factor, expr)"
+      status: spec_complete
+      depends_on: ["00.0"]
+      description: |
+        Implement seven utilities spanning time operations, randomness, and expression
+        evaluation. date formats and displays date/time with configurable output. sleep pauses
+        for a specified duration with suffix support. touch creates files and updates timestamps.
+        timeout runs a command with a time limit and signal escalation. shuf randomly permutes
+        input lines or generates random samples. factor prints prime factorizations. expr
+        evaluates arithmetic, comparison, and string expressions. All are verified by
+        differential testing against GNU coreutils reference binaries.
+      use_cases:
+        - id: rel08.0-uc001-date
+          status: spec_complete
+        - id: rel08.0-uc002-sleep
+          status: spec_complete
+        - id: rel08.0-uc003-touch
+          status: spec_complete
+        - id: rel08.0-uc004-timeout
+          status: spec_complete
+        - id: rel08.0-uc005-shuf
+          status: spec_complete
+        - id: rel08.0-uc006-factor
+          status: spec_complete
+        - id: rel08.0-uc007-expr
+          status: spec_complete

--- a/docs/specs/product-requirements/prd060-date.yaml
+++ b/docs/specs/product-requirements/prd060-date.yaml
@@ -1,0 +1,109 @@
+id: prd060-date
+title: "cmd/date: Display and Format Date and Time"
+
+problem: |
+  Shell scripts and log pipelines use date to print the current date and time in configurable
+  formats. The macOS BSD date differs from GNU date in format string syntax, the -d flag
+  (BSD uses -d for DST adjustment, GNU uses -d for parsing arbitrary date strings), and
+  timezone handling. The Go implementation must match the Homebrew GNU reference binary
+  (gdate, installed by coreutils) in output and exit codes for all supported flag
+  combinations, verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Print the current date and time to stdout in a configurable format.
+  - G2: Support custom output format strings via the +FORMAT argument.
+  - G3: Support displaying a specific date via -d/--date instead of the current time.
+  - G4: Verify functional parity against gdate via differential testing.
+
+requirements:
+  R1:
+    title: Default behavior and format strings
+    items:
+      - R1.1: When invoked with no arguments, must print the current date and time in the default format and exit 0.
+      - R1.2: When a +FORMAT argument is given, must format the date according to the strftime-style format string and print the result followed by a newline.
+      - R1.3: Must support all standard strftime conversion specifications including %Y (year), %m (month), %d (day), %H (hour), %M (minute), %S (second), %Z (timezone name), %s (seconds since epoch), %N (nanoseconds), %A (weekday name), %B (month name), %j (day of year), %u (day of week 1-7), and %w (day of week 0-6).
+      - R1.4: Must support GNU extensions including %P (lowercase am/pm) and padding modifiers (%-d for no padding, %_d for space padding, %0d for zero padding).
+
+  R2:
+    title: Date string parsing (-d/--date)
+    items:
+      - R2.1: "-d STRING or --date=STRING must display the date described by STRING instead of the current time."
+      - R2.2: "Must parse epoch timestamps prefixed with @ (e.g., -d @1234567890)."
+      - R2.3: "Must parse ISO 8601 date strings (e.g., -d '2024-01-15 10:30:00')."
+      - R2.4: "When the date string cannot be parsed, must print an error to stderr and exit 1."
+
+  R3:
+    title: UTC mode and reference time
+    items:
+      - R3.1: "-u or --utc or --universal must display the date in UTC instead of the local timezone."
+      - R3.2: "-r FILE or --reference=FILE must display the last modification time of FILE instead of the current time."
+      - R3.3: "When the referenced file does not exist, must print an error to stderr and exit 1."
+      - R3.4: Must not read from stdin. Must write formatted output to stdout only.
+
+  R4:
+    title: Exit codes and differential testing
+    items:
+      - R4.1: Must exit 0 when the date is displayed successfully.
+      - R4.2: Must exit 1 when an invalid date string is given or a referenced file does not exist.
+      - R4.3: "Differential tests must compare stdout and exit codes between the Go binary and the reference binary via pkg/testutils. Tests must use fixed dates via -d @EPOCH to ensure deterministic output."
+      - R4.4: "Tests must cover: default output with fixed epoch, +FORMAT with various conversion specs, -d with epoch and ISO strings, -u UTC mode, -r reference file, padding modifiers, and error cases (invalid date, missing file)."
+
+non_goals:
+  - cmd/date does not implement -s/--set to set the system clock.
+  - cmd/date does not implement --rfc-3339 or --rfc-email output modes beyond what +FORMAT can express.
+  - cmd/date does not parse relative date strings (e.g., "yesterday", "2 days ago") which require GNU date's complex natural language parser.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "go run ./cmd/date -d @0 '+%Y-%m-%d %H:%M:%S' produces '1970-01-01 00:00:00' under TZ=UTC, matching gdate."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R2.1
+      - R2.2
+  - id: AC2
+    criterion: "go run ./cmd/date -u -d @1700000000 '+%s' produces '1700000000', matching gdate."
+    traces:
+      - R1.2
+      - R1.3
+      - R2.1
+      - R2.2
+      - R3.1
+  - id: AC3
+    criterion: "go run ./cmd/date -d 'invalid' exits 1 with error on stderr, matching gdate."
+    traces:
+      - R2.4
+      - R4.1
+      - R4.2
+  - id: AC4
+    criterion: "go run ./cmd/date -r /tmp/testfile '+%Y' prints the file modification year, matching gdate."
+    traces:
+      - R1.2
+      - R3.2
+      - R3.3
+      - R3.4
+  - id: AC5
+    criterion: "Differential test against gdate passes for all flag combinations listed in R4.4."
+    traces:
+      - R4.3
+      - R4.4
+  - id: AC6
+    criterion: "cmd/date compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+      - R3.1
+      - R3.2
+      - R3.3
+      - R3.4
+      - R4.1
+      - R4.2
+      - R4.3
+      - R4.4

--- a/docs/specs/product-requirements/prd061-sleep.yaml
+++ b/docs/specs/product-requirements/prd061-sleep.yaml
@@ -1,0 +1,99 @@
+id: prd061-sleep
+title: "cmd/sleep: Pause for a Specified Duration"
+
+problem: |
+  Shell scripts use sleep to introduce delays between commands, in retry loops, and in
+  polling intervals. The macOS BSD sleep accepts only integer seconds, while GNU sleep
+  supports fractional seconds and multiple arguments (summed). The Go implementation must
+  match the Homebrew GNU reference binary (gsleep, installed by coreutils) in argument
+  parsing and exit code behavior, verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Pause execution for the specified duration.
+  - G2: Support fractional seconds and duration suffixes (s, m, h, d).
+  - G3: Support multiple arguments whose durations are summed.
+
+requirements:
+  R1:
+    title: Core sleep behavior
+    items:
+      - R1.1: Must pause for NUMBER seconds when given a single numeric argument, then exit 0.
+      - R1.2: Must support fractional seconds (e.g., sleep 0.5 pauses for 500 milliseconds).
+      - R1.3: Must support suffix multipliers s (seconds, default), m (minutes, x60), h (hours, x3600), d (days, x86400). The suffix is case-sensitive and lowercase only.
+      - R1.4: When multiple arguments are given, must sum all durations and sleep for the total.
+
+  R2:
+    title: Input validation and error handling
+    items:
+      - R2.1: Must accept zero as a valid duration and return immediately with exit 0.
+      - R2.2: When no arguments are given, must print a usage error to stderr and exit 1.
+      - R2.3: When a non-numeric or negative argument is given, must print an error to stderr and exit 1.
+      - R2.4: "Must support infinity (or inf) as a duration, sleeping indefinitely until interrupted."
+
+  R3:
+    title: Signal handling and output
+    items:
+      - R3.1: Must not produce any output to stdout or stderr under normal operation.
+      - R3.2: Must not read from stdin.
+      - R3.3: When --help is the first argument, must print a usage message to stdout and exit 0.
+      - R3.4: When --version is the first argument, must print version information to stdout and exit 0.
+
+  R4:
+    title: Exit codes and differential testing
+    items:
+      - R4.1: Must exit 0 after sleeping for the requested duration.
+      - R4.2: Must exit 1 when given invalid arguments (no args, non-numeric, negative).
+      - R4.3: "Differential tests must compare exit codes between the Go binary and the reference binary via pkg/testutils. Tests must use short durations (0 or 0.01) to avoid slow test execution."
+      - R4.4: "Tests must cover: zero duration, fractional seconds, suffix multipliers (s, m, h, d), multiple arguments summed, error on no args, error on invalid arg, and error on negative arg."
+
+non_goals:
+  - cmd/sleep does not implement signal-based early wake (SIGALRM or similar).
+  - cmd/sleep does not report remaining time on interruption.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "go run ./cmd/sleep 0; echo $? prints 0 immediately, matching gsleep."
+    traces:
+      - R1.1
+      - R2.1
+      - R4.1
+  - id: AC2
+    criterion: "go run ./cmd/sleep 0.01 completes in roughly 10ms and exits 0, matching gsleep."
+    traces:
+      - R1.1
+      - R1.2
+      - R4.1
+  - id: AC3
+    criterion: "go run ./cmd/sleep exits 1 with error when given no arguments, matching gsleep."
+    traces:
+      - R2.2
+      - R4.2
+  - id: AC4
+    criterion: "go run ./cmd/sleep abc exits 1 with error on stderr, matching gsleep."
+    traces:
+      - R2.3
+      - R4.2
+  - id: AC5
+    criterion: "Differential test against gsleep passes for all cases listed in R4.4."
+    traces:
+      - R4.3
+      - R4.4
+  - id: AC6
+    criterion: "cmd/sleep compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+      - R3.1
+      - R3.2
+      - R3.3
+      - R3.4
+      - R4.1
+      - R4.2
+      - R4.3
+      - R4.4

--- a/docs/specs/product-requirements/prd062-touch.yaml
+++ b/docs/specs/product-requirements/prd062-touch.yaml
@@ -1,0 +1,99 @@
+id: prd062-touch
+title: "cmd/touch: Create Files and Update Timestamps"
+
+problem: |
+  Shell scripts and build systems use touch to create empty files and update file timestamps.
+  The macOS BSD touch differs from GNU touch in -d date string parsing and --time flag
+  behavior. The Go implementation must match the Homebrew GNU reference binary (gtouch,
+  installed by coreutils) in file creation, timestamp modification, and exit codes for all
+  supported flag combinations, verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Create empty files that do not exist.
+  - G2: Update access and modification timestamps of existing files.
+  - G3: Support explicit timestamp specification via -t, -d, and -r.
+
+requirements:
+  R1:
+    title: Default behavior and file creation
+    items:
+      - R1.1: When given one or more FILE arguments, must update the access and modification times of each file to the current time.
+      - R1.2: When a named file does not exist, must create it as an empty file with default permissions.
+      - R1.3: "-c or --no-create must suppress file creation. If the file does not exist, must not create it and must not report an error."
+      - R1.4: Must support multiple file arguments, processing each in order.
+
+  R2:
+    title: Timestamp selection and explicit times
+    items:
+      - R2.1: "-a must change only the access time."
+      - R2.2: "-m must change only the modification time."
+      - R2.3: "When neither -a nor -m is given, must change both access and modification times."
+      - R2.4: "-t STAMP must use the timestamp [[CC]YY]MMDDhhmm[.ss] instead of the current time."
+
+  R3:
+    title: Reference file and date string
+    items:
+      - R3.1: "-r FILE or --reference=FILE must use the timestamps of FILE instead of the current time."
+      - R3.2: "-d STRING or --date=STRING must parse the date string and use it instead of the current time."
+      - R3.3: "When a reference file does not exist, must print an error to stderr and exit 1."
+      - R3.4: "-h or --no-dereference must affect the symbolic link itself rather than the file it points to."
+
+  R4:
+    title: Exit codes and differential testing
+    items:
+      - R4.1: Must exit 0 when all files are processed successfully.
+      - R4.2: Must exit 1 when an error occurs (invalid timestamp, missing reference file, permission denied). Must continue processing remaining files after an error.
+      - R4.3: "Differential tests must compare exit codes and resulting file timestamps between the Go binary and the reference binary via pkg/testutils."
+      - R4.4: "Tests must cover: create new file, update existing file, -c no-create, -a access only, -m modification only, -t explicit timestamp, -d date string, -r reference file, multiple files, and error cases (invalid timestamp, missing reference file)."
+
+non_goals:
+  - cmd/touch does not implement the obsolescent -t format with two-digit years outside the [[CC]YY]MMDDhhmm[.ss] specification.
+  - cmd/touch does not implement --time=WORD as a standalone flag (it is an alias for -a/-m in GNU touch but rarely used).
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "go run ./cmd/touch /tmp/newfile creates the file if absent, matching gtouch."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.4
+  - id: AC2
+    criterion: "go run ./cmd/touch -c /tmp/nonexistent does not create the file and exits 0, matching gtouch."
+    traces:
+      - R1.3
+      - R4.1
+  - id: AC3
+    criterion: "go run ./cmd/touch -t 202401151030.00 /tmp/testfile sets the timestamp, matching gtouch."
+    traces:
+      - R2.3
+      - R2.4
+      - R4.1
+  - id: AC4
+    criterion: "go run ./cmd/touch -r /tmp/reffile /tmp/testfile copies timestamps, matching gtouch."
+    traces:
+      - R3.1
+      - R3.3
+  - id: AC5
+    criterion: "Differential test against gtouch passes for all flag combinations listed in R4.4."
+    traces:
+      - R4.3
+      - R4.4
+  - id: AC6
+    criterion: "cmd/touch compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+      - R3.1
+      - R3.2
+      - R3.3
+      - R3.4
+      - R4.1
+      - R4.2
+      - R4.3
+      - R4.4

--- a/docs/specs/product-requirements/prd063-timeout.yaml
+++ b/docs/specs/product-requirements/prd063-timeout.yaml
@@ -1,0 +1,101 @@
+id: prd063-timeout
+title: "cmd/timeout: Run a Command with a Time Limit"
+
+problem: |
+  Build scripts, CI pipelines, and system administration tools use timeout to run a command
+  with a time limit and kill it if it does not complete. The macOS BSD system has no built-in
+  timeout command. GNU timeout from coreutils provides duration parsing, signal selection,
+  and kill-after escalation. The Go implementation must match the Homebrew GNU reference
+  binary (gtimeout, installed by coreutils) in exit codes and signal behavior, verified by
+  differential testing via pkg/testutils.
+
+goals:
+  - G1: Run a command and kill it if it exceeds a specified duration.
+  - G2: Support configurable signal selection and kill-after escalation.
+  - G3: Support duration suffixes (s, m, h, d) and fractional values.
+
+requirements:
+  R1:
+    title: Core timeout behavior
+    items:
+      - R1.1: "Must run COMMAND with optional ARGS and kill it with SIGTERM if it does not exit within DURATION seconds."
+      - R1.2: Must support fractional durations (e.g., timeout 0.5 command).
+      - R1.3: Must support suffix multipliers s (seconds, default), m (minutes), h (hours), d (days).
+      - R1.4: "When DURATION is 0, must not impose a time limit (the command runs indefinitely)."
+
+  R2:
+    title: Signal selection and kill-after
+    items:
+      - R2.1: "-s SIGNAL or --signal=SIGNAL must send the specified signal instead of SIGTERM. Must accept signal names (e.g., KILL, HUP) and numeric signal values."
+      - R2.2: "-k DURATION or --kill-after=DURATION must send SIGKILL if the command is still running DURATION seconds after the initial signal."
+      - R2.3: "--foreground must not create a separate process group, allowing the command to use the terminal."
+      - R2.4: "--preserve-status must exit with the same status as the command, even on timeout, instead of the timeout-specific exit code 124."
+
+  R3:
+    title: Exit codes
+    items:
+      - R3.1: "When the command exits before the timeout, must exit with the command's exit status."
+      - R3.2: "When the command is killed due to timeout, must exit 124 (unless --preserve-status is given)."
+      - R3.3: "When the command is killed by a signal not sent by timeout, must exit 128+signum."
+      - R3.4: "When the timeout command itself fails (invalid arguments, command not found), must exit 125 for internal error or 126/127 for command execution failure."
+
+  R4:
+    title: Differential testing
+    items:
+      - R4.1: "Differential tests must compare exit codes between the Go binary and the reference binary via pkg/testutils."
+      - R4.2: "Tests must cover: command completes before timeout (exit with command status), command exceeds timeout (exit 124), duration 0 (no limit), -s with named and numeric signals, -k kill-after escalation, --preserve-status, and error cases (no args, invalid duration, command not found)."
+      - R4.3: "Tests must use fast commands (true, false, sleep 0) and short durations to avoid slow test execution."
+      - R4.4: "Tests must verify that the timed-out process is actually killed and does not remain as an orphan."
+
+non_goals:
+  - cmd/timeout does not implement --verbose or any diagnostic output beyond error messages.
+  - cmd/timeout does not implement platform-specific process group management beyond what Go's os/exec provides with SysProcAttr.Setpgid.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "go run ./cmd/timeout 10 true exits 0, matching gtimeout."
+    traces:
+      - R1.1
+      - R3.1
+  - id: AC2
+    criterion: "go run ./cmd/timeout 0.01 sleep 10 exits 124, matching gtimeout."
+    traces:
+      - R1.1
+      - R1.2
+      - R3.2
+  - id: AC3
+    criterion: "go run ./cmd/timeout 0 sleep 0 exits 0 (no time limit), matching gtimeout."
+    traces:
+      - R1.4
+      - R3.1
+  - id: AC4
+    criterion: "go run ./cmd/timeout -s KILL 0.01 sleep 10 sends SIGKILL and exits 137, matching gtimeout."
+    traces:
+      - R2.1
+      - R3.3
+  - id: AC5
+    criterion: "Differential test against gtimeout passes for all cases listed in R4.2."
+    traces:
+      - R4.1
+      - R4.2
+      - R4.3
+      - R4.4
+  - id: AC6
+    criterion: "cmd/timeout compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+      - R3.1
+      - R3.2
+      - R3.3
+      - R3.4
+      - R4.1
+      - R4.2
+      - R4.3
+      - R4.4

--- a/docs/specs/product-requirements/prd064-shuf.yaml
+++ b/docs/specs/product-requirements/prd064-shuf.yaml
@@ -1,0 +1,103 @@
+id: prd064-shuf
+title: "cmd/shuf: Shuffle Lines Randomly"
+
+problem: |
+  Shell scripts and data pipelines use shuf to randomly permute input lines, select random
+  samples, or generate random numbers within a range. The macOS BSD system has no built-in
+  shuf command. GNU shuf from coreutils supports input from files or stdin, range generation,
+  head count limiting, and repeat mode. The Go implementation must match the Homebrew GNU
+  reference binary (gshuf, installed by coreutils) in output format and exit codes, verified
+  by differential testing via pkg/testutils. Because shuf output is non-deterministic,
+  differential tests verify structural properties (line count, value ranges, uniqueness)
+  rather than exact byte equality.
+
+goals:
+  - G1: Randomly permute input lines from files or stdin.
+  - G2: Support integer range generation via -i LO-HI.
+  - G3: Support output count limiting via -n COUNT and repeat mode via -r.
+
+requirements:
+  R1:
+    title: Default shuffle behavior
+    items:
+      - R1.1: When given one or more FILE arguments, must read all lines from each file, randomly permute them, and write the result to stdout.
+      - R1.2: When no file arguments are given or when "-" is given as a filename, must read from stdin.
+      - R1.3: Must output each input line exactly once in a random order (a permutation, not sampling with replacement) unless -r is given.
+      - R1.4: Must treat each line as terminated by a newline. The last line need not end with a newline, but must be included in the shuffle.
+
+  R2:
+    title: Range mode and output control
+    items:
+      - R2.1: "-i LO-HI or --input-range=LO-HI must generate and shuffle integers from LO to HI inclusive, one per line. Must not be combined with file arguments."
+      - R2.2: "-n COUNT or --head-count=COUNT must output at most COUNT lines."
+      - R2.3: "-r or --repeat must allow output lines to repeat (sampling with replacement). Without -n, runs indefinitely."
+      - R2.4: "-o FILE or --output=FILE must write output to FILE instead of stdout."
+
+  R3:
+    title: Random source and zero-delimiter
+    items:
+      - R3.1: "--random-source=FILE must read random bytes from FILE instead of the system random source."
+      - R3.2: "-z or --zero-terminated must use NUL (\\0) as the line delimiter instead of newline, for both input and output."
+      - R3.3: "-e or --echo must treat each ARG as an input line instead of reading from files."
+      - R3.4: Must handle empty input (zero lines) by producing no output and exiting 0.
+
+  R4:
+    title: Exit codes and differential testing
+    items:
+      - R4.1: Must exit 0 on successful operation.
+      - R4.2: Must exit 1 on error (invalid range, conflicting options, write error).
+      - R4.3: "Differential tests must verify structural properties rather than exact output: correct line count, values within range for -i, no duplicates without -r, duplicates allowed with -r."
+      - R4.4: "Tests must cover: shuffle stdin lines, shuffle file lines, -i range mode, -n head count, -r repeat mode, -e echo mode, -z zero-terminated, empty input, and error cases (invalid range, -i with files)."
+
+non_goals:
+  - cmd/shuf does not guarantee a specific PRNG algorithm or reproducible output for a given random seed.
+  - cmd/shuf does not implement --random-source with /dev/urandom compatibility testing (the random source changes output).
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "printf 'a\\nb\\nc\\n' | go run ./cmd/shuf produces exactly 3 lines containing a, b, c in some order."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+  - id: AC2
+    criterion: "go run ./cmd/shuf -i 1-5 -n 3 produces exactly 3 distinct integers from 1 to 5."
+    traces:
+      - R2.1
+      - R2.2
+  - id: AC3
+    criterion: "go run ./cmd/shuf -e alpha beta gamma produces exactly 3 lines containing alpha, beta, gamma in some order."
+    traces:
+      - R3.3
+      - R4.1
+  - id: AC4
+    criterion: "go run ./cmd/shuf -i 1-5 -r -n 10 produces exactly 10 integers each between 1 and 5 (duplicates allowed)."
+    traces:
+      - R2.1
+      - R2.2
+      - R2.3
+  - id: AC5
+    criterion: "Differential test against gshuf passes for all structural checks listed in R4.4."
+    traces:
+      - R4.3
+      - R4.4
+  - id: AC6
+    criterion: "cmd/shuf compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+      - R3.1
+      - R3.2
+      - R3.3
+      - R3.4
+      - R4.1
+      - R4.2
+      - R4.3
+      - R4.4

--- a/docs/specs/product-requirements/prd065-factor.yaml
+++ b/docs/specs/product-requirements/prd065-factor.yaml
@@ -1,0 +1,96 @@
+id: prd065-factor
+title: "cmd/factor: Prime Factorization"
+
+problem: |
+  Shell scripts and mathematical workflows use factor to decompose integers into their prime
+  factors. The macOS BSD system has a factor command but it differs from GNU factor in output
+  formatting (spacing after the colon) and input handling (stdin vs arguments). The Go
+  implementation must match the Homebrew GNU reference binary (gfactor, installed by
+  coreutils) in output format and exit codes, verified by differential testing via
+  pkg/testutils.
+
+goals:
+  - G1: Print the prime factorization of each integer argument.
+  - G2: Read integers from stdin when no arguments are given.
+  - G3: "Match GNU factor output format exactly (NUMBER: FACTOR FACTOR ...)."
+
+requirements:
+  R1:
+    title: Core factorization behavior
+    items:
+      - R1.1: "For each integer argument, must print a line in the format 'NUMBER: FACTOR FACTOR ...' where factors are in ascending order with repetition for multiplicity (e.g., '12: 2 2 3')."
+      - R1.2: "For the number 1, must print '1:' with no factors."
+      - R1.3: Must handle prime numbers by printing the number itself as the sole factor.
+      - R1.4: Must process multiple arguments in order, printing one factorization line per argument.
+
+  R2:
+    title: Stdin mode and input handling
+    items:
+      - R2.1: When no arguments are given, must read integers from stdin, one per line, and factorize each.
+      - R2.2: Must accept integers up to at least 2^63-1 (the Go int64 maximum).
+      - R2.3: Must skip blank lines in stdin mode without producing output or error.
+      - R2.4: When a non-integer or negative input is encountered, must print an error to stderr and continue processing remaining inputs.
+
+  R3:
+    title: Help, version, and output
+    items:
+      - R3.1: When --help is the first argument, must print a usage message to stdout and exit 0.
+      - R3.2: When --version is the first argument, must print version information to stdout and exit 0.
+      - R3.3: Must write factorization output to stdout, one line per integer.
+      - R3.4: Must write error messages to stderr without stopping processing of remaining inputs.
+
+  R4:
+    title: Exit codes and differential testing
+    items:
+      - R4.1: Must exit 0 when all inputs are valid and factorized successfully.
+      - R4.2: Must exit 1 when any input is invalid (non-integer, negative, overflow).
+      - R4.3: "Differential tests must compare stdout and exit codes between the Go binary and the reference binary via pkg/testutils."
+      - R4.4: "Tests must cover: single number, multiple numbers, primes, composites, 1, large numbers, stdin mode, error on non-integer, and error on negative number."
+
+non_goals:
+  - cmd/factor does not implement arbitrary-precision factorization beyond int64 range.
+  - cmd/factor does not implement advanced factorization algorithms (Pollard rho, quadratic sieve). Trial division suffices for the int64 range.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "go run ./cmd/factor 12 prints '12: 2 2 3', matching gfactor."
+    traces:
+      - R1.1
+      - R1.4
+  - id: AC2
+    criterion: "go run ./cmd/factor 1 prints '1:', matching gfactor."
+    traces:
+      - R1.2
+  - id: AC3
+    criterion: "go run ./cmd/factor 97 prints '97: 97', matching gfactor."
+    traces:
+      - R1.3
+  - id: AC4
+    criterion: "echo '15' | go run ./cmd/factor prints '15: 3 5', matching gfactor stdin mode."
+    traces:
+      - R2.1
+      - R2.4
+  - id: AC5
+    criterion: "Differential test against gfactor passes for all cases listed in R4.4."
+    traces:
+      - R4.3
+      - R4.4
+  - id: AC6
+    criterion: "cmd/factor compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+      - R3.1
+      - R3.2
+      - R3.3
+      - R3.4
+      - R4.1
+      - R4.2
+      - R4.3
+      - R4.4

--- a/docs/specs/product-requirements/prd066-expr.yaml
+++ b/docs/specs/product-requirements/prd066-expr.yaml
@@ -1,0 +1,101 @@
+id: prd066-expr
+title: "cmd/expr: Evaluate Expressions"
+
+problem: |
+  Shell scripts use expr to evaluate integer arithmetic, string comparisons, string matching,
+  and logical expressions from the command line. The macOS BSD expr differs from GNU expr in
+  regex syntax and the + operator for string protection. The Go implementation must match the
+  Homebrew GNU reference binary (gexpr, installed by coreutils) in output and exit codes for
+  all supported operations, verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Evaluate arithmetic, comparison, and logical expressions given as arguments.
+  - G2: Support string matching and substring operations.
+  - G3: Match GNU expr precedence, associativity, and output format.
+
+requirements:
+  R1:
+    title: Arithmetic and comparison operators
+    items:
+      - R1.1: "Must support integer arithmetic operators: + (add), - (subtract), * (multiply), / (integer divide), % (modulo). Each operator and operand is a separate argument."
+      - R1.2: "Must support comparison operators: < (less), <= (less-equal), = (equal), != (not-equal), >= (greater-equal), > (greater). Comparisons on two integers use numeric comparison; otherwise use lexicographic comparison. Must return 1 for true and 0 for false."
+      - R1.3: "Must support logical operators: | (or) returns the first argument if it is nonzero/non-empty, else the second; & (and) returns the first argument if both are nonzero/non-empty, else 0."
+      - R1.4: "Must support parentheses for grouping: ( and ) override default precedence. Parentheses are separate arguments."
+
+  R2:
+    title: String operations
+    items:
+      - R2.1: "match STRING REGEXP or STRING : REGEXP must anchor the pattern at the beginning of STRING and return the matched substring if the pattern contains \\( \\), or the number of matched characters otherwise."
+      - R2.2: "substr STRING POS LENGTH must return a substring of STRING starting at position POS (1-based) with length LENGTH."
+      - R2.3: "index STRING CHARS must return the position (1-based) of the first character in STRING that is also in CHARS, or 0 if none."
+      - R2.4: "length STRING must return the number of characters in STRING."
+
+  R3:
+    title: Special tokens and precedence
+    items:
+      - R3.1: "+ TOKEN must interpret TOKEN as a string even if it is a keyword (match, substr, index, length) or operator. The + is consumed and not part of the value."
+      - R3.2: "Operator precedence from lowest to highest: | , & , comparisons (< <= = != >= >), + - (arithmetic), * / %."
+      - R3.3: "All binary operators are left-associative."
+      - R3.4: "Division by zero must print an error to stderr and exit 2."
+
+  R4:
+    title: Exit codes and differential testing
+    items:
+      - R4.1: "Must exit 0 when the expression evaluates to a non-null, non-zero value."
+      - R4.2: "Must exit 1 when the expression evaluates to null or 0."
+      - R4.3: "Must exit 2 on syntax error (invalid expression, missing operand, division by zero). Must exit 3 on internal error."
+      - R4.4: "Differential tests must compare stdout, stderr emptiness, and exit codes between the Go binary and the reference binary via pkg/testutils. Tests must cover: integer arithmetic (all operators), comparisons (numeric and string), logical operators, string operations (match, substr, index, length), parentheses, + escaping, division by zero, and missing operand errors."
+
+non_goals:
+  - cmd/expr does not implement GNU expr's --help and --version when they appear as the sole argument and could be confused with an expression operand.
+  - cmd/expr does not implement arbitrary-precision arithmetic. Integer overflow behavior matches the host platform's int64 semantics.
+  - cmd/expr does not implement extended regex. Only basic regular expressions (BRE) with \\( \\) grouping are supported.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "go run ./cmd/expr 2 + 3 prints '5' and exits 0, matching gexpr."
+    traces:
+      - R1.1
+      - R4.1
+  - id: AC2
+    criterion: "go run ./cmd/expr 5 '<' 10 prints '1' and exits 0, matching gexpr."
+    traces:
+      - R1.2
+      - R4.1
+  - id: AC3
+    criterion: "go run ./cmd/expr match abcdef 'abc\\(.*\\)' prints 'def', matching gexpr."
+    traces:
+      - R2.1
+  - id: AC4
+    criterion: "go run ./cmd/expr length hello prints '5', matching gexpr."
+    traces:
+      - R2.4
+      - R4.1
+  - id: AC5
+    criterion: "go run ./cmd/expr 1 / 0 exits 2 with error on stderr, matching gexpr."
+    traces:
+      - R3.4
+      - R4.3
+  - id: AC6
+    criterion: "Differential test against gexpr passes for all cases listed in R4.4."
+    traces:
+      - R4.4
+  - id: AC7
+    criterion: "cmd/expr compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+      - R3.1
+      - R3.2
+      - R3.3
+      - R3.4
+      - R4.1
+      - R4.2
+      - R4.3
+      - R4.4

--- a/docs/specs/test-suites/test-rel-08.0.yaml
+++ b/docs/specs/test-suites/test-rel-08.0.yaml
@@ -1,0 +1,571 @@
+id: test-rel08.0
+title: "Test Suite: rel08.0 — date, sleep, touch, timeout, shuf, factor, expr"
+release: rel08.0
+
+traces:
+  - rel08.0-uc001-date
+  - rel08.0-uc002-sleep
+  - rel08.0-uc003-touch
+  - rel08.0-uc004-timeout
+  - rel08.0-uc005-shuf
+  - rel08.0-uc006-factor
+  - rel08.0-uc007-expr
+  - prd060-date R1
+  - prd060-date R2
+  - prd060-date R3
+  - prd060-date R4
+  - prd061-sleep R1
+  - prd061-sleep R2
+  - prd061-sleep R3
+  - prd061-sleep R4
+  - prd062-touch R1
+  - prd062-touch R2
+  - prd062-touch R3
+  - prd062-touch R4
+  - prd063-timeout R1
+  - prd063-timeout R2
+  - prd063-timeout R3
+  - prd063-timeout R4
+  - prd064-shuf R1
+  - prd064-shuf R2
+  - prd064-shuf R3
+  - prd064-shuf R4
+  - prd065-factor R1
+  - prd065-factor R2
+  - prd065-factor R3
+  - prd065-factor R4
+  - prd066-expr R1
+  - prd066-expr R2
+  - prd066-expr R3
+  - prd066-expr R4
+
+preconditions:
+  - ./bin/date, ./bin/sleep, ./bin/touch, ./bin/timeout, ./bin/shuf, ./bin/factor, and ./bin/expr exist (built via mage build).
+  - Reference binaries gdate, gsleep, gtouch, gtimeout, gshuf, gfactor, and gexpr are installed via Homebrew (coreutils) and on PATH.
+  - Tests are run via go test ./cmd/<utility>/... which invokes RunDiffTests from pkg/testutils.
+  - All tests use LC_ALL=C to eliminate locale-dependent divergence.
+  - "date tests use -d @EPOCH with TZ=UTC for deterministic output comparison."
+  - "sleep tests use 0 or very short durations (0.01s) to avoid slow test execution."
+  - "touch tests use explicit timestamps (-t) for deterministic comparison."
+  - "timeout tests use fast commands (true, false, sleep 0) with short deadlines."
+  - "shuf tests verify structural properties (line count, ranges, uniqueness) not exact bytes."
+  - "factor and expr output is deterministic; exact byte comparison is used."
+
+test_cases:
+  # --- date ---
+  - name: date_epoch_format
+    description: "date -d @0 '+%Y-%m-%d %H:%M:%S' under TZ=UTC; expect '1970-01-01 00:00:00'."
+    inputs:
+      args: ["-d", "@0", "+%Y-%m-%d %H:%M:%S"]
+      stdin: ""
+      env: ["LC_ALL=C", "TZ=UTC"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "1970-01-01 00:00:00\n"
+      stderr: ""
+    traces:
+      - prd060-date R1.2
+      - prd060-date R1.3
+      - prd060-date R2.2
+
+  - name: date_epoch_seconds
+    description: "date -u -d @1700000000 '+%s'; expect '1700000000'."
+    inputs:
+      args: ["-u", "-d", "@1700000000", "+%s"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "1700000000\n"
+      stderr: ""
+    traces:
+      - prd060-date R1.3
+      - prd060-date R2.2
+      - prd060-date R3.1
+
+  - name: date_invalid_string
+    description: "date -d 'invalid'; expect exit 1 with error on stderr."
+    inputs:
+      args: ["-d", "invalid"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 1
+      stdout: ""
+      stderr: "non-empty error message"
+    traces:
+      - prd060-date R2.4
+      - prd060-date R4.2
+
+  - name: date_weekday_format
+    description: "date -d @0 '+%A' under TZ=UTC; expect 'Thursday'."
+    inputs:
+      args: ["-d", "@0", "+%A"]
+      stdin: ""
+      env: ["LC_ALL=C", "TZ=UTC"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "Thursday\n"
+      stderr: ""
+    traces:
+      - prd060-date R1.3
+
+  # --- sleep ---
+  - name: sleep_zero
+    description: "sleep 0; expect immediate exit 0."
+    inputs:
+      args: ["0"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd061-sleep R1.1
+      - prd061-sleep R2.1
+
+  - name: sleep_no_args
+    description: "sleep with no arguments; expect exit 1 with error."
+    inputs:
+      args: []
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 1
+      stdout: ""
+      stderr: "non-empty error message"
+    traces:
+      - prd061-sleep R2.2
+      - prd061-sleep R4.2
+
+  - name: sleep_invalid_arg
+    description: "sleep abc; expect exit 1 with error on stderr."
+    inputs:
+      args: ["abc"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 1
+      stdout: ""
+      stderr: "non-empty error message"
+    traces:
+      - prd061-sleep R2.3
+      - prd061-sleep R4.2
+
+  - name: sleep_negative_arg
+    description: "sleep -1; expect exit 1 with error on stderr."
+    inputs:
+      args: ["-1"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 1
+      stdout: ""
+      stderr: "non-empty error message"
+    traces:
+      - prd061-sleep R2.3
+      - prd061-sleep R4.2
+
+  # --- touch ---
+  - name: touch_create_file
+    description: "touch newfile creates the file if absent."
+    inputs:
+      args: ["$TMPDIR/touch_test_new"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd062-touch R1.1
+      - prd062-touch R1.2
+
+  - name: touch_no_create
+    description: "touch -c nonexistent does not create file, exits 0."
+    inputs:
+      args: ["-c", "$TMPDIR/touch_test_nocreate"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd062-touch R1.3
+      - prd062-touch R4.1
+
+  - name: touch_explicit_timestamp
+    description: "touch -t 202401151030.00 file sets explicit timestamp."
+    inputs:
+      args: ["-t", "202401151030.00", "$TMPDIR/touch_test_ts"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd062-touch R2.4
+
+  - name: touch_reference_missing
+    description: "touch -r /nonexistent /tmp/f; expect exit 1 with error."
+    inputs:
+      args: ["-r", "/nonexistent", "$TMPDIR/touch_test_ref"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 1
+      stdout: ""
+      stderr: "non-empty error message"
+    traces:
+      - prd062-touch R3.3
+      - prd062-touch R4.2
+
+  # --- timeout ---
+  - name: timeout_command_succeeds
+    description: "timeout 10 true; expect exit 0."
+    inputs:
+      args: ["10", "true"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd063-timeout R1.1
+      - prd063-timeout R3.1
+
+  - name: timeout_command_fails
+    description: "timeout 10 false; expect exit 1 (command status)."
+    inputs:
+      args: ["10", "false"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 1
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd063-timeout R3.1
+
+  - name: timeout_zero_duration
+    description: "timeout 0 sleep 0; expect exit 0 (no time limit)."
+    inputs:
+      args: ["0", "sleep", "0"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd063-timeout R1.4
+      - prd063-timeout R3.1
+
+  - name: timeout_no_args
+    description: "timeout with no arguments; expect exit 125 with error."
+    inputs:
+      args: []
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 125
+      stdout: ""
+      stderr: "non-empty error message"
+    traces:
+      - prd063-timeout R3.4
+
+  # --- shuf ---
+  - name: shuf_stdin_three_lines
+    description: "shuf on three-line stdin; expect exactly 3 lines containing a, b, c."
+    inputs:
+      args: []
+      stdin: "a\nb\nc\n"
+      env: ["LC_ALL=C"]
+    normalization: "structural: 3 lines, set {a, b, c}"
+    expected:
+      exit_code: 0
+      stdout: "3 lines containing a, b, c in any order"
+      stderr: ""
+    traces:
+      - prd064-shuf R1.1
+      - prd064-shuf R1.2
+      - prd064-shuf R1.3
+
+  - name: shuf_range_mode
+    description: "shuf -i 1-5; expect exactly 5 lines, distinct integers 1-5."
+    inputs:
+      args: ["-i", "1-5"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: "structural: 5 lines, distinct integers in [1,5]"
+    expected:
+      exit_code: 0
+      stdout: "5 lines, each a distinct integer from 1 to 5"
+      stderr: ""
+    traces:
+      - prd064-shuf R2.1
+
+  - name: shuf_head_count
+    description: "shuf -i 1-100 -n 3; expect exactly 3 lines, distinct integers 1-100."
+    inputs:
+      args: ["-i", "1-100", "-n", "3"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: "structural: 3 lines, distinct integers in [1,100]"
+    expected:
+      exit_code: 0
+      stdout: "3 lines, each a distinct integer from 1 to 100"
+      stderr: ""
+    traces:
+      - prd064-shuf R2.1
+      - prd064-shuf R2.2
+
+  - name: shuf_echo_mode
+    description: "shuf -e alpha beta gamma; expect 3 lines containing alpha, beta, gamma."
+    inputs:
+      args: ["-e", "alpha", "beta", "gamma"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: "structural: 3 lines, set {alpha, beta, gamma}"
+    expected:
+      exit_code: 0
+      stdout: "3 lines containing alpha, beta, gamma in any order"
+      stderr: ""
+    traces:
+      - prd064-shuf R3.3
+
+  - name: shuf_empty_input
+    description: "shuf on empty stdin; expect no output."
+    inputs:
+      args: []
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd064-shuf R3.4
+
+  # --- factor ---
+  - name: factor_composite
+    description: "factor 12; expect '12: 2 2 3'."
+    inputs:
+      args: ["12"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "12: 2 2 3\n"
+      stderr: ""
+    traces:
+      - prd065-factor R1.1
+
+  - name: factor_one
+    description: "factor 1; expect '1:'."
+    inputs:
+      args: ["1"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "1:\n"
+      stderr: ""
+    traces:
+      - prd065-factor R1.2
+
+  - name: factor_prime
+    description: "factor 97; expect '97: 97'."
+    inputs:
+      args: ["97"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "97: 97\n"
+      stderr: ""
+    traces:
+      - prd065-factor R1.3
+
+  - name: factor_multiple_args
+    description: "factor 6 15; expect '6: 2 3' and '15: 3 5'."
+    inputs:
+      args: ["6", "15"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "6: 2 3\n15: 3 5\n"
+      stderr: ""
+    traces:
+      - prd065-factor R1.4
+
+  - name: factor_stdin_mode
+    description: "echo 15 | factor; expect '15: 3 5'."
+    inputs:
+      args: []
+      stdin: "15\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "15: 3 5\n"
+      stderr: ""
+    traces:
+      - prd065-factor R2.1
+
+  - name: factor_large_number
+    description: "factor 999999937 (large prime); expect '999999937: 999999937'."
+    inputs:
+      args: ["999999937"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "999999937: 999999937\n"
+      stderr: ""
+    traces:
+      - prd065-factor R1.3
+      - prd065-factor R2.2
+
+  # --- expr ---
+  - name: expr_addition
+    description: "expr 2 + 3; expect '5'."
+    inputs:
+      args: ["2", "+", "3"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "5\n"
+      stderr: ""
+    traces:
+      - prd066-expr R1.1
+
+  - name: expr_multiplication
+    description: "expr 4 '*' 5; expect '20'."
+    inputs:
+      args: ["4", "*", "5"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "20\n"
+      stderr: ""
+    traces:
+      - prd066-expr R1.1
+
+  - name: expr_comparison_less
+    description: "expr 5 '<' 10; expect '1' (true)."
+    inputs:
+      args: ["5", "<", "10"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "1\n"
+      stderr: ""
+    traces:
+      - prd066-expr R1.2
+
+  - name: expr_string_length
+    description: "expr length hello; expect '5'."
+    inputs:
+      args: ["length", "hello"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "5\n"
+      stderr: ""
+    traces:
+      - prd066-expr R2.4
+
+  - name: expr_substr
+    description: "expr substr hello 2 3; expect 'ell'."
+    inputs:
+      args: ["substr", "hello", "2", "3"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "ell\n"
+      stderr: ""
+    traces:
+      - prd066-expr R2.2
+
+  - name: expr_division_by_zero
+    description: "expr 1 / 0; expect exit 2 with error on stderr."
+    inputs:
+      args: ["1", "/", "0"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 2
+      stdout: ""
+      stderr: "non-empty error message"
+    traces:
+      - prd066-expr R3.4
+      - prd066-expr R4.3
+
+  - name: expr_zero_result_exit_code
+    description: "expr 0 + 0; expect '0' and exit 1 (result is zero)."
+    inputs:
+      args: ["0", "+", "0"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 1
+      stdout: "0\n"
+      stderr: ""
+    traces:
+      - prd066-expr R1.1
+      - prd066-expr R4.2
+
+  - name: expr_parentheses
+    description: "expr '(' 2 + 3 ')' '*' 4; expect '20'."
+    inputs:
+      args: ["(", "2", "+", "3", ")", "*", "4"]
+      stdin: ""
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: "20\n"
+      stderr: ""
+    traces:
+      - prd066-expr R1.4
+      - prd066-expr R3.2

--- a/docs/specs/use-cases/rel08.0-uc001-date.yaml
+++ b/docs/specs/use-cases/rel08.0-uc001-date.yaml
@@ -1,0 +1,52 @@
+id: rel08.0-uc001-date
+title: "Display and format date/time via date"
+
+summary: |
+  The operator invokes the Go date binary to print formatted date and time output. The
+  differential testing harness runs both the Go binary and the Homebrew reference binary
+  (gdate from coreutils) with the same arguments and environment, then compares stdout
+  and exit codes. Tests use fixed epoch timestamps via -d @EPOCH to produce deterministic
+  output.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd060-date.yaml) and invokes do-work to produce
+  a passing differential test for cmd/date.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises date with default output (using fixed epoch), +FORMAT with
+      various conversion specifications (%Y, %m, %d, %H, %M, %S, %s, %N, %Z), -d with
+      epoch and ISO strings, -u UTC mode, -r reference file, padding modifiers (%-d, %_d,
+      %0d), and error cases (invalid date string, missing reference file).
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/date and gdate
+      with the same arguments and environment. Requires F1 (binary must be built). All
+      tests set TZ=UTC and use -d @EPOCH for deterministic comparison.
+
+touchpoints:
+  - T1: "cmd/date — format output, date parsing, UTC mode, reference file (prd060-date R1, R2, R3, R4)"
+  - T2: "pkg/testutils — RunDiffTests, stdout and exit code comparison"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for fixed-epoch formatting, all conversion specs,
+      -d date parsing, -u UTC mode, -r reference file, padding modifiers, and error
+      cases, confirming output and exit code parity with gdate.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+      - AC5
+
+out_of_scope:
+  - Default (current time) output is not tested via differential comparison because the
+    two binaries execute at slightly different times. Tests use -d @EPOCH exclusively.
+  - Relative date strings (yesterday, 2 days ago) are excluded per the PRD.
+
+test_suite: test-rel08.0

--- a/docs/specs/use-cases/rel08.0-uc002-sleep.yaml
+++ b/docs/specs/use-cases/rel08.0-uc002-sleep.yaml
@@ -1,0 +1,49 @@
+id: rel08.0-uc002-sleep
+title: "Pause for a duration via sleep"
+
+summary: |
+  The operator invokes the Go sleep binary to pause execution for a specified duration. The
+  differential testing harness runs both the Go binary and the Homebrew reference binary
+  (gsleep from coreutils) with the same arguments and compares exit codes. Tests use zero
+  or very short durations to avoid slow test execution.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd061-sleep.yaml) and invokes do-work to produce
+  a passing differential test for cmd/sleep.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises sleep with zero duration, fractional seconds (0.01), suffix
+      multipliers (0.001s, 0.001m), multiple arguments summed, and error cases (no args,
+      non-numeric arg, negative arg).
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/sleep and gsleep
+      with the same arguments. Requires F1 (binary must be built). Only exit codes are
+      compared; stdout and stderr are compared for error cases.
+
+touchpoints:
+  - T1: "cmd/sleep — duration parsing, suffix handling, multi-arg sum (prd061-sleep R1, R2, R3, R4)"
+  - T2: "pkg/testutils — RunDiffTests, exit code comparison"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for zero duration, fractional seconds, suffix
+      multipliers, multiple arguments, and error cases, confirming exit code parity
+      with gsleep.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+      - AC5
+
+out_of_scope:
+  - Long-duration sleeps are not tested (would make tests slow).
+  - Signal interruption behavior is not tested in the differential harness.
+
+test_suite: test-rel08.0

--- a/docs/specs/use-cases/rel08.0-uc003-touch.yaml
+++ b/docs/specs/use-cases/rel08.0-uc003-touch.yaml
@@ -1,0 +1,50 @@
+id: rel08.0-uc003-touch
+title: "Create files and update timestamps via touch"
+
+summary: |
+  The operator invokes the Go touch binary to create empty files and update file timestamps.
+  The differential testing harness runs both the Go binary and the Homebrew reference binary
+  (gtouch from coreutils) with the same arguments and environment, then compares exit codes
+  and resulting file system state (existence, timestamps).
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd062-touch.yaml) and invokes do-work to produce
+  a passing differential test for cmd/touch.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises touch with file creation, update of existing files, -c
+      no-create, -a access-only, -m modification-only, -t explicit timestamp, -d date
+      string, -r reference file, multiple files, and error cases (invalid timestamp,
+      missing reference file).
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/touch and gtouch
+      with the same arguments and environment. Requires F1 (binary must be built). The
+      harness compares exit codes and verifies file existence and timestamps.
+
+touchpoints:
+  - T1: "cmd/touch — file creation, timestamp update, explicit time, reference file (prd062-touch R1, R2, R3, R4)"
+  - T2: "pkg/testutils — RunDiffTests, exit code and file system state comparison"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for file creation, timestamp update, -c no-create,
+      -a access only, -m modification only, -t explicit timestamp, -d date string,
+      -r reference file, and error cases, confirming parity with gtouch.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+      - AC5
+
+out_of_scope:
+  - Symlink timestamp modification (-h) is platform-dependent and not tested on all systems.
+  - Nanosecond-precision timestamp comparison is not performed (filesystem granularity varies).
+
+test_suite: test-rel08.0

--- a/docs/specs/use-cases/rel08.0-uc004-timeout.yaml
+++ b/docs/specs/use-cases/rel08.0-uc004-timeout.yaml
@@ -1,0 +1,51 @@
+id: rel08.0-uc004-timeout
+title: "Run command with time limit via timeout"
+
+summary: |
+  The operator invokes the Go timeout binary to run a command with a time limit. The
+  differential testing harness runs both the Go binary and the Homebrew reference binary
+  (gtimeout from coreutils) with the same arguments and compares exit codes. Tests use
+  fast commands (true, false, sleep) and short durations.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd063-timeout.yaml) and invokes do-work to produce
+  a passing differential test for cmd/timeout.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises timeout with a command completing before the deadline, a
+      command exceeding the deadline (exit 124), duration 0 (no limit), -s with named
+      and numeric signals, -k kill-after escalation, --preserve-status, and error cases
+      (no args, invalid duration, command not found).
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/timeout and
+      gtimeout with the same arguments. Requires F1 (binary must be built). The harness
+      compares exit codes and verifies the timed-out child process is terminated.
+
+touchpoints:
+  - T1: "cmd/timeout — deadline enforcement, signal selection, kill-after, foreground, preserve-status (prd063-timeout R1, R2, R3, R4)"
+  - T2: "pkg/testutils — RunDiffTests, exit code comparison"
+  - T3: "pkg/sys — process group management (setpgid, killpg) for child process cleanup"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for command completing before timeout, command
+      exceeding timeout, duration 0, signal selection, kill-after escalation,
+      preserve-status, and error cases, confirming exit code parity with gtimeout.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+      - AC5
+
+out_of_scope:
+  - Interactive terminal behavior with --foreground is not tested in the differential harness.
+  - Long-running timeout tests are excluded to keep test execution fast.
+
+test_suite: test-rel08.0

--- a/docs/specs/use-cases/rel08.0-uc005-shuf.yaml
+++ b/docs/specs/use-cases/rel08.0-uc005-shuf.yaml
@@ -1,0 +1,52 @@
+id: rel08.0-uc005-shuf
+title: "Shuffle lines randomly via shuf"
+
+summary: |
+  The operator invokes the Go shuf binary to randomly permute input lines or generate
+  random samples. The differential testing harness runs both the Go binary and the Homebrew
+  reference binary (gshuf from coreutils) with the same arguments and compares structural
+  properties of the output (line count, value ranges, uniqueness) rather than exact bytes,
+  because shuf output is non-deterministic.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd064-shuf.yaml) and invokes do-work to produce
+  a passing differential test for cmd/shuf.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises shuf with stdin line shuffle, file line shuffle, -i range
+      mode, -n head count, -r repeat mode, -e echo mode, -z zero-terminated, empty
+      input, and error cases (invalid range, -i with files).
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/shuf and gshuf
+      with the same arguments. Requires F1 (binary must be built). The harness verifies
+      structural properties: line count matches, values fall within expected range, no
+      duplicates appear without -r.
+
+touchpoints:
+  - T1: "cmd/shuf — line shuffle, range mode, head count, repeat, echo, zero-terminated (prd064-shuf R1, R2, R3, R4)"
+  - T2: "pkg/testutils — RunDiffTests, structural property comparison"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for stdin shuffle, file shuffle, -i range mode,
+      -n head count, -r repeat mode, -e echo mode, -z zero-terminated, empty input,
+      and error cases, confirming structural output parity with gshuf.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+      - AC5
+
+out_of_scope:
+  - Exact byte-for-byte output comparison is not possible because shuf output is random.
+  - --random-source testing is excluded because it changes the output deterministically
+    but depends on the random file content.
+
+test_suite: test-rel08.0

--- a/docs/specs/use-cases/rel08.0-uc006-factor.yaml
+++ b/docs/specs/use-cases/rel08.0-uc006-factor.yaml
@@ -1,0 +1,49 @@
+id: rel08.0-uc006-factor
+title: "Prime factorization via factor"
+
+summary: |
+  The operator invokes the Go factor binary to print the prime factorization of integers.
+  The differential testing harness runs both the Go binary and the Homebrew reference binary
+  (gfactor from coreutils) with the same arguments and stdin, then compares stdout and exit
+  codes byte-for-byte. factor output is deterministic so exact comparison is used.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd065-factor.yaml) and invokes do-work to produce
+  a passing differential test for cmd/factor.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises factor with single numbers, multiple numbers, primes,
+      composites, the number 1, large numbers near int64 max, stdin mode, and error
+      cases (non-integer input, negative number).
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/factor and
+      gfactor with the same arguments and stdin. Requires F1 (binary must be built).
+      The harness compares stdout byte-for-byte and exit codes.
+
+touchpoints:
+  - T1: "cmd/factor — factorization, stdin mode, output formatting (prd065-factor R1, R2, R3, R4)"
+  - T2: "pkg/testutils — RunDiffTests, stdout and exit code comparison"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for single numbers, multiple numbers, primes,
+      composites, 1, large numbers, stdin mode, and error cases, confirming byte-for-byte
+      stdout and exit code parity with gfactor.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+      - AC5
+
+out_of_scope:
+  - Numbers exceeding int64 range are not tested because Go's int64 and GNU factor's
+    unsigned long long have different overflow behavior.
+
+test_suite: test-rel08.0

--- a/docs/specs/use-cases/rel08.0-uc007-expr.yaml
+++ b/docs/specs/use-cases/rel08.0-uc007-expr.yaml
@@ -1,0 +1,52 @@
+id: rel08.0-uc007-expr
+title: "Evaluate expressions via expr"
+
+summary: |
+  The operator invokes the Go expr binary to evaluate arithmetic, comparison, and string
+  expressions. The differential testing harness runs both the Go binary and the Homebrew
+  reference binary (gexpr from coreutils) with the same arguments, then compares stdout
+  and exit codes byte-for-byte. expr output is deterministic so exact comparison is used.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd066-expr.yaml) and invokes do-work to produce
+  a passing differential test for cmd/expr.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises expr with integer arithmetic (all operators), numeric and
+      string comparisons, logical operators (| and &), string operations (match, substr,
+      index, length), parentheses grouping, + token escaping, division by zero, and
+      missing operand errors.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/expr and gexpr
+      with the same arguments. Requires F1 (binary must be built). The harness compares
+      stdout byte-for-byte and exit codes.
+
+touchpoints:
+  - T1: "cmd/expr — arithmetic, comparisons, logical ops, string ops, precedence (prd066-expr R1, R2, R3, R4)"
+  - T2: "pkg/testutils — RunDiffTests, stdout and exit code comparison"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for integer arithmetic, comparisons, logical operators,
+      string operations, parentheses, + escaping, division by zero, and missing operand
+      errors, confirming byte-for-byte stdout and exit code parity with gexpr.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+      - AC5
+      - AC6
+
+out_of_scope:
+  - Extended regular expressions are not tested; only BRE with \\( \\) grouping is supported.
+  - Integer overflow behavior at the int64 boundary is not tested differentially because
+    GNU expr uses GMP for arbitrary precision.
+
+test_suite: test-rel08.0


### PR DESCRIPTION
## Summary

Specifies 7 new utilities for rel08.0: date, sleep, touch, timeout, shuf, factor, expr. All specs-only, no implementation code. Brings total PRD count from 59 to 66.

## Changes

- 7 PRDs: prd060-date through prd066-expr (4 requirement groups each)
- 7 use cases: rel08.0-uc001 through rel08.0-uc007
- 1 test suite: test-rel-08.0.yaml (35 test cases)
- Updated road-map.yaml with rel08.0 (spec_complete)
- Updated configuration.yaml releases list

## Test plan

- [x] `mage analyze` passes (0 errors, 66 PRDs, 66 use cases, 23 test suites)
- [x] All PRDs follow prd-format completeness checklist
- [x] No implementation code

Closes #1401

🤖 Generated with [Claude Code](https://claude.com/claude-code)