### PR TITLE
Add golangci-lint config for function size and duplication limits

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,15 @@
+linters:
+  enable:
+    - funlen
+    - dupl
+    - gocognit
+
+linters-settings:
+  funlen:
+    lines: -1
+    statements: 40
+    ignore-comments: true
+  dupl:
+    threshold: 100
+  gocognit:
+    min-complexity: 15


### PR DESCRIPTION
## Summary

- Enable **funlen** with `statements: 40` (lines check disabled) to enforce the 40-statement function limit mechanically
- Enable **dupl** with `threshold: 100` tokens to catch copy-pasted logic blocks
- Enable **gocognit** with `min-complexity: 15` to flag hard-to-follow functions

PRD acceptance criteria already require "compiles with no warnings under golangci-lint" (e.g. AC19 in prd008-ls). These linters turn prose constitution rules into hard failures the generator must fix before a task passes.

## Test plan

- [ ] `golangci-lint run ./...` passes on current codebase (specs-only, no Go to lint)
- [ ] Next generation run produces functions under 40 statements
- [ ] Next generation run avoids duplicated logic blocks

Closes #2610

🤖 Generated with [Claude Code](https://claude.com/claude-code)