### PR TITLE
GH-1410: Post-generation repository cleanup

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -45,7 +45,7 @@ generation:
 cobbler:
     dir: .cobbler/
     max_stitch_issues_per_cycle: 1
-    max_measure_issues: 3
+    max_measure_issues: 1
     measure_prompt: docs/prompts/measure.yaml
     stitch_prompt: docs/prompts/stitch.yaml
     planning_constitution: docs/constitutions/planning.yaml


### PR DESCRIPTION
## Summary

Post-run-35 audit. Fixed 2 issues: reset max_measure_issues from 3 (test value) to 1, deleted 2 stale branches from run 34. All other checks passed.

## Changes

- `configuration.yaml`: max_measure_issues 3 → 1
- Deleted local branches: `generation-gh-1400-run34`, `task/gh-1400-generate-run34-2453`

## Test plan

- [x] All checklist items verified (see issue comment)
- [x] `mage analyze` passes

Closes #1410

🤖 Generated with [Claude Code](https://claude.com/claude-code)