### PR TITLE
GH-1331: Upgrade cobbler-scaffold v0.20260314.1 → v0.20260315.0

### DIFF
--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260314.1
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260315.0
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260314.1 h1:Pjat0plmH7C7r5EKwaoS17f/rlCkTppLWRzh9XsSTZ0=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260314.1/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260315.0 h1:8SFEvur0IZiuTwJZNBnK3v2/OTyRGLRFxponkzkWeOg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260315.0/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Summary

Upgrades cobbler-scaffold from v0.20260314.1 to v0.20260315.0.

## Changes

- Updated `magefiles/go.mod` and `magefiles/go.sum`

## Test plan

- [x] `mage analyze` passes
- [x] Local customizations preserved

Closes #1331

🤖 Generated with [Claude Code](https://claude.com/claude-code)