### PR TITLE
GH-2655: Upgrade cobbler-scaffold v0.20260317.2 → v0.20260322.0

### DIFF
--- a/docs/constitutions/design.yaml
+++ b/docs/constitutions/design.yaml
@@ -134,6 +134,19 @@ document_types:
       requirement_groups: "R1, R2, R3, ..."
       requirement_items: "R1.1, R1.2, R2.1, ..."
       requirement_id_format: "R{group}.{item} — numeric dotted only (e.g., R1.1, R2.3). Letter suffixes (R2a) are not valid and are flagged by mage analyze."
+      requirement_weight: |
+        Each R-item may optionally specify a weight indicating implementation
+        complexity. Weight is a positive integer with no upper bound, default 1.
+        The measure agent uses weights to batch requirements into tasks that fit
+        within the max_weight_per_task budget. Two YAML formats are supported:
+
+        Simple (weight defaults to 1):
+          - R1.1: Must accept -f flag
+
+        Weighted:
+          - R6.1:
+              text: Must scan each input line for known timestamp patterns
+              weight: 3
       acceptance_criteria_ids: "AC1, AC2, AC3, ... (sequential within each PRD)"
     acceptance_criteria_schema:
       description: |

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260317.2
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260322.0
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260317.2 h1:+qDvfRE+V1mG4hsZjdupmPvu2DoagpDATTp79/FSUOo=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260317.2/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260322.0 h1:PekTrDBsxHfAmHZMCZvJUUqme4eoL0w9Yc/4JzmbQAk=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260322.0/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Summary

Upgrades cobbler-scaffold from v0.20260317.2 to v0.20260322.0. Adds `requirement_weight` documentation to the design constitution, enabling variable batch sizing for measure agent tasks (cobbler-scaffold#1832).

## Changes

- `magefiles/go.mod` + `go.sum`: bumped cobbler-scaffold dependency
- `docs/constitutions/design.yaml`: added `requirement_weight` schema documentation

## Stats

- Go LOC: 0 (sources reset after generation run 37, no delta)
- Spec words: PRD 54,666 / use case 21,688 / test suite 21,499

## Test plan

- [x] `mage analyze` passes (same pre-existing issues as main)
- [x] Scaffolded files match v0.20260322.0
- [x] Local customizations preserved (configuration.yaml unchanged)

Closes #2655