### PR TITLE
Fix PRD specs that caused code quality issues in run 34

### DIFF
--- a/docs/specs/product-requirements/prd008-ls.yaml
+++ b/docs/specs/product-requirements/prd008-ls.yaml
@@ -112,18 +112,10 @@ requirements:
           -h must only take effect with -l (long format). When -h is given with -l, file sizes (fi.Size int64) must be displayed via pkg/format.HumanSize(bytes int64, opts HumanSizeOpts) string with opts.Binary = true (1024-base units, suffixes K/M/G/T/P/E). Without -l, -h must have no visible effect on output.
       - R3.6: -h must also apply to the "total N" block count line in long format. When -h is active, convert the total block count (sum(fi.Blocks)/2 as int64) to a human-readable string using the same binary algorithm before printing "total X\n".
       - R3.7: |
-          -h must apply to -s block counts when both -s and -h are given, converting block counts to human-readable form. Use the following binary HumanSize algorithm directly in cmd/ls (do not call pkg/format.HumanSize):
-
-            func humanSize(n int64) string {
-                if n == 0 { return "0" }
-                suffixes := []string{"", "K", "M", "G", "T", "P", "E"}
-                f := float64(n)
-                i := 0
-                for f >= 1024 && i < len(suffixes)-1 { f /= 1024; i++ }
-                if i == 0 { return fmt.Sprintf("%d", n) }
-                if f == float64(int64(f)) { return fmt.Sprintf("%d%s", int64(f), suffixes[i]) }
-                return fmt.Sprintf("%.1f%s", f, suffixes[i])
-            }
+          -h must apply to -s block counts when both -s and -h are given, converting
+          block counts to human-readable form. Use pkg/format.HumanSize(bytes int64,
+          opts HumanSizeOpts) string with opts.Binary = true, consistent with R3.5.
+          Do not duplicate the HumanSize algorithm inline.
       - R3.8: -F must append a type indicator character after each entry name. The indicators are "/" for directories, "*" for executable regular files, "@" for symbolic links, "|" for named pipes (FIFOs), "=" for sockets. Regular non-executable files receive no indicator.
       - R3.9: Executable is defined as having any execute bit set (owner, group, or other) in the file's permission mode.
       - R3.10: -F must work with all output formats (-l, -1, -C, -x) and with color output. When color is enabled, the indicator character is printed after the ANSI reset sequence so it is not colorized.

--- a/docs/specs/product-requirements/prd037-ln.yaml
+++ b/docs/specs/product-requirements/prd037-ln.yaml
@@ -35,7 +35,15 @@ requirements:
     items:
       - R3.1: -f or --force must remove existing destination files before creating the link.
       - R3.2: -n or --no-dereference must treat a destination that is a symlink to a directory as a regular file, rather than following it.
-      - R3.3: -i or --interactive must prompt the user on stderr before removing an existing destination, and must not remove if the user declines.
+      - R3.3: |
+          -i or --interactive must prompt the user on stderr before removing an existing
+          destination. Prompt format: 'ln: replace 'DEST'? ' where DEST is the destination
+          path. Read one line from stdin. If the response starts with 'y' or 'Y', proceed
+          with removal and link creation. Any other response (including empty) means decline;
+          do not remove the destination and do not create the link. Do not retry on invalid
+          input. When stdin is not a terminal (detected via os.Stdin.Fd() isatty check),
+          treat as decline (do not prompt, do not remove). When -f and -i are both given,
+          the last flag on the command line wins, matching GNU ln behavior.
       - R3.4: -v or --verbose must print the name of each link created to stdout.
       - R3.5: -b must create a backup of each existing destination file before removal, using the default backup suffix '~'. --backup=METHOD must accept numbered, existing, simple, and none as backup methods.
       - R3.6: -S SUFFIX or --suffix=SUFFIX must use SUFFIX instead of '~' for backup file names.


### PR DESCRIPTION
## Summary

- **prd037-ln R3.3**: Flesh out `-i/--interactive` with exact prompt format (`ln: replace 'DEST'? `), accepted input (y/Y prefix = yes, else decline), non-terminal behavior (treat as decline), and `-f/-i` last-flag-wins precedence. The vague requirement caused the generator to parse the flag without implementing prompting.
- **prd008-ls R3.7**: Remove inline `humanSize` algorithm that contradicted the DRY constitution rule. Point to `pkg/format.HumanSize` consistent with R3.5.

## Test plan

- [ ] Verify prd037-ln R3.3 is unambiguous — a generator can implement it without guessing
- [ ] Verify prd008-ls R3.7 no longer contains inline code or "do not call pkg/format" directive
- [ ] Next generation run produces cmd/ln with working `-i` flag
- [ ] Next generation run produces cmd/ls without duplicated humanSize logic

Companion issue for constitution changes: petar-djukic/cobbler-scaffold#1583

Closes #2608

🤖 Generated with [Claude Code](https://claude.com/claude-code)