### PR TITLE
GH-2627: Post-generation repository cleanup (run 36)

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -44,8 +44,8 @@ generation:
     cycles: 6
 cobbler:
     dir: .cobbler/
-    max_stitch_issues_per_cycle: 3
-    max_measure_issues: 3
+    max_stitch_issues_per_cycle: 1
+    max_measure_issues: 1
     measure_prompt: docs/prompts/measure.yaml
     stitch_prompt: docs/prompts/stitch.yaml
     planning_constitution: docs/constitutions/planning.yaml


### PR DESCRIPTION
## Summary

Post-generation cleanup after aborted run 36 (multi-issue measure investigation). Reset test configuration values and removed a stale task branch.

## Changes

- Reset `max_measure_issues` and `max_stitch_issues_per_cycle` from 3 to 1 in `configuration.yaml`
- Deleted stale `task/generation-gh-2626-run36-2649` branch
- Filed cobbler-scaffold#1608 for generator worktree improvements

## Test plan

- [x] `mage analyze` passes with 0 errors
- [x] Full cleanup checklist verified (source, spec, git, GitHub, config)

Closes #2627