### PR TITLE
GH-3134: Add requirement_weight to all PRD requirement items

### DIFF
--- a/docs/specs/product-requirements/prd001-testutils.yaml
+++ b/docs/specs/product-requirements/prd001-testutils.yaml
@@ -50,92 +50,136 @@ requirements:
   R1:
     title: Test case data structure
     items:
-      - R1.1: |
-          Must define DiffTest as the following named struct in package testutils:
+      - R1.1:
+          text: |
+            Must define DiffTest as the following named struct in package testutils:
 
-            type DiffTest struct {
-                Name          string                 // subtest name used with t.Run; required
-                Args          []string               // command-line arguments passed to both binaries
-                Stdin         []byte                 // nil = no stdin (both binaries receive EOF immediately)
-                Env           []string               // nil = use defaults only (LC_ALL=C); non-nil = KEY=VALUE pairs merged into inherited environment
-                WorkDir       string                 // empty = per-test t.TempDir(); non-empty = use this directory for both binaries
-                ExitCode      int                    // expected exit code for both binaries
-                Normalize     []func([]byte) []byte  // applied in order to stdout and stderr of both binaries before comparison; nil or empty = no normalization
-                ExpectedFiles map[string][]byte      // optional: path -> expected byte content after execution, for file-output utilities (sponge, cp)
-            }
-      - R1.2: DiffTest.Stdin nil means both binaries receive EOF immediately on stdin. An empty non-nil slice ([]byte{}) also produces no bytes but is semantically distinct (open stdin that is immediately closed).
-      - R1.3: |
-          DiffTest.Env nil means both binaries inherit the test process environment with
-          default overrides applied (see R2.6). When non-nil, the KEY=VALUE pairs in the
-          slice are merged into the inherited environment: matching keys are overridden, new
-          keys are added. This merge behavior matches the struct comment ("override or
-          extend") and avoids requiring callers to replicate the full environment for a
-          single override.
-      - R1.4: Must define type NormalizeFunc = func([]byte) []byte as a named type alias in package testutils. The Normalize field in DiffTest uses this element type. When the slice is nil or empty, no normalization is applied to stdout or stderr.
+              type DiffTest struct {
+                  Name          string                 // subtest name used with t.Run; required
+                  Args          []string               // command-line arguments passed to both binaries
+                  Stdin         []byte                 // nil = no stdin (both binaries receive EOF immediately)
+                  Env           []string               // nil = use defaults only (LC_ALL=C); non-nil = KEY=VALUE pairs merged into inherited environment
+                  WorkDir       string                 // empty = per-test t.TempDir(); non-empty = use this directory for both binaries
+                  ExitCode      int                    // expected exit code for both binaries
+                  Normalize     []func([]byte) []byte  // applied in order to stdout and stderr of both binaries before comparison; nil or empty = no normalization
+                  ExpectedFiles map[string][]byte      // optional: path -> expected byte content after execution, for file-output utilities (sponge, cp)
+              }
+          weight: 1
+      - R1.2:
+          text: DiffTest.Stdin nil means both binaries receive EOF immediately on stdin. An empty non-nil slice ([]byte{}) also produces no bytes but is semantically distinct (open stdin that is immediately closed).
+          weight: 1
+      - R1.3:
+          text: |
+            DiffTest.Env nil means both binaries inherit the test process environment with
+            default overrides applied (see R2.6). When non-nil, the KEY=VALUE pairs in the
+            slice are merged into the inherited environment: matching keys are overridden, new
+            keys are added. This merge behavior matches the struct comment ("override or
+            extend") and avoids requiring callers to replicate the full environment for a
+            single override.
+          weight: 1
+      - R1.4:
+          text: Must define type NormalizeFunc = func([]byte) []byte as a named type alias in package testutils. The Normalize field in DiffTest uses this element type. When the slice is nil or empty, no normalization is applied to stdout or stderr.
+          weight: 1
 
   R2:
     title: Binary execution
     items:
-      - R2.1: |
-          Must provide func RunDiffTests(t *testing.T, goBinary, refBinary string, tests []DiffTest) that accepts the path to the Go binary under test (goBinary) and the GNU reference binary (refBinary), then runs each DiffTest as a named subtest via t.Run(test.Name, ...). Both binaries are invoked with identical Args, Stdin, and Env for each test case.
-      - R2.2: Must capture stdout, stderr, and exit code from each binary independently.
-      - R2.3: Must impose a configurable timeout on each binary invocation. The default timeout must be 10 seconds. The test fails if either binary exceeds the timeout.
-      - R2.4: Must not write any output to the test process stdout or stderr during a passing test run.
-      - R2.5: |
-          Must support passing a working directory to each binary invocation via a WorkDir
-          field on DiffTest. When WorkDir is empty, both binaries run in a per-test temporary
-          directory created by the harness via t.TempDir(). The harness must use the same
-          working directory for both binaries in a given test case. The DiffTest struct gains:
+      - R2.1:
+          text: |
+            Must provide func RunDiffTests(t *testing.T, goBinary, refBinary string, tests []DiffTest) that accepts the path to the Go binary under test (goBinary) and the GNU reference binary (refBinary), then runs each DiffTest as a named subtest via t.Run(test.Name, ...). Both binaries are invoked with identical Args, Stdin, and Env for each test case.
+          weight: 1
+      - R2.2:
+          text: Must capture stdout, stderr, and exit code from each binary independently.
+          weight: 1
+      - R2.3:
+          text: Must impose a configurable timeout on each binary invocation. The default timeout must be 10 seconds. The test fails if either binary exceeds the timeout.
+          weight: 1
+      - R2.4:
+          text: Must not write any output to the test process stdout or stderr during a passing test run.
+          weight: 1
+      - R2.5:
+          text: |
+            Must support passing a working directory to each binary invocation via a WorkDir
+            field on DiffTest. When WorkDir is empty, both binaries run in a per-test temporary
+            directory created by the harness via t.TempDir(). The harness must use the same
+            working directory for both binaries in a given test case. The DiffTest struct gains:
 
-            WorkDir string // empty = per-test t.TempDir(); non-empty = use this directory for both binaries
-      - R2.6: |
-          Must set LC_ALL=C in the environment for both binaries unless the DiffTest.Env
-          explicitly overrides LC_ALL. This ensures deterministic sort order and formatting
-          across locales. The harness applies this default before merging DiffTest.Env.
+              WorkDir string // empty = per-test t.TempDir(); non-empty = use this directory for both binaries
+          weight: 1
+      - R2.6:
+          text: |
+            Must set LC_ALL=C in the environment for both binaries unless the DiffTest.Env
+            explicitly overrides LC_ALL. This ensures deterministic sort order and formatting
+            across locales. The harness applies this default before merging DiffTest.Env.
+          weight: 1
 
   R3:
     title: Comparison and reporting
     items:
-      - R3.1: Must apply the DiffTest.Normalize function (if non-nil) to both binaries' stdout and stderr before comparison.
-      - R3.2: Must compare normalized stdout byte-for-byte. Any difference must be reported as a test failure.
-      - R3.3: Must compare normalized stderr byte-for-byte. Any difference must be reported as a test failure.
-      - R3.4: Must compare exit codes exactly. A difference must be reported as a test failure.
-      - R3.5: 'Must report divergence with the following information in the failure message: the DiffTest args, the stdin content (truncated to 256 bytes if longer), the reference binary stdout, the Go binary stdout, the reference stderr, the Go stderr, and both exit codes.'
-      - R3.6: Must run each DiffTest as a named subtest (t.Run) so individual test case failures are identifiable in go test output.
+      - R3.1:
+          text: Must apply the DiffTest.Normalize function (if non-nil) to both binaries' stdout and stderr before comparison.
+          weight: 1
+      - R3.2:
+          text: Must compare normalized stdout byte-for-byte. Any difference must be reported as a test failure.
+          weight: 1
+      - R3.3:
+          text: Must compare normalized stderr byte-for-byte. Any difference must be reported as a test failure.
+          weight: 1
+      - R3.4:
+          text: Must compare exit codes exactly. A difference must be reported as a test failure.
+          weight: 1
+      - R3.5:
+          text: 'Must report divergence with the following information in the failure message: the DiffTest args, the stdin content (truncated to 256 bytes if longer), the reference binary stdout, the Go binary stdout, the reference stderr, the Go stderr, and both exit codes.'
+          weight: 1
+      - R3.6:
+          text: Must run each DiffTest as a named subtest (t.Run) so individual test case failures are identifiable in go test output.
+          weight: 1
 
   R4:
     title: Normalization hooks
     items:
-      - R4.1: Must allow per-DiffTest normalization via the Normalize field. The function receives the raw output bytes and returns the normalized bytes.
-      - R4.2: Must provide a built-in TimestampNormalizer that replaces common strftime timestamp patterns with a fixed placeholder string. This normalizer is used by cmd/ts tests.
-      - R4.3: |
-          Must allow normalizers to be composed: the harness must accept a slice of Normalize
-          functions applied in order, not a single function. When the slice is nil or empty,
-          no normalization is applied.
-      - R4.4: |
-          Must provide func ComposeNormalizers(fns ...NormalizeFunc) NormalizeFunc that returns
-          a single NormalizeFunc applying the given functions in order. This is a convenience
-          for cmd/ test files that combine multiple normalizers:
+      - R4.1:
+          text: Must allow per-DiffTest normalization via the Normalize field. The function receives the raw output bytes and returns the normalized bytes.
+          weight: 1
+      - R4.2:
+          text: Must provide a built-in TimestampNormalizer that replaces common strftime timestamp patterns with a fixed placeholder string. This normalizer is used by cmd/ts tests.
+          weight: 1
+      - R4.3:
+          text: |
+            Must allow normalizers to be composed: the harness must accept a slice of Normalize
+            functions applied in order, not a single function. When the slice is nil or empty,
+            no normalization is applied.
+          weight: 1
+      - R4.4:
+          text: |
+            Must provide func ComposeNormalizers(fns ...NormalizeFunc) NormalizeFunc that returns
+            a single NormalizeFunc applying the given functions in order. This is a convenience
+            for cmd/ test files that combine multiple normalizers:
 
-            normalize := testutils.ComposeNormalizers(
-                testutils.TimestampNormalizer,
-                customNormalizer,
-            )
+              normalize := testutils.ComposeNormalizers(
+                  testutils.TimestampNormalizer,
+                  customNormalizer,
+              )
+          weight: 1
 
   R5:
     title: File-state comparison
     items:
-      - R5.1: |
-          Must support utilities whose primary output is a file rather than stdout (sponge,
-          cp, mv). DiffTest.ExpectedFiles is a map[string][]byte where keys are file paths
-          relative to the working directory and values are the expected byte content after
-          execution. When ExpectedFiles is non-nil, the harness checks each entry after both
-          binaries complete.
-      - R5.2: |
-          Must compare each ExpectedFiles entry byte-for-byte against the file produced by
-          the Go binary. Any difference must be reported as a test failure with the same
-          format as stdout divergence: file path, expected content (from reference), actual
-          content (from Go binary). Missing files must also be reported as failures.
+      - R5.1:
+          text: |
+            Must support utilities whose primary output is a file rather than stdout (sponge,
+            cp, mv). DiffTest.ExpectedFiles is a map[string][]byte where keys are file paths
+            relative to the working directory and values are the expected byte content after
+            execution. When ExpectedFiles is non-nil, the harness checks each entry after both
+            binaries complete.
+          weight: 1
+      - R5.2:
+          text: |
+            Must compare each ExpectedFiles entry byte-for-byte against the file produced by
+            the Go binary. Any difference must be reported as a test failure with the same
+            format as stdout divergence: file path, expected content (from reference), actual
+            content (from Go binary). Missing files must also be reported as failures.
+          weight: 1
 
 non_goals:
   - pkg/testutils does not build or compile the Go binaries under test.

--- a/docs/specs/product-requirements/prd002-sys.yaml
+++ b/docs/specs/product-requirements/prd002-sys.yaml
@@ -24,60 +24,92 @@ requirements:
   R1:
     title: Terminal width and TTY detection
     items:
-      - R1.1: Must provide func TerminalWidth() (int, error) that returns the current terminal column count by calling ioctl(TIOCGWINSZ) on stdout. Returns an error (not panic) when stdout is not a terminal or when ioctl fails.
-      - R1.2: Must use golang.org/x/sys/unix (the project's only external dependency) to perform the TIOCGWINSZ ioctl; must not shell out to tput or stty and must not import golang.org/x/term.
-      - R1.3: |
-          Must provide func IsTerminal(fd uintptr) bool that returns true when the file
-          descriptor refers to a terminal, and false otherwise. Implementation: call
-          golang.org/x/sys/unix.IoctlGetWinsize(int(fd), unix.TIOCGWINSZ) and return
-          err == nil. Returns false for pipes, regular files, and non-terminal descriptors.
-          The caller (pkg/format ColorEnabled) is responsible for extracting the fd from an
-          io.Writer via type assertion to *os.File. Required by pkg/format to suppress color
-          output when stdout is redirected.
-      - R1.4: 'Utility context — ls (ls.c:2281): ls uses struct winsize to determine column count for its default multi-column layout and for the -w/--width flag default.'
-      - R1.5: |
-          Must provide func InstallSIGPIPEHandler() that installs a SIGPIPE handler causing the
-          process to exit 0 when stdout or stderr is closed by a downstream consumer.
-          Implementation: use signal.Notify(c, syscall.SIGPIPE) with a buffered channel of
-          size 1; in a dedicated goroutine call os.Exit(0) when the channel receives. Must not
-          use signal.Ignore so that deferred cleanup functions do not run on SIGPIPE (matching
-          GNU behavior where SIGPIPE terminates silently).
-      - R1.6: InstallSIGPIPEHandler must be safe to call multiple times; only one goroutine per invocation is started.
-      - R1.7: 'Utility context — ls (ls.c:1600-1620): ls installs a SIGPIPE handler via sigaction so that piping ls output to head does not produce a broken-pipe error message. du, find, and xargs have the same requirement.'
+      - R1.1:
+          text: Must provide func TerminalWidth() (int, error) that returns the current terminal column count by calling ioctl(TIOCGWINSZ) on stdout. Returns an error (not panic) when stdout is not a terminal or when ioctl fails.
+          weight: 1
+      - R1.2:
+          text: Must use golang.org/x/sys/unix (the project's only external dependency) to perform the TIOCGWINSZ ioctl; must not shell out to tput or stty and must not import golang.org/x/term.
+          weight: 1
+      - R1.3:
+          text: |
+            Must provide func IsTerminal(fd uintptr) bool that returns true when the file
+            descriptor refers to a terminal, and false otherwise. Implementation: call
+            golang.org/x/sys/unix.IoctlGetWinsize(int(fd), unix.TIOCGWINSZ) and return
+            err == nil. Returns false for pipes, regular files, and non-terminal descriptors.
+            The caller (pkg/format ColorEnabled) is responsible for extracting the fd from an
+            io.Writer via type assertion to *os.File. Required by pkg/format to suppress color
+            output when stdout is redirected.
+          weight: 1
+      - R1.4:
+          text: 'Utility context — ls (ls.c:2281): ls uses struct winsize to determine column count for its default multi-column layout and for the -w/--width flag default.'
+          weight: 1
+      - R1.5:
+          text: |
+            Must provide func InstallSIGPIPEHandler() that installs a SIGPIPE handler causing the
+            process to exit 0 when stdout or stderr is closed by a downstream consumer.
+            Implementation: use signal.Notify(c, syscall.SIGPIPE) with a buffered channel of
+            size 1; in a dedicated goroutine call os.Exit(0) when the channel receives. Must not
+            use signal.Ignore so that deferred cleanup functions do not run on SIGPIPE (matching
+            GNU behavior where SIGPIPE terminates silently).
+          weight: 1
+      - R1.6:
+          text: InstallSIGPIPEHandler must be safe to call multiple times; only one goroutine per invocation is started.
+          weight: 1
+      - R1.7:
+          text: 'Utility context — ls (ls.c:1600-1620): ls installs a SIGPIPE handler via sigaction so that piping ls output to head does not produce a broken-pipe error message. du, find, and xargs have the same requirement.'
+          weight: 1
 
   R2:
     title: Extended file metadata
     items:
-      - R2.1: Must provide func Stat(path string) (*FileInfo, error) and func Lstat(path string) (*FileInfo, error). Stat follows symbolic links (equivalent to os.Stat); Lstat does not follow symbolic links (equivalent to os.Lstat). Both return a *FileInfo populated from syscall.Stat_t.
-      - R2.2: |
-          FileInfo must be defined as the following named struct in package sys:
+      - R2.1:
+          text: Must provide func Stat(path string) (*FileInfo, error) and func Lstat(path string) (*FileInfo, error). Stat follows symbolic links (equivalent to os.Stat); Lstat does not follow symbolic links (equivalent to os.Lstat). Both return a *FileInfo populated from syscall.Stat_t.
+          weight: 1
+      - R2.2:
+          text: |
+            FileInfo must be defined as the following named struct in package sys:
 
-            type FileInfo struct {
-                Mode    os.FileMode // file mode and type bits (from syscall.Stat_t.Mode)
-                Size    int64       // apparent file size in bytes (st_size)
-                Nlink   uint64      // hard-link count (st_nlink)
-                Uid     uint32      // owner user ID (st_uid)
-                Gid     uint32      // owner group ID (st_gid)
-                Rdev    uint64      // device ID for special files (st_rdev)
-                Dev     uint64      // device ID of the containing filesystem (st_dev)
-                Ino     uint64      // inode number (st_ino)
-                Blocks  int64       // number of 512-byte blocks allocated (st_blocks)
-                Blksize int64       // preferred I/O block size (st_blksize)
-                ModTime time.Time   // modification time (st_mtime / st_mtimespec)
-                Info    os.FileInfo // underlying os.FileInfo for os package compatibility
-            }
-      - R2.3: Must abstract the Darwin/Linux divergence in struct field names (st_mtimespec on Darwin vs st_mtim on Linux; st_blocks interpretation) so callers use a single API regardless of target platform.
-      - R2.4: 'Utility context — ls (ls.c:213, 371): ls needs Nlink, Uid, Gid, Rdev, Mode for -l format; Blocks for -s; Ino for -i.'
-      - R2.5: 'Utility context — du (du.c:554): du needs Dev and Ino for hard-link deduplication, and Blocks for physical block-count accumulation.'
-      - R2.6: 'Utility context — find (find/ftsfind.c:172): find predicates (-type, -size, -newer, -perm, -uid, -gid) require Mode, Size, ModTime, Uid, Gid, Nlink from the stat struct.'
+              type FileInfo struct {
+                  Mode    os.FileMode // file mode and type bits (from syscall.Stat_t.Mode)
+                  Size    int64       // apparent file size in bytes (st_size)
+                  Nlink   uint64      // hard-link count (st_nlink)
+                  Uid     uint32      // owner user ID (st_uid)
+                  Gid     uint32      // owner group ID (st_gid)
+                  Rdev    uint64      // device ID for special files (st_rdev)
+                  Dev     uint64      // device ID of the containing filesystem (st_dev)
+                  Ino     uint64      // inode number (st_ino)
+                  Blocks  int64       // number of 512-byte blocks allocated (st_blocks)
+                  Blksize int64       // preferred I/O block size (st_blksize)
+                  ModTime time.Time   // modification time (st_mtime / st_mtimespec)
+                  Info    os.FileInfo // underlying os.FileInfo for os package compatibility
+              }
+          weight: 1
+      - R2.3:
+          text: Must abstract the Darwin/Linux divergence in struct field names (st_mtimespec on Darwin vs st_mtim on Linux; st_blocks interpretation) so callers use a single API regardless of target platform.
+          weight: 1
+      - R2.4:
+          text: 'Utility context — ls (ls.c:213, 371): ls needs Nlink, Uid, Gid, Rdev, Mode for -l format; Blocks for -s; Ino for -i.'
+          weight: 1
+      - R2.5:
+          text: 'Utility context — du (du.c:554): du needs Dev and Ino for hard-link deduplication, and Blocks for physical block-count accumulation.'
+          weight: 1
+      - R2.6:
+          text: 'Utility context — find (find/ftsfind.c:172): find predicates (-type, -size, -newer, -perm, -uid, -gid) require Mode, Size, ModTime, Uid, Gid, Nlink from the stat struct.'
+          weight: 1
 
   R3:
     title: SIGWINCH handling
     items:
-      - R3.1: |
-          Must provide func OnTerminalResize(callback func(width int)) that registers a SIGWINCH handler. When the terminal is resized, the handler calls TerminalWidth() and invokes the callback with the new width. If TerminalWidth() returns an error the callback is not invoked.
-      - R3.2: Must support multiple calls to OnTerminalResize; each registered callback must be called on resize. Callbacks are called in registration order.
-      - R3.3: 'Utility context — ls (ls.c:2281, SIGWINCH registration): ls re-queries terminal width on SIGWINCH to re-format output when the terminal window is resized during a long listing.'
+      - R3.1:
+          text: |
+            Must provide func OnTerminalResize(callback func(width int)) that registers a SIGWINCH handler. When the terminal is resized, the handler calls TerminalWidth() and invokes the callback with the new width. If TerminalWidth() returns an error the callback is not invoked.
+          weight: 1
+      - R3.2:
+          text: Must support multiple calls to OnTerminalResize; each registered callback must be called on resize. Callbacks are called in registration order.
+          weight: 1
+      - R3.3:
+          text: 'Utility context — ls (ls.c:2281, SIGWINCH registration): ls re-queries terminal width on SIGWINCH to re-format output when the terminal window is resized during a long listing.'
+          weight: 1
 
 non_goals:
   - pkg/sys does not wrap all of syscall or golang.org/x/sys; it exposes only the surfaces required by the current utility batch.

--- a/docs/specs/product-requirements/prd003-format.yaml
+++ b/docs/specs/product-requirements/prd003-format.yaml
@@ -23,47 +23,81 @@ requirements:
   R1:
     title: Column alignment
     items:
-      - R1.1: Must provide a Columns(entries []string, termWidth int) [][]string function that distributes entries into the maximum number of columns that fit within termWidth, using the longest entry in each column to determine column width.
-      - R1.2: Must provide a PadRight(s string, width int) string and PadLeft(s string, width int) string function for left- and right-aligned field padding within a fixed-width column.
-      - R1.3: 'Must treat multi-byte Unicode characters correctly: column width must be computed from display width (rune count via utf8.RuneCountInString), not byte count. East-asian full-width character handling is deferred; rune count is sufficient for ASCII-dominant utility output in the current roadmap.'
-      - R1.4: 'Utility context — ls (ls.c multi-column layout): ls default output places filenames in as many columns as fit in the terminal width. Column widths are computed from the longest filename in each column, not the global maximum.'
+      - R1.1:
+          text: Must provide a Columns(entries []string, termWidth int) [][]string function that distributes entries into the maximum number of columns that fit within termWidth, using the longest entry in each column to determine column width.
+          weight: 1
+      - R1.2:
+          text: Must provide a PadRight(s string, width int) string and PadLeft(s string, width int) string function for left- and right-aligned field padding within a fixed-width column.
+          weight: 1
+      - R1.3:
+          text: 'Must treat multi-byte Unicode characters correctly: column width must be computed from display width (rune count via utf8.RuneCountInString), not byte count. East-asian full-width character handling is deferred; rune count is sufficient for ASCII-dominant utility output in the current roadmap.'
+          weight: 1
+      - R1.4:
+          text: 'Utility context — ls (ls.c multi-column layout): ls default output places filenames in as many columns as fit in the terminal width. Column widths are computed from the longest filename in each column, not the global maximum.'
+          weight: 1
 
   R2:
     title: ANSI color
     items:
-      - R2.1: Must provide a FileTypeColor(mode os.FileMode) string function that returns the ANSI escape sequence for a file's type (directory, symlink, executable, block device, character device, socket, pipe, regular file).
-      - R2.2: Must provide a Reset() string constant or function that returns the ANSI reset sequence ("\033[0m").
-      - R2.3: |
-          Must provide a ColorEnabled(w io.Writer) bool function that returns true only when w is a TTY. Implementation: attempt a type assertion to *os.File; if it fails return false; call pkg/sys.IsTerminal(f.Fd()) which returns true when the file descriptor is a terminal (detected via TIOCGWINSZ ioctl), and false for pipes, regular files, and non-terminal descriptors. When ColorEnabled returns false, FileTypeColor must return an empty string and Reset must return an empty string.
-      - R2.4: 'Must use the same color assignments as GNU ls LS_COLORS defaults: directory=34 (blue), symlink=36 (cyan), executable=32 (green), block device=33;1 (yellow bold), character device=33;1 (yellow bold), socket=35 (magenta), pipe=33 (yellow), regular=0 (reset/default).'
-      - R2.5: 'Utility context — ls (ls.c:103 includes dircolors.h, ls.c:273 get_color_indicator): ls outputs ANSI escapes before and after each filename in colorized mode. Color is suppressed when stdout is not a TTY or when --color=never is set.'
-      - R2.6: |
-          Must provide func SetColorEnabled(enabled bool) that overrides the automatic TTY
-          detection from ColorEnabled. When set to true, FileTypeColor and Reset return ANSI
-          sequences regardless of whether stdout is a TTY. When set to false, they return
-          empty strings regardless. This supports --color=always and --color=never flags in
-          utilities like ls. The override is process-global.
-      - R2.7: |
-          Must provide func ResetColorEnabled() that clears any override set by
-          SetColorEnabled, reverting to automatic TTY detection via ColorEnabled. Utilities
-          must call ResetColorEnabled in deferred cleanup or test teardown to avoid leaking
-          the override across test cases.
+      - R2.1:
+          text: Must provide a FileTypeColor(mode os.FileMode) string function that returns the ANSI escape sequence for a file's type (directory, symlink, executable, block device, character device, socket, pipe, regular file).
+          weight: 1
+      - R2.2:
+          text: Must provide a Reset() string constant or function that returns the ANSI reset sequence ("\033[0m").
+          weight: 1
+      - R2.3:
+          text: |
+            Must provide a ColorEnabled(w io.Writer) bool function that returns true only when w is a TTY. Implementation: attempt a type assertion to *os.File; if it fails return false; call pkg/sys.IsTerminal(f.Fd()) which returns true when the file descriptor is a terminal (detected via TIOCGWINSZ ioctl), and false for pipes, regular files, and non-terminal descriptors. When ColorEnabled returns false, FileTypeColor must return an empty string and Reset must return an empty string.
+          weight: 1
+      - R2.4:
+          text: 'Must use the same color assignments as GNU ls LS_COLORS defaults: directory=34 (blue), symlink=36 (cyan), executable=32 (green), block device=33;1 (yellow bold), character device=33;1 (yellow bold), socket=35 (magenta), pipe=33 (yellow), regular=0 (reset/default).'
+          weight: 1
+      - R2.5:
+          text: 'Utility context — ls (ls.c:103 includes dircolors.h, ls.c:273 get_color_indicator): ls outputs ANSI escapes before and after each filename in colorized mode. Color is suppressed when stdout is not a TTY or when --color=never is set.'
+          weight: 1
+      - R2.6:
+          text: |
+            Must provide func SetColorEnabled(enabled bool) that overrides the automatic TTY
+            detection from ColorEnabled. When set to true, FileTypeColor and Reset return ANSI
+            sequences regardless of whether stdout is a TTY. When set to false, they return
+            empty strings regardless. This supports --color=always and --color=never flags in
+            utilities like ls. The override is process-global.
+          weight: 1
+      - R2.7:
+          text: |
+            Must provide func ResetColorEnabled() that clears any override set by
+            SetColorEnabled, reverting to automatic TTY detection via ColorEnabled. Utilities
+            must call ResetColorEnabled in deferred cleanup or test teardown to avoid leaking
+            the override across test cases.
+          weight: 1
 
   R3:
     title: Human-readable size conversion
     items:
-      - R3.1: |
-          Must provide func HumanSize(bytes int64, opts HumanSizeOpts) string that converts a byte count to a human-readable string. HumanSizeOpts is defined as:
+      - R3.1:
+          text: |
+            Must provide func HumanSize(bytes int64, opts HumanSizeOpts) string that converts a byte count to a human-readable string. HumanSizeOpts is defined as:
 
-            type HumanSizeOpts struct {
-                Binary bool // true = 1024-based with suffixes K/M/G/T/P/E (default); false = SI 1000-based with suffixes kB/MB/GB/TB
-            }
-      - R3.2: |
-          When opts.Binary is true (the default zero value), use base 1024 and suffixes []string{"", "K", "M", "G", "T", "P", "E"}. When opts.Binary is false, use base 1000 and suffixes []string{"", "kB", "MB", "GB", "TB"}.
-      - R3.3: Must format the output to at most one decimal place when the value is not an integer at the chosen unit (e.g., 1536 bytes must produce "1.5K", not "2K").
-      - R3.4: Must return "0" for a zero byte count regardless of the unit mode.
-      - R3.5: 'Utility context — ls (ls.c -h flag, human_output_opts): ls -h shows file sizes in human-readable form in -l output. The same conversion applies to ls -s (block counts).'
-      - R3.6: 'Utility context — du (du.c:153 human_output_opts, du.c:442 human_readable()): du -h outputs directory sizes as human-readable strings. du uses the same binary/SI distinction as ls -h.'
+              type HumanSizeOpts struct {
+                  Binary bool // true = 1024-based with suffixes K/M/G/T/P/E (default); false = SI 1000-based with suffixes kB/MB/GB/TB
+              }
+          weight: 1
+      - R3.2:
+          text: |
+            When opts.Binary is true (the default zero value), use base 1024 and suffixes []string{"", "K", "M", "G", "T", "P", "E"}. When opts.Binary is false, use base 1000 and suffixes []string{"", "kB", "MB", "GB", "TB"}.
+          weight: 1
+      - R3.3:
+          text: Must format the output to at most one decimal place when the value is not an integer at the chosen unit (e.g., 1536 bytes must produce "1.5K", not "2K").
+          weight: 1
+      - R3.4:
+          text: Must return "0" for a zero byte count regardless of the unit mode.
+          weight: 1
+      - R3.5:
+          text: 'Utility context — ls (ls.c -h flag, human_output_opts): ls -h shows file sizes in human-readable form in -l output. The same conversion applies to ls -s (block counts).'
+          weight: 1
+      - R3.6:
+          text: 'Utility context — du (du.c:153 human_output_opts, du.c:442 human_readable()): du -h outputs directory sizes as human-readable strings. du uses the same binary/SI distinction as ls -h.'
+          weight: 1
 
 non_goals:
   - pkg/format does not read or parse LS_COLORS environment variables; it uses GNU ls defaults only.

--- a/docs/specs/product-requirements/prd004-ts.yaml
+++ b/docs/specs/product-requirements/prd004-ts.yaml
@@ -21,42 +21,82 @@ requirements:
   R1:
     title: Default behavior (no flags)
     items:
-      - R1.1: Must read stdin line by line (newline-delimited). Each line must be written to stdout prefixed by a timestamp and a single space.
-      - R1.2: The default timestamp format must be "%b %d %H:%M:%S" (strftime, e.g. "Feb 19 14:05:32"). The format must be evaluated at the time each line is received, not at startup.
-      - R1.3: Must flush stdout after each line so that downstream consumers receive timestamps in real time.
-      - R1.4: Must preserve the original newline at the end of each line; must not add an extra newline.
-      - R1.5: Must pass through partial lines (lines not terminated by a newline at EOF) with a timestamp prefix.
-      - R1.6: Exit code must be 0 after stdin is closed with EOF. Must not exit non-zero due to SIGPIPE when stdout is closed by a downstream consumer.
+      - R1.1:
+          text: Must read stdin line by line (newline-delimited). Each line must be written to stdout prefixed by a timestamp and a single space.
+          weight: 1
+      - R1.2:
+          text: The default timestamp format must be "%b %d %H:%M:%S" (strftime, e.g. "Feb 19 14:05:32"). The format must be evaluated at the time each line is received, not at startup.
+          weight: 1
+      - R1.3:
+          text: Must flush stdout after each line so that downstream consumers receive timestamps in real time.
+          weight: 1
+      - R1.4:
+          text: Must preserve the original newline at the end of each line; must not add an extra newline.
+          weight: 1
+      - R1.5:
+          text: Must pass through partial lines (lines not terminated by a newline at EOF) with a timestamp prefix.
+          weight: 1
+      - R1.6:
+          text: Exit code must be 0 after stdin is closed with EOF. Must not exit non-zero due to SIGPIPE when stdout is closed by a downstream consumer.
+          weight: 1
 
   R2:
     title: Custom format string
     items:
-      - R2.1: Must accept an optional positional argument specifying a custom strftime format string, e.g. "ts '%Y-%m-%dT%H:%M:%S'".
-      - R2.2: Must support all standard strftime(3) conversion specifications available on the target platform.
-      - R2.3: 'Must support three ts-specific subsecond extensions: %.S (seconds with microsecond suffix, e.g. "32.001234"), %.s (Unix epoch with microsecond suffix, e.g. "1708358732.001234"), %.T (HH:MM:SS with microsecond suffix, e.g. "14:05:32.001234"). These extensions require Time::HiRes in the Perl reference; the Go implementation must use time.Now() sub-nanosecond precision formatted to six decimal places.'
-      - R2.4: When a subsecond extension is used in the format string, must obtain both the second and microsecond components atomically from a single time sample per line.
+      - R2.1:
+          text: Must accept an optional positional argument specifying a custom strftime format string, e.g. "ts '%Y-%m-%dT%H:%M:%S'".
+          weight: 1
+      - R2.2:
+          text: Must support all standard strftime(3) conversion specifications available on the target platform.
+          weight: 1
+      - R2.3:
+          text: 'Must support three ts-specific subsecond extensions: %.S (seconds with microsecond suffix, e.g. "32.001234"), %.s (Unix epoch with microsecond suffix, e.g. "1708358732.001234"), %.T (HH:MM:SS with microsecond suffix, e.g. "14:05:32.001234"). These extensions require Time::HiRes in the Perl reference; the Go implementation must use time.Now() sub-nanosecond precision formatted to six decimal places.'
+          weight: 1
+      - R2.4:
+          text: When a subsecond extension is used in the format string, must obtain both the second and microsecond components atomically from a single time sample per line.
+          weight: 1
 
   R3:
     title: Incremental mode (-i)
     items:
-      - R3.1: -i must change the timestamp to the time elapsed since the previous line was received. The first line's timestamp is the time elapsed since ts started.
-      - R3.2: The default format in -i mode must be "%H:%M:%S". The TZ environment must be set to GMT so that strftime on a delta-second value produces a correct elapsed string (e.g., 5 seconds since last line → "00:00:05").
-      - R3.3: A custom format argument overrides the -i default format. The TZ=GMT behavior still applies.
-      - R3.4: -i and -s are mutually exclusive; passing both must print a usage error to stderr and exit non-zero.
+      - R3.1:
+          text: -i must change the timestamp to the time elapsed since the previous line was received. The first line's timestamp is the time elapsed since ts started.
+          weight: 1
+      - R3.2:
+          text: The default format in -i mode must be "%H:%M:%S". The TZ environment must be set to GMT so that strftime on a delta-second value produces a correct elapsed string (e.g., 5 seconds since last line → "00:00:05").
+          weight: 1
+      - R3.3:
+          text: A custom format argument overrides the -i default format. The TZ=GMT behavior still applies.
+          weight: 1
+      - R3.4:
+          text: -i and -s are mutually exclusive; passing both must print a usage error to stderr and exit non-zero.
+          weight: 1
 
   R4:
     title: Elapsed-since-start mode (-s)
     items:
-      - R4.1: -s must change the timestamp to the time elapsed since ts started, increasing monotonically across lines (unlike -i which resets per line).
-      - R4.2: The default format in -s mode must be "%H:%M:%S" with TZ=GMT, same as -i.
-      - R4.3: A custom format argument overrides the -s default format.
+      - R4.1:
+          text: -s must change the timestamp to the time elapsed since ts started, increasing monotonically across lines (unlike -i which resets per line).
+          weight: 1
+      - R4.2:
+          text: The default format in -s mode must be "%H:%M:%S" with TZ=GMT, same as -i.
+          weight: 1
+      - R4.3:
+          text: A custom format argument overrides the -s default format.
+          weight: 1
 
   R5:
     title: Monotonic clock mode (-m)
     items:
-      - R5.1: -m must use the system's monotonic clock (CLOCK_MONOTONIC via time.Now() in Go, which automatically uses the monotonic reading) instead of the wall clock for timestamp sampling.
-      - R5.2: -m is compatible with all format modes (-i, -s, default) and with custom format strings including subsecond extensions.
-      - R5.3: When -m is active, the timestamp must not jump backwards or exhibit discontinuities if the wall clock is adjusted (e.g., by NTP) while ts is running.
+      - R5.1:
+          text: -m must use the system's monotonic clock (CLOCK_MONOTONIC via time.Now() in Go, which automatically uses the monotonic reading) instead of the wall clock for timestamp sampling.
+          weight: 1
+      - R5.2:
+          text: -m is compatible with all format modes (-i, -s, default) and with custom format strings including subsecond extensions.
+          weight: 1
+      - R5.3:
+          text: When -m is active, the timestamp must not jump backwards or exhibit discontinuities if the wall clock is adjusted (e.g., by NTP) while ts is running.
+          weight: 1
 
   # R6 (relative-time conversion mode) deferred to release 99.0.
   # Repeatedly exceeded the 15-minute stitch timeout in run 37 due to
@@ -65,22 +105,34 @@ requirements:
   R7:
     title: Exit codes and error handling
     items:
-      - R7.1: Must exit 0 on clean EOF from stdin.
-      - R7.2: Must exit non-zero and print a usage message to stderr when an unrecognized flag is given.
+      - R7.1:
+          text: Must exit 0 on clean EOF from stdin.
+          weight: 1
+      - R7.2:
+          text: Must exit non-zero and print a usage message to stderr when an unrecognized flag is given.
+          weight: 1
       # R7.3 deferred with R6 (references -r mode)
 
   R8:
     title: Environment
     items:
-      - R8.1: Must respect the TZ environment variable to determine the local time zone for wall-clock timestamps (non -i/-s modes). Setting TZ=UTC must cause timestamps to be in UTC.
-      - R8.2: In -i and -s modes, must use TZ=GMT internally for elapsed-time formatting regardless of the user's TZ setting, matching the Perl source behavior.
+      - R8.1:
+          text: Must respect the TZ environment variable to determine the local time zone for wall-clock timestamps (non -i/-s modes). Setting TZ=UTC must cause timestamps to be in UTC.
+          weight: 1
+      - R8.2:
+          text: In -i and -s modes, must use TZ=GMT internally for elapsed-time formatting regardless of the user's TZ setting, matching the Perl source behavior.
+          weight: 1
 
   R9:
     title: Differential testing
     items:
-      - R9.1: |
-          Differential tests must use testutils.TimestampNormalizer (type func([]byte) []byte, defined in pkg/testutils) to replace wall-clock timestamps in output with a fixed placeholder before comparing Go and reference binary outputs. Pass it in the DiffTest.Normalize slice. The normalizer matches strftime-formatted patterns such as "Feb 19 14:05:32" and replaces them with a fixed string so that wall-clock differences do not cause test failures.
-      - R9.2: 'Tests must cover: default format, custom strftime format, -s mode, -i mode, -m mode (with monotonic normalization), multi-line stdin, empty stdin, and partial last line (no trailing newline).'
+      - R9.1:
+          text: |
+            Differential tests must use testutils.TimestampNormalizer (type func([]byte) []byte, defined in pkg/testutils) to replace wall-clock timestamps in output with a fixed placeholder before comparing Go and reference binary outputs. Pass it in the DiffTest.Normalize slice. The normalizer matches strftime-formatted patterns such as "Feb 19 14:05:32" and replaces them with a fixed string so that wall-clock differences do not cause test failures.
+          weight: 1
+      - R9.2:
+          text: 'Tests must cover: default format, custom strftime format, -s mode, -i mode, -m mode (with monotonic normalization), multi-line stdin, empty stdin, and partial last line (no trailing newline).'
+          weight: 1
 
 non_goals:
   - cmd/ts does not implement egrep-style timestamp colorization.

--- a/docs/specs/product-requirements/prd005-wc.yaml
+++ b/docs/specs/product-requirements/prd005-wc.yaml
@@ -18,48 +18,92 @@ requirements:
   R1:
     title: Default behavior (no flags)
     items:
-      - R1.1: When no flags are given, must print line count, word count, and byte count (in that order) for each input, matching the wc.c default (print_lines = print_words = print_bytes = true; set at wc.c:862).
-      - R1.2: Must read from stdin when no file arguments are given. Must read from each named file in order when file arguments are given.
-      - R1.3: Output for each file must be on a single line with counts followed by the filename. For stdin input, no filename is printed.
-      - R1.4: When more than one file is given, must print a final "total" line with the sum of all counts.
+      - R1.1:
+          text: When no flags are given, must print line count, word count, and byte count (in that order) for each input, matching the wc.c default (print_lines = print_words = print_bytes = true; set at wc.c:862).
+          weight: 1
+      - R1.2:
+          text: Must read from stdin when no file arguments are given. Must read from each named file in order when file arguments are given.
+          weight: 1
+      - R1.3:
+          text: Output for each file must be on a single line with counts followed by the filename. For stdin input, no filename is printed.
+          weight: 1
+      - R1.4:
+          text: When more than one file is given, must print a final "total" line with the sum of all counts.
+          weight: 1
 
   R2:
     title: Flag behavior
     items:
-      - R2.1: -l must count newline characters (not logical lines). A file with no trailing newline has a newline count equal to the number of complete lines.
-      - R2.2: -w must count words, where a word is a maximal sequence of non-whitespace characters. Whitespace is determined by the locale-sensitive isspace() equivalent in Go (unicode.IsSpace).
-      - R2.3: -c must count bytes. -c and -m are mutually exclusive in output but may be passed together; -m takes precedence when both are given (matching wc.c behavior where print_chars overrides print_bytes display).
-      - R2.4: -m must count characters (Unicode code points), not bytes. When the input is valid UTF-8, this is the rune count. When the input contains invalid UTF-8, each invalid byte counts as one character.
-      - R2.5: -L must print the length of the longest line in the input, measured in display columns (tab-expanded, treating each tab as advancing to the next multiple of 8). -L is independent of other flags and may be combined with any of them.
-      - R2.6: 'When flags are combined, must print each requested count in the order: lines (-l), words (-w), chars (-m) or bytes (-c), max-line-length (-L). This is the fixed output column order from wc.c:237-247, not the flag order given by the user.'
+      - R2.1:
+          text: -l must count newline characters (not logical lines). A file with no trailing newline has a newline count equal to the number of complete lines.
+          weight: 1
+      - R2.2:
+          text: -w must count words, where a word is a maximal sequence of non-whitespace characters. Whitespace is determined by the locale-sensitive isspace() equivalent in Go (unicode.IsSpace).
+          weight: 1
+      - R2.3:
+          text: -c must count bytes. -c and -m are mutually exclusive in output but may be passed together; -m takes precedence when both are given (matching wc.c behavior where print_chars overrides print_bytes display).
+          weight: 1
+      - R2.4:
+          text: -m must count characters (Unicode code points), not bytes. When the input is valid UTF-8, this is the rune count. When the input contains invalid UTF-8, each invalid byte counts as one character.
+          weight: 1
+      - R2.5:
+          text: -L must print the length of the longest line in the input, measured in display columns (tab-expanded, treating each tab as advancing to the next multiple of 8). -L is independent of other flags and may be combined with any of them.
+          weight: 1
+      - R2.6:
+          text: 'When flags are combined, must print each requested count in the order: lines (-l), words (-w), chars (-m) or bytes (-c), max-line-length (-L). This is the fixed output column order from wc.c:237-247, not the flag order given by the user.'
+          weight: 1
 
   R3:
     title: Multi-file output and column alignment
     items:
-      - R3.1: When multiple files are given, each line must right-align counts in columns wide enough for the largest count in that column across all files. This matches GNU wc's dynamic column-width behavior.
-      - R3.2: The total line must use the label "total" (not a filename). The counts in the total line must be the arithmetic sum of counts from all files.
-      - R3.3: Must support --total=auto (default), --total=always (print total even for one file), --total=only (print only the total, not per-file lines), and --total=never (never print total, even for multiple files).
+      - R3.1:
+          text: When multiple files are given, each line must right-align counts in columns wide enough for the largest count in that column across all files. This matches GNU wc's dynamic column-width behavior.
+          weight: 1
+      - R3.2:
+          text: The total line must use the label "total" (not a filename). The counts in the total line must be the arithmetic sum of counts from all files.
+          weight: 1
+      - R3.3:
+          text: Must support --total=auto (default), --total=always (print total even for one file), --total=only (print only the total, not per-file lines), and --total=never (never print total, even for multiple files).
+          weight: 1
 
   R4:
     title: Stdin and special inputs
     items:
-      - R4.1: Must treat "-" as a filename argument meaning stdin, consistent with POSIX convention.
-      - R4.2: Must handle binary input (arbitrary byte sequences) without corrupting output or panicking.
-      - R4.3: Must handle empty input (zero bytes) and produce "0 0 0" (or the selected subset of counts) correctly.
-      - R4.4: Must support --files0-from=FILE which reads NUL-delimited filenames from FILE and processes each. When FILE is "-", filenames are read from stdin.
+      - R4.1:
+          text: Must treat "-" as a filename argument meaning stdin, consistent with POSIX convention.
+          weight: 1
+      - R4.2:
+          text: Must handle binary input (arbitrary byte sequences) without corrupting output or panicking.
+          weight: 1
+      - R4.3:
+          text: Must handle empty input (zero bytes) and produce "0 0 0" (or the selected subset of counts) correctly.
+          weight: 1
+      - R4.4:
+          text: Must support --files0-from=FILE which reads NUL-delimited filenames from FILE and processes each. When FILE is "-", filenames are read from stdin.
+          weight: 1
 
   R5:
     title: Locale handling
     items:
-      - R5.1: Differential tests must set LC_ALL=C to avoid locale-dependent divergence between the Go and reference binary outputs for -m (character count). Document this constraint in the test suite.
-      - R5.2: Under LC_ALL=C, -m and -c must produce identical counts (each byte counts as one character). The Go implementation must produce the same result.
+      - R5.1:
+          text: Differential tests must set LC_ALL=C to avoid locale-dependent divergence between the Go and reference binary outputs for -m (character count). Document this constraint in the test suite.
+          weight: 1
+      - R5.2:
+          text: Under LC_ALL=C, -m and -c must produce identical counts (each byte counts as one character). The Go implementation must produce the same result.
+          weight: 1
 
   R6:
     title: Exit codes
     items:
-      - R6.1: Must exit 0 when all inputs are processed successfully.
-      - R6.2: Must exit 1 when any input file cannot be opened or read. Must still process and print counts for the files that were successfully read before exiting 1.
-      - R6.3: Must exit 1 when a write error occurs on stdout.
+      - R6.1:
+          text: Must exit 0 when all inputs are processed successfully.
+          weight: 1
+      - R6.2:
+          text: Must exit 1 when any input file cannot be opened or read. Must still process and print counts for the files that were successfully read before exiting 1.
+          weight: 1
+      - R6.3:
+          text: Must exit 1 when a write error occurs on stdout.
+          weight: 1
 
 non_goals:
   - cmd/wc does not implement -c with block-size adjustments (those belong to du).

--- a/docs/specs/product-requirements/prd006-cat.yaml
+++ b/docs/specs/product-requirements/prd006-cat.yaml
@@ -20,48 +20,98 @@ requirements:
   R1:
     title: Default behavior (no flags)
     items:
-      - R1.1: Must read each named file in argument order and write its contents verbatim to stdout.
-      - R1.2: Must read from stdin when no file arguments are given, or when "-" is given as a filename.
-      - R1.3: "Must support concatenating multiple files: each file's content is written in sequence with no separator."
-      - R1.4: "Must not corrupt binary input: output bytes must be identical to input bytes when no transformation flags are active."
-      - R1.5: Must not add or remove newlines from the input.
+      - R1.1:
+          text: Must read each named file in argument order and write its contents verbatim to stdout.
+          weight: 1
+      - R1.2:
+          text: Must read from stdin when no file arguments are given, or when "-" is given as a filename.
+          weight: 1
+      - R1.3:
+          text: "Must support concatenating multiple files: each file's content is written in sequence with no separator."
+          weight: 1
+      - R1.4:
+          text: "Must not corrupt binary input: output bytes must be identical to input bytes when no transformation flags are active."
+          weight: 1
+      - R1.5:
+          text: Must not add or remove newlines from the input.
+          weight: 1
 
   R2:
     title: Line numbering (-n, -b)
     items:
-      - R2.1: '-n must prepend a line number to every output line. The line number must be right-justified in a field of width 6, followed by a tab character and then the line content (format: "%6d\t%s"). Line numbering resets to 1 at the start of each cat invocation, not per file.'
-      - R2.2: -b must prepend a line number only to non-blank lines. Blank lines receive no number and no tab prefix. -b implies -n (activates line numbering) but overrides it by skipping blank lines.
-      - R2.3: When -b and -n are both given, -b takes precedence (blank lines are not numbered). This matches cat.c:602 where number_nonblank overrides number.
-      - R2.4: A blank line is a line containing only a newline character (zero non-newline bytes). Lines with spaces or tabs are not blank.
+      - R2.1:
+          text: '-n must prepend a line number to every output line. The line number must be right-justified in a field of width 6, followed by a tab character and then the line content (format: "%6d\t%s"). Line numbering resets to 1 at the start of each cat invocation, not per file.'
+          weight: 1
+      - R2.2:
+          text: -b must prepend a line number only to non-blank lines. Blank lines receive no number and no tab prefix. -b implies -n (activates line numbering) but overrides it by skipping blank lines.
+          weight: 1
+      - R2.3:
+          text: When -b and -n are both given, -b takes precedence (blank lines are not numbered). This matches cat.c:602 where number_nonblank overrides number.
+          weight: 1
+      - R2.4:
+          text: A blank line is a line containing only a newline character (zero non-newline bytes). Lines with spaces or tabs are not blank.
+          weight: 1
 
   R3:
     title: Blank-line squeezing (-s)
     items:
-      - R3.1: "-s must suppress repeated blank lines: when two or more consecutive blank lines appear in the output, only one must be written. The first blank line is written; subsequent consecutive blank lines are discarded."
-      - R3.2: "-s must apply across file boundaries when multiple files are concatenated: if the last line of file A and the first line of file B are both blank, they count as consecutive blank lines."
-      - R3.3: "-s is compatible with -n and -b. When combined, squeezing is applied before numbering: the suppressed blank lines do not consume line numbers."
+      - R3.1:
+          text: "-s must suppress repeated blank lines: when two or more consecutive blank lines appear in the output, only one must be written. The first blank line is written; subsequent consecutive blank lines are discarded."
+          weight: 1
+      - R3.2:
+          text: "-s must apply across file boundaries when multiple files are concatenated: if the last line of file A and the first line of file B are both blank, they count as consecutive blank lines."
+          weight: 1
+      - R3.3:
+          text: "-s is compatible with -n and -b. When combined, squeezing is applied before numbering: the suppressed blank lines do not consume line numbers."
+          weight: 1
 
   R4:
     title: Non-printing display (-v, -E, -T, -A, -e, -t)
     items:
-      - R4.1: '-v must display non-printing characters using caret notation and M- prefix. Control characters (0x00-0x1F except 0x09 tab and 0x0A newline) must be shown as ^X where X is the character 64 positions higher (e.g., 0x01 -> "^A", 0x1B -> "^["). Characters in the range 0x80-0x9F must be shown as "M-^X". Characters in the range 0xA0-0xFE must be shown as "M-X" where X is the character minus 0x80. The DEL character (0x7F) must be shown as "^?". 0xFF must be shown as "M-^?".'
-      - R4.2: -v must not alter tab (0x09) or newline (0x0A) characters. Those are the two control characters exempted from -v display.
-      - R4.3: -E must append a "$" character before each newline in the output. The newline itself is still written after the "$".
-      - R4.4: -T must display tab characters (0x09) as the two-character sequence "^I" rather than the tab character itself.
-      - R4.5: -A is equivalent to -v -E -T combined. All three transformations are active simultaneously.
-      - R4.6: -e is equivalent to -v -E combined (show non-printing, show ends).
-      - R4.7: -t is equivalent to -v -T combined (show non-printing, show tabs).
-      - R4.8: '-u is accepted but has no effect (cat.c:616: "we provide the -u feature unconditionally"). The flag must not produce an error.'
-      - R4.9: "Transformation flags are compatible with -n, -b, and -s. The order of application is: squeeze blanks (-s), then apply non-printing display (-v/-T), then append end-of-line marker (-E), then prepend line number (-n/-b)."
+      - R4.1:
+          text: '-v must display non-printing characters using caret notation and M- prefix. Control characters (0x00-0x1F except 0x09 tab and 0x0A newline) must be shown as ^X where X is the character 64 positions higher (e.g., 0x01 -> "^A", 0x1B -> "^["). Characters in the range 0x80-0x9F must be shown as "M-^X". Characters in the range 0xA0-0xFE must be shown as "M-X" where X is the character minus 0x80. The DEL character (0x7F) must be shown as "^?". 0xFF must be shown as "M-^?".'
+          weight: 1
+      - R4.2:
+          text: -v must not alter tab (0x09) or newline (0x0A) characters. Those are the two control characters exempted from -v display.
+          weight: 1
+      - R4.3:
+          text: -E must append a "$" character before each newline in the output. The newline itself is still written after the "$".
+          weight: 1
+      - R4.4:
+          text: -T must display tab characters (0x09) as the two-character sequence "^I" rather than the tab character itself.
+          weight: 1
+      - R4.5:
+          text: -A is equivalent to -v -E -T combined. All three transformations are active simultaneously.
+          weight: 1
+      - R4.6:
+          text: -e is equivalent to -v -E combined (show non-printing, show ends).
+          weight: 1
+      - R4.7:
+          text: -t is equivalent to -v -T combined (show non-printing, show tabs).
+          weight: 1
+      - R4.8:
+          text: '-u is accepted but has no effect (cat.c:616: "we provide the -u feature unconditionally"). The flag must not produce an error.'
+          weight: 1
+      - R4.9:
+          text: "Transformation flags are compatible with -n, -b, and -s. The order of application is: squeeze blanks (-s), then apply non-printing display (-v/-T), then append end-of-line marker (-E), then prepend line number (-n/-b)."
+          weight: 1
 
   R5:
     title: Error handling and exit codes
     items:
-      - R5.1: Must exit 0 when all inputs are processed successfully.
-      - R5.2: Must exit 1 when any input file cannot be opened. The error message must be written to stderr. cat must continue processing remaining file arguments after the error.
-      - R5.3: Must exit 1 when a write error occurs on stdout (e.g., SIGPIPE or full disk). The write error must be detected and reported; the process must not hang.
-      - R5.4: |
-          Must not exit non-zero due to SIGPIPE when stdout is closed by a downstream consumer. At startup, install a SIGPIPE handler: use signal.Notify(c, syscall.SIGPIPE) with a buffered channel of size 1; in a dedicated goroutine call os.Exit(0) when the channel receives. Do not use signal.Ignore (deferred cleanup functions must not run on SIGPIPE, matching GNU behavior).
+      - R5.1:
+          text: Must exit 0 when all inputs are processed successfully.
+          weight: 1
+      - R5.2:
+          text: Must exit 1 when any input file cannot be opened. The error message must be written to stderr. cat must continue processing remaining file arguments after the error.
+          weight: 1
+      - R5.3:
+          text: Must exit 1 when a write error occurs on stdout (e.g., SIGPIPE or full disk). The write error must be detected and reported; the process must not hang.
+          weight: 1
+      - R5.4:
+          text: |
+            Must not exit non-zero due to SIGPIPE when stdout is closed by a downstream consumer. At startup, install a SIGPIPE handler: use signal.Notify(c, syscall.SIGPIPE) with a buffered channel of size 1; in a dedicated goroutine call os.Exit(0) when the channel receives. Do not use signal.Ignore (deferred cleanup functions must not run on SIGPIPE, matching GNU behavior).
+          weight: 1
 
 non_goals:
   - cmd/cat does not implement the FIONREAD ioctl optimization from cat.c:298; it uses standard io.Copy which is sufficient for correctness.

--- a/docs/specs/product-requirements/prd007-sponge.yaml
+++ b/docs/specs/product-requirements/prd007-sponge.yaml
@@ -24,48 +24,92 @@ requirements:
   R1:
     title: Core soak-before-write contract
     items:
-      - R1.1: Must read all bytes from stdin before opening or creating the output file. Opening the output file before stdin is closed violates the core contract and is not permitted.
-      - R1.2: Must buffer stdin in memory using a dynamically grown buffer starting at 8192 bytes, doubling on overflow, matching sponge.c:BUFF_SIZE and the realloc loop at sponge.c:313-324.
-      - R1.3: "When the in-memory buffer would exceed the available memory threshold (derived from physmem_available() in the reference; in Go, use runtime.MemStats or a fixed fraction of RLIMIT_DATA), must spill the current buffer to a temp file and continue reading. The spill must be transparent: the final output is still a single concatenated byte stream."
-      - R1.4: Must create the temp file in the directory specified by the TMPDIR environment variable, or "/tmp" if TMPDIR is not set. The temp file name must follow the pattern "sponge.XXXXXX" (mkstemp-style random suffix).
-      - R1.5: "Must register a cleanup handler (atexit equivalent in Go: defer or os/signal) that deletes the temp file if the process exits or receives SIGINT, SIGTERM, SIGHUP, or SIGPIPE before the rename completes."
+      - R1.1:
+          text: Must read all bytes from stdin before opening or creating the output file. Opening the output file before stdin is closed violates the core contract and is not permitted.
+          weight: 1
+      - R1.2:
+          text: Must buffer stdin in memory using a dynamically grown buffer starting at 8192 bytes, doubling on overflow, matching sponge.c:BUFF_SIZE and the realloc loop at sponge.c:313-324.
+          weight: 1
+      - R1.3:
+          text: "When the in-memory buffer would exceed the available memory threshold (derived from physmem_available() in the reference; in Go, use runtime.MemStats or a fixed fraction of RLIMIT_DATA), must spill the current buffer to a temp file and continue reading. The spill must be transparent: the final output is still a single concatenated byte stream."
+          weight: 1
+      - R1.4:
+          text: Must create the temp file in the directory specified by the TMPDIR environment variable, or "/tmp" if TMPDIR is not set. The temp file name must follow the pattern "sponge.XXXXXX" (mkstemp-style random suffix).
+          weight: 1
+      - R1.5:
+          text: "Must register a cleanup handler (atexit equivalent in Go: defer or os/signal) that deletes the temp file if the process exits or receives SIGINT, SIGTERM, SIGHUP, or SIGPIPE before the rename completes."
+          weight: 1
 
   R2:
     title: Output file handling
     items:
-      - R2.1: When an output filename is given, must attempt an atomic rename of the temp file to the output filename when the output file is a regular file or does not yet exist (sponge.c:371-373).
-      - R2.2: When the rename fails (e.g., cross-device move), must fall back to a byte-for-byte copy of the temp file content to the output file, then delete the temp file.
-      - R2.3: When the output file already exists, must preserve its file mode (permissions) by reading the mode via lstat before writing and applying it to the output file via chmod (sponge.c:338-346). When the output file does not exist, must apply the default mode 0666 masked by the process umask.
-      - R2.4: "Must use lstat (not stat) to check whether the output path exists and is a regular file (sponge.c:332-333). This matters when the output path is a symlink: sponge must replace the symlink target, not follow it blindly."
-      - R2.5: The output file must never be in a partially-written state observable by other processes. Either the rename succeeds atomically or the copy completes before the old file is removed.
+      - R2.1:
+          text: When an output filename is given, must attempt an atomic rename of the temp file to the output filename when the output file is a regular file or does not yet exist (sponge.c:371-373).
+          weight: 1
+      - R2.2:
+          text: When the rename fails (e.g., cross-device move), must fall back to a byte-for-byte copy of the temp file content to the output file, then delete the temp file.
+          weight: 1
+      - R2.3:
+          text: When the output file already exists, must preserve its file mode (permissions) by reading the mode via lstat before writing and applying it to the output file via chmod (sponge.c:338-346). When the output file does not exist, must apply the default mode 0666 masked by the process umask.
+          weight: 1
+      - R2.4:
+          text: "Must use lstat (not stat) to check whether the output path exists and is a regular file (sponge.c:332-333). This matters when the output path is a symlink: sponge must replace the symlink target, not follow it blindly."
+          weight: 1
+      - R2.5:
+          text: The output file must never be in a partially-written state observable by other processes. Either the rename succeeds atomically or the copy completes before the old file is removed.
+          weight: 1
 
   R3:
     title: Append mode (-a)
     items:
-      - R3.1: "-a must cause sponge to prepend the existing content of the output file to the stdin content before writing. The result is: [original file content][stdin content] written to the output file."
-      - R3.2: -a applies only when the output file already exists and is a regular file. When the output file does not exist, -a behaves identically to the default mode (creates a new file with stdin content).
-      - R3.3: The prepend operation must copy the original file content into the temp file first, then append the stdin buffer to the temp file (sponge.c:352-357). The original file must be read before the temp file is renamed over it.
+      - R3.1:
+          text: "-a must cause sponge to prepend the existing content of the output file to the stdin content before writing. The result is: [original file content][stdin content] written to the output file."
+          weight: 1
+      - R3.2:
+          text: -a applies only when the output file already exists and is a regular file. When the output file does not exist, -a behaves identically to the default mode (creates a new file with stdin content).
+          weight: 1
+      - R3.3:
+          text: The prepend operation must copy the original file content into the temp file first, then append the stdin buffer to the temp file (sponge.c:352-357). The original file must be read before the temp file is renamed over it.
+          weight: 1
 
   R4:
     title: Passthrough mode (no output filename)
     items:
-      - R4.1: When no output filename is given, must write the buffered stdin content to stdout after stdin is fully consumed.
-      - R4.2: In passthrough mode with large input (temp file spill), must seek the temp file to the beginning and copy its content to stdout (sponge.c:403-406).
-      - R4.3: In passthrough mode with small input (buffer fits in memory), must write the in-memory buffer directly to stdout without creating or reading a temp file (sponge.c:408-411).
+      - R4.1:
+          text: When no output filename is given, must write the buffered stdin content to stdout after stdin is fully consumed.
+          weight: 1
+      - R4.2:
+          text: In passthrough mode with large input (temp file spill), must seek the temp file to the beginning and copy its content to stdout (sponge.c:403-406).
+          weight: 1
+      - R4.3:
+          text: In passthrough mode with small input (buffer fits in memory), must write the in-memory buffer directly to stdout without creating or reading a temp file (sponge.c:408-411).
+          weight: 1
 
   R5:
     title: Exit codes and error handling
     items:
-      - R5.1: Must exit 0 on success.
-      - R5.2: Must exit 1 when stdin cannot be read, when the temp file cannot be created or written, when the output file cannot be opened, or when the rename or copy fails. In all error cases, must print a descriptive error message to stderr via perror-equivalent before exiting.
-      - R5.3: Must exit 1 when memory allocation fails (buffer realloc). Must print an error and exit rather than panicking.
-      - R5.4: Must clean up the temp file on exit in all error paths. The temp file must not persist after the process exits, whether due to success or failure.
+      - R5.1:
+          text: Must exit 0 on success.
+          weight: 1
+      - R5.2:
+          text: Must exit 1 when stdin cannot be read, when the temp file cannot be created or written, when the output file cannot be opened, or when the rename or copy fails. In all error cases, must print a descriptive error message to stderr via perror-equivalent before exiting.
+          weight: 1
+      - R5.3:
+          text: Must exit 1 when memory allocation fails (buffer realloc). Must print an error and exit rather than panicking.
+          weight: 1
+      - R5.4:
+          text: Must clean up the temp file on exit in all error paths. The temp file must not persist after the process exits, whether due to success or failure.
+          weight: 1
 
   R6:
     title: Differential testing
     items:
-      - R6.1: Differential tests must compare the content of the output file (not stdout) after both the Go binary and the reference binary have exited, using file-content comparison provided by pkg/testutils.
-      - R6.2: "Tests must cover: small stdin (fits in memory), large stdin (forces temp file spill, tested with input larger than 1 MB), append mode, passthrough mode (no filename), output file does not exist, output file already exists (mode preservation), and the cross-device rename fallback (tested by placing the output file on a different filesystem from TMPDIR)."
+      - R6.1:
+          text: Differential tests must compare the content of the output file (not stdout) after both the Go binary and the reference binary have exited, using file-content comparison provided by pkg/testutils.
+          weight: 1
+      - R6.2:
+          text: "Tests must cover: small stdin (fits in memory), large stdin (forces temp file spill, tested with input larger than 1 MB), append mode, passthrough mode (no filename), output file does not exist, output file already exists (mode preservation), and the cross-device rename fallback (tested by placing the output file on a different filesystem from TMPDIR)."
+          weight: 1
 
 non_goals:
   - cmd/sponge does not implement interactive editing or prompt modes.

--- a/docs/specs/product-requirements/prd008-ls.yaml
+++ b/docs/specs/product-requirements/prd008-ls.yaml
@@ -25,119 +25,225 @@ requirements:
   R1:
     title: Output formats and layout (default, -1, -l, -C, -x)
     items:
-      - R1.1: |
-          When stdout is a TTY and no format flag is given, must produce multi-column output sorted vertically (down columns, then across). Terminal width is obtained by calling pkg/sys.TerminalWidth() (int, error) — returns the current terminal column count via TIOCGWINSZ ioctl on stdout; returns an error when stdout is not a terminal. Entries are laid out by calling pkg/format.Columns(entries []string, termWidth int) [][]string — distributes entries into the maximum number of columns fitting within termWidth, with column widths computed as per-column maxima of entry lengths.
-      - R1.2: When stdout is not a TTY (pipe, file redirect) and no format flag is given, must produce single-column output with one entry per line. This matches GNU ls behavior (ls.c detects stdout is not a TTY and sets format to single-column).
-      - R1.3: Must sort entries in the C locale order (LC_COLLATE=C). Differential tests must set LC_ALL=C to eliminate locale-dependent sort divergence.
-      - R1.4: Must not list entries whose names start with "." unless -a or -A is given. This is the default filter behavior matching GNU ls.
-      - R1.5: -1 must produce single-column output with one entry per line regardless of whether stdout is a TTY. This overrides the default multi-column layout.
-      - R1.6: |
-          -l flag skeleton and permission string. When -l is given, produce long-format output. Field order (left to right): permissions (10 chars), nlink, owner, group, size, mtime, name. Fields separated by a single space. Numeric fields (nlink, size) are right-aligned in columns wide enough for the largest value in the listing.
+      - R1.1:
+          text: |
+            When stdout is a TTY and no format flag is given, must produce multi-column output sorted vertically (down columns, then across). Terminal width is obtained by calling pkg/sys.TerminalWidth() (int, error) — returns the current terminal column count via TIOCGWINSZ ioctl on stdout; returns an error when stdout is not a terminal. Entries are laid out by calling pkg/format.Columns(entries []string, termWidth int) [][]string — distributes entries into the maximum number of columns fitting within termWidth, with column widths computed as per-column maxima of entry lengths.
+          weight: 1
+      - R1.2:
+          text: When stdout is not a TTY (pipe, file redirect) and no format flag is given, must produce single-column output with one entry per line. This matches GNU ls behavior (ls.c detects stdout is not a TTY and sets format to single-column).
+          weight: 1
+      - R1.3:
+          text: Must sort entries in the C locale order (LC_COLLATE=C). Differential tests must set LC_ALL=C to eliminate locale-dependent sort divergence.
+          weight: 1
+      - R1.4:
+          text: Must not list entries whose names start with "." unless -a or -A is given. This is the default filter behavior matching GNU ls.
+          weight: 1
+      - R1.5:
+          text: -1 must produce single-column output with one entry per line regardless of whether stdout is a TTY. This overrides the default multi-column layout.
+          weight: 1
+      - R1.6:
+          text: |
+            -l flag skeleton and permission string. When -l is given, produce long-format output. Field order (left to right): permissions (10 chars), nlink, owner, group, size, mtime, name. Fields separated by a single space. Numeric fields (nlink, size) are right-aligned in columns wide enough for the largest value in the listing.
 
-          Permission string algorithm (10 characters):
-          - Position 0 (file type): 'd' for directory (fi.Mode&os.ModeDir != 0), 'l' for symlink (fi.Mode&os.ModeSymlink != 0), 'c' for char device (fi.Mode&os.ModeDevice != 0 && fi.Mode&os.ModeCharDevice != 0), 'b' for block device (fi.Mode&os.ModeDevice != 0 && fi.Mode&os.ModeCharDevice == 0), 'p' for FIFO (fi.Mode&os.ModeNamedPipe != 0), 's' for socket (fi.Mode&os.ModeSocket != 0), '-' for regular file.
-          - Positions 1-3 (owner rwx): 'r'/'- ' for bit 0o400, 'w'/'-' for 0o200, 'x'/'-' for 0o100. If setuid (fi.Mode&os.ModeSetuid != 0): replace 'x' with 's', or replace '-' with 'S'.
-          - Positions 4-6 (group rwx): bits 0o040, 0o020, 0o010. If setgid (fi.Mode&os.ModeSetgid != 0): replace 'x' with 's', or replace '-' with 'S'.
-          - Positions 7-9 (other rwx): bits 0o004, 0o002, 0o001. If sticky (fi.Mode&os.ModeSticky != 0): replace 'x' with 't', or replace '-' with 'T'.
-      - R1.7: |
-          File metadata via pkg/sys.Lstat. Obtain metadata for each listed entry by calling pkg/sys.Lstat(path string) (*sys.FileInfo, error) — does not follow symbolic links; returns the symlink's own metadata when path is a symlink.
+            Permission string algorithm (10 characters):
+            - Position 0 (file type): 'd' for directory (fi.Mode&os.ModeDir != 0), 'l' for symlink (fi.Mode&os.ModeSymlink != 0), 'c' for char device (fi.Mode&os.ModeDevice != 0 && fi.Mode&os.ModeCharDevice != 0), 'b' for block device (fi.Mode&os.ModeDevice != 0 && fi.Mode&os.ModeCharDevice == 0), 'p' for FIFO (fi.Mode&os.ModeNamedPipe != 0), 's' for socket (fi.Mode&os.ModeSocket != 0), '-' for regular file.
+            - Positions 1-3 (owner rwx): 'r'/'- ' for bit 0o400, 'w'/'-' for 0o200, 'x'/'-' for 0o100. If setuid (fi.Mode&os.ModeSetuid != 0): replace 'x' with 's', or replace '-' with 'S'.
+            - Positions 4-6 (group rwx): bits 0o040, 0o020, 0o010. If setgid (fi.Mode&os.ModeSetgid != 0): replace 'x' with 's', or replace '-' with 'S'.
+            - Positions 7-9 (other rwx): bits 0o004, 0o002, 0o001. If sticky (fi.Mode&os.ModeSticky != 0): replace 'x' with 't', or replace '-' with 'T'.
+          weight: 1
+      - R1.7:
+          text: |
+            File metadata via pkg/sys.Lstat. Obtain metadata for each listed entry by calling pkg/sys.Lstat(path string) (*sys.FileInfo, error) — does not follow symbolic links; returns the symlink's own metadata when path is a symlink.
 
-          sys.FileInfo struct (embedded here for reference):
-            type FileInfo struct {
-                Mode    os.FileMode // file mode and type bits
-                Size    int64       // apparent file size in bytes (st_size)
-                Nlink   uint64      // hard-link count (st_nlink)
-                Uid     uint32      // owner user ID (st_uid)
-                Gid     uint32      // owner group ID (st_gid)
-                Rdev    uint64      // device ID for special files (st_rdev)
-                Dev     uint64      // device ID of the containing filesystem (st_dev)
-                Ino     uint64      // inode number (st_ino)
-                Blocks  int64       // number of 512-byte blocks allocated (st_blocks)
-                Blksize int64       // preferred I/O block size (st_blksize)
-                ModTime time.Time   // modification time
-                Sys     os.FileInfo // underlying os.FileInfo
-            }
+            sys.FileInfo struct (embedded here for reference):
+              type FileInfo struct {
+                  Mode    os.FileMode // file mode and type bits
+                  Size    int64       // apparent file size in bytes (st_size)
+                  Nlink   uint64      // hard-link count (st_nlink)
+                  Uid     uint32      // owner user ID (st_uid)
+                  Gid     uint32      // owner group ID (st_gid)
+                  Rdev    uint64      // device ID for special files (st_rdev)
+                  Dev     uint64      // device ID of the containing filesystem (st_dev)
+                  Ino     uint64      // inode number (st_ino)
+                  Blocks  int64       // number of 512-byte blocks allocated (st_blocks)
+                  Blksize int64       // preferred I/O block size (st_blksize)
+                  ModTime time.Time   // modification time
+                  Sys     os.FileInfo // underlying os.FileInfo
+              }
 
-          In long format: print fi.Nlink (uint64) right-aligned; print fi.Size (int64, bytes) right-aligned. Both columns sized to the widest value across all listed entries.
-      - R1.8: |
-          Owner and group name resolution in long format. Resolve owner name by calling os/user.LookupId(strconv.Itoa(int(fi.Uid))); on success use u.Username; on error (user not found or lookup fails) fall back to strconv.FormatUint(uint64(fi.Uid), 10). Resolve group name by calling os/user.LookupGroupId(strconv.Itoa(int(fi.Gid))); on success use g.Name; on error fall back to strconv.FormatUint(uint64(fi.Gid), 10). Owner and group fields are left-padded to column width for alignment.
-      - R1.9: |
-          Modification time formatting in long format. Use fi.ModTime (time.Time from sys.FileInfo). If time.Since(fi.ModTime) < 6*30*24*time.Hour (approximately six months), format as fi.ModTime.Format("Jan _2 15:04"). Otherwise format as fi.ModTime.Format("Jan _2  2006"). Both patterns produce a 12-character field.
-      - R1.10: |
-          Total block count line and symlink display. Before the directory listing, print "total N\n" where N = sum(fi.Blocks for all listed entries) / 2. The division converts 512-byte st_blocks units to 1K-block units matching GNU ls. N is a plain integer (no trailing suffix) unless -h is active (see R3).
+            In long format: print fi.Nlink (uint64) right-aligned; print fi.Size (int64, bytes) right-aligned. Both columns sized to the widest value across all listed entries.
+          weight: 1
+      - R1.8:
+          text: |
+            Owner and group name resolution in long format. Resolve owner name by calling os/user.LookupId(strconv.Itoa(int(fi.Uid))); on success use u.Username; on error (user not found or lookup fails) fall back to strconv.FormatUint(uint64(fi.Uid), 10). Resolve group name by calling os/user.LookupGroupId(strconv.Itoa(int(fi.Gid))); on success use g.Name; on error fall back to strconv.FormatUint(uint64(fi.Gid), 10). Owner and group fields are left-padded to column width for alignment.
+          weight: 1
+      - R1.9:
+          text: |
+            Modification time formatting in long format. Use fi.ModTime (time.Time from sys.FileInfo). If time.Since(fi.ModTime) < 6*30*24*time.Hour (approximately six months), format as fi.ModTime.Format("Jan _2 15:04"). Otherwise format as fi.ModTime.Format("Jan _2  2006"). Both patterns produce a 12-character field.
+          weight: 1
+      - R1.10:
+          text: |
+            Total block count line and symlink display. Before the directory listing, print "total N\n" where N = sum(fi.Blocks for all listed entries) / 2. The division converts 512-byte st_blocks units to 1K-block units matching GNU ls. N is a plain integer (no trailing suffix) unless -h is active (see R3).
 
-          Symlink display: when fi.Mode&os.ModeSymlink != 0, read the link target with os.Readlink(path) and append " -> " + target to the entry name field. Use Lstat (not Stat) so the symlink's own fi.Size and fi.Nlink are used, not the target's.
-      - R1.11: |
-          -C must force multi-column output regardless of whether stdout is a TTY. Layout uses pkg/format.Columns(entries []string, termWidth int) [][]string. When stdout is not a TTY, -C must use a default width of 80 columns (matching GNU ls behavior when stdout is not a TTY and -C is given without -w).
-      - R1.12: -C must sort entries vertically (down columns, then across to the next column). This is the same sort direction as the default multi-column mode in R1.1.
-      - R1.13: -x must produce multi-column output with entries sorted horizontally (across columns, then down to the next row). This differs from -C which sorts vertically.
-      - R1.14: -C and -x are mutually exclusive with -l and -1. If -l or -1 appears after -C or -x on the command line, it overrides the multi-column mode. If -C or -x appears after -l or -1, it overrides the long or single-column format. The last format flag wins, matching GNU ls behavior.
+            Symlink display: when fi.Mode&os.ModeSymlink != 0, read the link target with os.Readlink(path) and append " -> " + target to the entry name field. Use Lstat (not Stat) so the symlink's own fi.Size and fi.Nlink are used, not the target's.
+          weight: 1
+      - R1.11:
+          text: |
+            -C must force multi-column output regardless of whether stdout is a TTY. Layout uses pkg/format.Columns(entries []string, termWidth int) [][]string. When stdout is not a TTY, -C must use a default width of 80 columns (matching GNU ls behavior when stdout is not a TTY and -C is given without -w).
+          weight: 1
+      - R1.12:
+          text: -C must sort entries vertically (down columns, then across to the next column). This is the same sort direction as the default multi-column mode in R1.1.
+          weight: 1
+      - R1.13:
+          text: -x must produce multi-column output with entries sorted horizontally (across columns, then down to the next row). This differs from -C which sorts vertically.
+          weight: 1
+      - R1.14:
+          text: -C and -x are mutually exclusive with -l and -1. If -l or -1 appears after -C or -x on the command line, it overrides the multi-column mode. If -C or -x appears after -l or -1, it overrides the long or single-column format. The last format flag wins, matching GNU ls behavior.
+          weight: 1
 
   R2:
     title: Filtering, sorting, and metadata display (-a, -A, -d, -t, -S, -r, -U, -v, -i, -s, -n)
     items:
-      - R2.1: -a must include entries whose names start with "." including the special entries "." and ".." in the listing.
-      - R2.2: -A must include entries whose names start with "." except for "." and "..". -A is the "almost all" filter.
-      - R2.3: -d must list directory entries themselves rather than their contents. When a directory is given as an argument with -d, must print the directory name (or its long-format entry with -l) without descending into it.
-      - R2.4: When both -a and -A are given, the last one on the command line takes precedence, matching GNU ls behavior.
-      - R2.5: |
-          -t must sort entries by modification time, newest first. Obtain metadata via pkg/sys.Lstat(path string) (*sys.FileInfo, error); use sys.FileInfo.ModTime time.Time for comparison (fi.ModTime.After(fj.ModTime) for newest-first ordering). Entries with the same modification time must be sorted by name in C locale order as a tiebreaker.
-      - R2.6: |
-          -S must sort entries by file size (st_size), largest first. Obtain file size from sys.FileInfo.Size int64 — apparent file size in bytes (st_size). Entries with the same size must be sorted by name in C locale order as a tiebreaker.
-      - R2.7: -r must reverse the current sort order. -r applies to whichever sort is active (name sort by default, -t for time, -S for size, -v for version). -r with the default sort produces reverse alphabetical order.
-      - R2.8: -U must disable sorting entirely and list entries in directory order (the order returned by readdir). -U overrides -t, -S, and -v. -r with -U has no defined effect (directory order is not reversible in a meaningful way), but must be accepted without error.
-      - R2.9: -v must sort entries using natural version sort semantics (strverscmp behavior). Runs of digits within filenames are compared numerically rather than lexicographically, so "file2" sorts before "file10". Must be implemented without external libraries.
-      - R2.10: When multiple sort flags are given, the last one on the command line takes precedence, matching GNU ls behavior.
-      - R2.11: |
-          -i must prepend the inode number of each entry before the entry name (or before the permissions in -l mode). Obtain the inode number via pkg/sys.Lstat(path string) (*sys.FileInfo, error) and read sys.FileInfo.Ino uint64 — inode number (st_ino). The inode number is right-aligned in a column wide enough for the largest inode in the listing.
-      - R2.12: |
-          -s must prepend the allocated block count for each entry before the entry name (or before the permissions in -l mode). Obtain the block count via pkg/sys.Lstat(path string) (*sys.FileInfo, error) and read sys.FileInfo.Blocks int64 — number of 512-byte blocks allocated (st_blocks). Report in 1024-byte block units: fi.Blocks / 2. The block count is right-aligned in a column wide enough for the largest count in the listing.
-      - R2.13: -s with -l must also modify the "total N" line to include block counts in the selected unit. The total is the sum of all listed entries' block allocations.
-      - R2.14: |
-          -n must activate long format (implies -l) and display numeric UID and GID instead of resolving owner and group names. Format UID as strconv.FormatUint(uint64(fi.Uid), 10) and GID as strconv.FormatUint(uint64(fi.Gid), 10), where fi.Uid uint32 and fi.Gid uint32 come from pkg/sys.Lstat. Do not call os/user.LookupId or os/user.LookupGroupId.
-      - R2.15: -i and -s may be combined. When both are given, inode is printed first, then block count, then the entry (or the long-format fields).
+      - R2.1:
+          text: -a must include entries whose names start with "." including the special entries "." and ".." in the listing.
+          weight: 1
+      - R2.2:
+          text: -A must include entries whose names start with "." except for "." and "..". -A is the "almost all" filter.
+          weight: 1
+      - R2.3:
+          text: -d must list directory entries themselves rather than their contents. When a directory is given as an argument with -d, must print the directory name (or its long-format entry with -l) without descending into it.
+          weight: 1
+      - R2.4:
+          text: When both -a and -A are given, the last one on the command line takes precedence, matching GNU ls behavior.
+          weight: 1
+      - R2.5:
+          text: |
+            -t must sort entries by modification time, newest first. Obtain metadata via pkg/sys.Lstat(path string) (*sys.FileInfo, error); use sys.FileInfo.ModTime time.Time for comparison (fi.ModTime.After(fj.ModTime) for newest-first ordering). Entries with the same modification time must be sorted by name in C locale order as a tiebreaker.
+          weight: 1
+      - R2.6:
+          text: |
+            -S must sort entries by file size (st_size), largest first. Obtain file size from sys.FileInfo.Size int64 — apparent file size in bytes (st_size). Entries with the same size must be sorted by name in C locale order as a tiebreaker.
+          weight: 1
+      - R2.7:
+          text: -r must reverse the current sort order. -r applies to whichever sort is active (name sort by default, -t for time, -S for size, -v for version). -r with the default sort produces reverse alphabetical order.
+          weight: 1
+      - R2.8:
+          text: -U must disable sorting entirely and list entries in directory order (the order returned by readdir). -U overrides -t, -S, and -v. -r with -U has no defined effect (directory order is not reversible in a meaningful way), but must be accepted without error.
+          weight: 1
+      - R2.9:
+          text: -v must sort entries using natural version sort semantics (strverscmp behavior). Runs of digits within filenames are compared numerically rather than lexicographically, so "file2" sorts before "file10". Must be implemented without external libraries.
+          weight: 1
+      - R2.10:
+          text: When multiple sort flags are given, the last one on the command line takes precedence, matching GNU ls behavior.
+          weight: 1
+      - R2.11:
+          text: |
+            -i must prepend the inode number of each entry before the entry name (or before the permissions in -l mode). Obtain the inode number via pkg/sys.Lstat(path string) (*sys.FileInfo, error) and read sys.FileInfo.Ino uint64 — inode number (st_ino). The inode number is right-aligned in a column wide enough for the largest inode in the listing.
+          weight: 1
+      - R2.12:
+          text: |
+            -s must prepend the allocated block count for each entry before the entry name (or before the permissions in -l mode). Obtain the block count via pkg/sys.Lstat(path string) (*sys.FileInfo, error) and read sys.FileInfo.Blocks int64 — number of 512-byte blocks allocated (st_blocks). Report in 1024-byte block units: fi.Blocks / 2. The block count is right-aligned in a column wide enough for the largest count in the listing.
+          weight: 1
+      - R2.13:
+          text: -s with -l must also modify the "total N" line to include block counts in the selected unit. The total is the sum of all listed entries' block allocations.
+          weight: 1
+      - R2.14:
+          text: |
+            -n must activate long format (implies -l) and display numeric UID and GID instead of resolving owner and group names. Format UID as strconv.FormatUint(uint64(fi.Uid), 10) and GID as strconv.FormatUint(uint64(fi.Gid), 10), where fi.Uid uint32 and fi.Gid uint32 come from pkg/sys.Lstat. Do not call os/user.LookupId or os/user.LookupGroupId.
+          weight: 1
+      - R2.15:
+          text: -i and -s may be combined. When both are given, inode is printed first, then block count, then the entry (or the long-format fields).
+          weight: 1
 
   R3:
     title: Display features (--color, -h, -F, -R)
     items:
-      - R3.1: Must support --color=always, --color=auto, and --color=never. When --color is given without a value, it must default to "always".
-      - R3.2: |
-          --color=auto must colorize output only when stdout is a TTY. TTY detection: call pkg/sys.IsTerminal(os.Stdout) — returns true when os.Stdout's file descriptor is a terminal (detected via golang.org/x/sys/unix.IoctlGetWinsize with TIOCGWINSZ), false otherwise. When stdout is not a TTY, --color=auto must behave like --color=never.
-      - R3.3: |
-          Colorized output uses GNU LS_COLORS default color assignments via pkg/format. Call pkg/format.FileTypeColor(mode os.FileMode) string to obtain the ANSI escape sequence for a given file type, and pkg/format.Reset() string for the reset sequence. Executable detection: fi.Mode&0o111 != 0 (any execute bit set). Each entry name is wrapped as: colorCode + name + resetCode. When color is suppressed, both codes are empty strings so no ANSI sequences appear in output.
+      - R3.1:
+          text: Must support --color=always, --color=auto, and --color=never. When --color is given without a value, it must default to "always".
+          weight: 1
+      - R3.2:
+          text: |
+            --color=auto must colorize output only when stdout is a TTY. TTY detection: call pkg/sys.IsTerminal(os.Stdout) — returns true when os.Stdout's file descriptor is a terminal (detected via golang.org/x/sys/unix.IoctlGetWinsize with TIOCGWINSZ), false otherwise. When stdout is not a TTY, --color=auto must behave like --color=never.
+          weight: 1
+      - R3.3:
+          text: |
+            Colorized output uses GNU LS_COLORS default color assignments via pkg/format. Call pkg/format.FileTypeColor(mode os.FileMode) string to obtain the ANSI escape sequence for a given file type, and pkg/format.Reset() string for the reset sequence. Executable detection: fi.Mode&0o111 != 0 (any execute bit set). Each entry name is wrapped as: colorCode + name + resetCode. When color is suppressed, both codes are empty strings so no ANSI sequences appear in output.
 
-          Set the process-global color mode based on the --color flag value: call pkg/format.SetColorEnabled(true) for --color=always, pkg/format.SetColorEnabled(false) for --color=never. For --color=auto, call pkg/sys.IsTerminal(os.Stdout.Fd()) and pass the result to pkg/format.SetColorEnabled. When color is disabled, pkg/format.FileTypeColor returns empty strings.
-      - R3.4: When --color=never or when color is suppressed (non-TTY with auto), must not emit any ANSI escape sequences in the output.
-      - R3.5: |
-          -h must only take effect with -l (long format). When -h is given with -l, file sizes (fi.Size int64) must be displayed via pkg/format.HumanSize(bytes int64, opts HumanSizeOpts) string with opts.Binary = true (1024-base units, suffixes K/M/G/T/P/E). Without -l, -h must have no visible effect on output.
-      - R3.6: -h must also apply to the "total N" block count line in long format. When -h is active, convert the total block count (sum(fi.Blocks)/2 as int64) to a human-readable string using the same binary algorithm before printing "total X\n".
-      - R3.7: |
-          -h must apply to -s block counts when both -s and -h are given, converting
-          block counts to human-readable form. Use pkg/format.HumanSize(bytes int64,
-          opts HumanSizeOpts) string with opts.Binary = true, consistent with R3.5.
-          Do not duplicate the HumanSize algorithm inline.
-      - R3.8: -F must append a type indicator character after each entry name. The indicators are "/" for directories, "*" for executable regular files, "@" for symbolic links, "|" for named pipes (FIFOs), "=" for sockets. Regular non-executable files receive no indicator.
-      - R3.9: Executable is defined as having any execute bit set (owner, group, or other) in the file's permission mode.
-      - R3.10: -F must work with all output formats (-l, -1, -C, -x) and with color output. When color is enabled, the indicator character is printed after the ANSI reset sequence so it is not colorized.
-      - R3.11: -R must recursively list the contents of each subdirectory encountered during the listing. Each subdirectory's contents are printed under a header line in the format "PATH:" followed by a blank line, then the directory contents, then a blank line before the next entry.
-      - R3.12: -R must respect the current format mode. With -l, each subdirectory's contents are listed in long format including the "total N" block line. With -C or default mode, each subdirectory's contents use multi-column layout.
-      - R3.13: -R must not follow symbolic links to directories. Only real subdirectories are recursed into.
-      - R3.14: -R must apply the current filter flags (-a, -A) to each subdirectory. Dotfiles in subdirectories are shown only if -a or -A is given.
-      - R3.15: -R must list directories in the same sort order as entries within a directory. If -t is active, subdirectories are recursed into in modification-time order.
+            Set the process-global color mode based on the --color flag value: call pkg/format.SetColorEnabled(true) for --color=always, pkg/format.SetColorEnabled(false) for --color=never. For --color=auto, call pkg/sys.IsTerminal(os.Stdout.Fd()) and pass the result to pkg/format.SetColorEnabled. When color is disabled, pkg/format.FileTypeColor returns empty strings.
+          weight: 1
+      - R3.4:
+          text: When --color=never or when color is suppressed (non-TTY with auto), must not emit any ANSI escape sequences in the output.
+          weight: 1
+      - R3.5:
+          text: |
+            -h must only take effect with -l (long format). When -h is given with -l, file sizes (fi.Size int64) must be displayed via pkg/format.HumanSize(bytes int64, opts HumanSizeOpts) string with opts.Binary = true (1024-base units, suffixes K/M/G/T/P/E). Without -l, -h must have no visible effect on output.
+          weight: 1
+      - R3.6:
+          text: -h must also apply to the "total N" block count line in long format. When -h is active, convert the total block count (sum(fi.Blocks)/2 as int64) to a human-readable string using the same binary algorithm before printing "total X\n".
+          weight: 1
+      - R3.7:
+          text: |
+            -h must apply to -s block counts when both -s and -h are given, converting
+            block counts to human-readable form. Use pkg/format.HumanSize(bytes int64,
+            opts HumanSizeOpts) string with opts.Binary = true, consistent with R3.5.
+            Do not duplicate the HumanSize algorithm inline.
+          weight: 1
+      - R3.8:
+          text: -F must append a type indicator character after each entry name. The indicators are "/" for directories, "*" for executable regular files, "@" for symbolic links, "|" for named pipes (FIFOs), "=" for sockets. Regular non-executable files receive no indicator.
+          weight: 1
+      - R3.9:
+          text: Executable is defined as having any execute bit set (owner, group, or other) in the file's permission mode.
+          weight: 1
+      - R3.10:
+          text: -F must work with all output formats (-l, -1, -C, -x) and with color output. When color is enabled, the indicator character is printed after the ANSI reset sequence so it is not colorized.
+          weight: 1
+      - R3.11:
+          text: -R must recursively list the contents of each subdirectory encountered during the listing. Each subdirectory's contents are printed under a header line in the format "PATH:" followed by a blank line, then the directory contents, then a blank line before the next entry.
+          weight: 1
+      - R3.12:
+          text: -R must respect the current format mode. With -l, each subdirectory's contents are listed in long format including the "total N" block line. With -C or default mode, each subdirectory's contents use multi-column layout.
+          weight: 1
+      - R3.13:
+          text: -R must not follow symbolic links to directories. Only real subdirectories are recursed into.
+          weight: 1
+      - R3.14:
+          text: -R must apply the current filter flags (-a, -A) to each subdirectory. Dotfiles in subdirectories are shown only if -a or -A is given.
+          weight: 1
+      - R3.15:
+          text: -R must list directories in the same sort order as entries within a directory. If -t is active, subdirectories are recursed into in modification-time order.
+          weight: 1
 
   R4:
     title: Exit codes, signal handling, and flag interactions
     items:
-      - R4.1: Must exit 0 when all listed paths are accessed and output is written successfully.
-      - R4.2: Must exit 1 when a minor problem occurs, such as failing to access a file or directory given as an argument (e.g., permission denied, file not found). Must still list the remaining accessible entries before exiting. Must print a diagnostic to stderr for each inaccessible entry.
-      - R4.3: Must exit 2 when a serious problem occurs, such as an invalid command-line option. This matches GNU ls (ls.c:5638 exit(status) where status is set to EXIT_FAILURE=2 for bad options at ls.c:2026).
-      - R4.4: |
-          Must install a SIGPIPE handler at startup so that piping ls output to head or other truncating consumers does not produce a broken-pipe error message. Implementation: call pkg/sys.InstallSIGPIPEHandler() — this uses signal.Notify(c, syscall.SIGPIPE) with a buffered channel of size 1; a dedicated goroutine calls os.Exit(0) when the channel receives. Must not use signal.Ignore (deferred cleanup functions must not run on SIGPIPE, matching GNU ls behavior).
-      - R4.5: Must install a SIGWINCH handler via pkg/sys.OnTerminalResize(callback func(width int)) that re-queries the terminal width and updates the column layout. pkg/sys.OnTerminalResize registers a SIGWINCH listener that calls pkg/sys.TerminalWidth() and invokes the callback with the new width; multiple callbacks may be registered. This allows ls to adapt column layout if the terminal is resized during a long listing.
-      - R4.6: -n implies -l. When -n is given without -l, the output must be in long format with numeric UID/GID.
-      - R4.7: -C and -x are mutually exclusive with -l and -1. The last format flag on the command line wins (see R1.14).
-      - R4.8: -R with -l must produce a "total N" block line for each subdirectory listing, matching GNU ls -lR output.
-      - R4.9: -i, -s, and -F may all be combined with -R. Each subdirectory listing applies the same metadata display and classification options.
+      - R4.1:
+          text: Must exit 0 when all listed paths are accessed and output is written successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when a minor problem occurs, such as failing to access a file or directory given as an argument (e.g., permission denied, file not found). Must still list the remaining accessible entries before exiting. Must print a diagnostic to stderr for each inaccessible entry.
+          weight: 1
+      - R4.3:
+          text: Must exit 2 when a serious problem occurs, such as an invalid command-line option. This matches GNU ls (ls.c:5638 exit(status) where status is set to EXIT_FAILURE=2 for bad options at ls.c:2026).
+          weight: 1
+      - R4.4:
+          text: |
+            Must install a SIGPIPE handler at startup so that piping ls output to head or other truncating consumers does not produce a broken-pipe error message. Implementation: call pkg/sys.InstallSIGPIPEHandler() — this uses signal.Notify(c, syscall.SIGPIPE) with a buffered channel of size 1; a dedicated goroutine calls os.Exit(0) when the channel receives. Must not use signal.Ignore (deferred cleanup functions must not run on SIGPIPE, matching GNU ls behavior).
+          weight: 1
+      - R4.5:
+          text: Must install a SIGWINCH handler via pkg/sys.OnTerminalResize(callback func(width int)) that re-queries the terminal width and updates the column layout. pkg/sys.OnTerminalResize registers a SIGWINCH listener that calls pkg/sys.TerminalWidth() and invokes the callback with the new width; multiple callbacks may be registered. This allows ls to adapt column layout if the terminal is resized during a long listing.
+          weight: 1
+      - R4.6:
+          text: -n implies -l. When -n is given without -l, the output must be in long format with numeric UID/GID.
+          weight: 1
+      - R4.7:
+          text: -C and -x are mutually exclusive with -l and -1. The last format flag on the command line wins (see R1.14).
+          weight: 1
+      - R4.8:
+          text: -R with -l must produce a "total N" block line for each subdirectory listing, matching GNU ls -lR output.
+          weight: 1
+      - R4.9:
+          text: -i, -s, and -F may all be combined with -R. Each subdirectory listing applies the same metadata display and classification options.
+          weight: 1
 
 non_goals:
   - --hyperlink (terminal hyperlinks) is out of scope for this project.

--- a/docs/specs/product-requirements/prd009-du.yaml
+++ b/docs/specs/product-requirements/prd009-du.yaml
@@ -27,59 +27,97 @@ requirements:
   R1:
     title: Default behavior
     items:
-      - R1.1: Must recurse into each directory argument and print the accumulated size and path for each subdirectory and the directory itself. When no arguments are given, must default to the current directory (".").
-      - R1.2: |
-          Must report sizes in 1024-byte (1K) block units by default. Each entry's size is fi.Blocks / 2 where fi.Blocks (int64) is the number of 512-byte blocks allocated (st_blocks from syscall.Stat_t). Obtain metadata via pkg/sys.Stat(path string) (*sys.FileInfo, error) — follows symbolic links. sys.FileInfo.Blocks int64 holds the 512-byte block count.
+      - R1.1:
+          text: Must recurse into each directory argument and print the accumulated size and path for each subdirectory and the directory itself. When no arguments are given, must default to the current directory (".").
+          weight: 1
+      - R1.2:
+          text: |
+            Must report sizes in 1024-byte (1K) block units by default. Each entry's size is fi.Blocks / 2 where fi.Blocks (int64) is the number of 512-byte blocks allocated (st_blocks from syscall.Stat_t). Obtain metadata via pkg/sys.Stat(path string) (*sys.FileInfo, error) — follows symbolic links. sys.FileInfo.Blocks int64 holds the 512-byte block count.
 
-          sys.FileInfo struct (embedded for reference):
-            type FileInfo struct {
-                Mode    os.FileMode
-                Size    int64       // apparent file size in bytes (st_size)
-                Nlink   uint64      // hard-link count (st_nlink)
-                Uid     uint32      // owner user ID (st_uid)
-                Gid     uint32      // owner group ID (st_gid)
-                Rdev    uint64      // device ID for special files (st_rdev)
-                Dev     uint64      // device ID of the containing filesystem (st_dev)
-                Ino     uint64      // inode number (st_ino)
-                Blocks  int64       // 512-byte blocks allocated (st_blocks)
-                Blksize int64       // preferred I/O block size
-                ModTime time.Time   // modification time
-                Sys     os.FileInfo // underlying os.FileInfo
-            }
-      - R1.3: Must print one line per entry in the format "SIZE\tPATH\n" where SIZE is a right-aligned integer (no leading spaces) and PATH is the relative path as given by the directory traversal.
-      - R1.4: Must not follow symbolic links during traversal. Use pkg/sys.Lstat(path string) (*sys.FileInfo, error) — does not follow symbolic links; returns the symlink's own metadata. pkg/sys.Lstat has the same return type as pkg/sys.Stat (see R1.2 for sys.FileInfo definition).
-      - R1.5: Must process multiple directory arguments in the order given on the command line. Each argument is traversed independently.
+            sys.FileInfo struct (embedded for reference):
+              type FileInfo struct {
+                  Mode    os.FileMode
+                  Size    int64       // apparent file size in bytes (st_size)
+                  Nlink   uint64      // hard-link count (st_nlink)
+                  Uid     uint32      // owner user ID (st_uid)
+                  Gid     uint32      // owner group ID (st_gid)
+                  Rdev    uint64      // device ID for special files (st_rdev)
+                  Dev     uint64      // device ID of the containing filesystem (st_dev)
+                  Ino     uint64      // inode number (st_ino)
+                  Blocks  int64       // 512-byte blocks allocated (st_blocks)
+                  Blksize int64       // preferred I/O block size
+                  ModTime time.Time   // modification time
+                  Sys     os.FileInfo // underlying os.FileInfo
+              }
+          weight: 1
+      - R1.3:
+          text: Must print one line per entry in the format "SIZE\tPATH\n" where SIZE is a right-aligned integer (no leading spaces) and PATH is the relative path as given by the directory traversal.
+          weight: 1
+      - R1.4:
+          text: Must not follow symbolic links during traversal. Use pkg/sys.Lstat(path string) (*sys.FileInfo, error) — does not follow symbolic links; returns the symlink's own metadata. pkg/sys.Lstat has the same return type as pkg/sys.Stat (see R1.2 for sys.FileInfo definition).
+          weight: 1
+      - R1.5:
+          text: Must process multiple directory arguments in the order given on the command line. Each argument is traversed independently.
+          weight: 1
 
   R2:
     title: Flag behavior
     items:
-      - R2.1: |
-          -h must display sizes as human-readable strings using binary mode (1024-based) via pkg/format.HumanSize(bytes int64, opts HumanSizeOpts) string with opts.Binary = true (1024-base units, suffixes K/M/G/T/P/E). -h applies to all output lines including the grand total line when -c is also given.
-      - R2.2: -s must print only one line per argument with the total size of that argument. When -s is given, subdirectory lines must not be printed. -s is equivalent to --max-depth=0.
-      - R2.3: -a must print a size line for every file encountered during traversal, not just directories. Without -a, only directory entries are printed (the default).
-      - R2.4: -d N (and the long form --max-depth=N) must limit the depth of reported entries. Depth 0 means only the argument itself (equivalent to -s). Depth 1 means the argument and its immediate children. Files and directories deeper than N are accumulated into their parent's total but not printed as separate lines.
-      - R2.5: -k must report sizes in 1024-byte blocks. Since 1K is already the default, -k has no visible effect but must be accepted without error for compatibility.
-      - R2.6: -m must report sizes in 1048576-byte (1M) blocks. Each entry's st_blocks value is converted from 512-byte blocks to 1M blocks, rounding up.
-      - R2.7: -c must print a grand total line after all arguments are processed. The grand total line has the format "SIZE\ttotal\n" where SIZE is the sum of all argument totals.
-      - R2.8: --apparent-size must report file sizes using st_size (the apparent file size in bytes) instead of st_blocks (the physical block allocation). The apparent size is then converted to the selected block unit (1K by default, or as overridden by -k, -m, or -h). Obtains st_size from the os.FileInfo.Size() method.
+      - R2.1:
+          text: |
+            -h must display sizes as human-readable strings using binary mode (1024-based) via pkg/format.HumanSize(bytes int64, opts HumanSizeOpts) string with opts.Binary = true (1024-base units, suffixes K/M/G/T/P/E). -h applies to all output lines including the grand total line when -c is also given.
+          weight: 1
+      - R2.2:
+          text: -s must print only one line per argument with the total size of that argument. When -s is given, subdirectory lines must not be printed. -s is equivalent to --max-depth=0.
+          weight: 1
+      - R2.3:
+          text: -a must print a size line for every file encountered during traversal, not just directories. Without -a, only directory entries are printed (the default).
+          weight: 1
+      - R2.4:
+          text: -d N (and the long form --max-depth=N) must limit the depth of reported entries. Depth 0 means only the argument itself (equivalent to -s). Depth 1 means the argument and its immediate children. Files and directories deeper than N are accumulated into their parent's total but not printed as separate lines.
+          weight: 1
+      - R2.5:
+          text: -k must report sizes in 1024-byte blocks. Since 1K is already the default, -k has no visible effect but must be accepted without error for compatibility.
+          weight: 1
+      - R2.6:
+          text: -m must report sizes in 1048576-byte (1M) blocks. Each entry's st_blocks value is converted from 512-byte blocks to 1M blocks, rounding up.
+          weight: 1
+      - R2.7:
+          text: -c must print a grand total line after all arguments are processed. The grand total line has the format "SIZE\ttotal\n" where SIZE is the sum of all argument totals.
+          weight: 1
+      - R2.8:
+          text: --apparent-size must report file sizes using st_size (the apparent file size in bytes) instead of st_blocks (the physical block allocation). The apparent size is then converted to the selected block unit (1K by default, or as overridden by -k, -m, or -h). Obtains st_size from the os.FileInfo.Size() method.
+          weight: 1
 
   R3:
     title: Hard-link deduplication
     items:
-      - R3.1: Must track files by their device number (st_dev) and inode number (st_ino) across the entire du invocation. A file that has already been counted (same st_dev and st_ino) must not be counted again. This prevents double-counting hard-linked files, matching GNU du behavior (du.c:554 inode tracking via hash table).
-      - R3.2: Must obtain dev and ino via pkg/sys.Stat or pkg/sys.Lstat (see R1.2 for sys.FileInfo). Use sys.FileInfo.Dev uint64 (device ID of the containing filesystem, st_dev) and sys.FileInfo.Ino uint64 (inode number, st_ino) as the deduplication key. The map is keyed by a struct{ Dev, Ino uint64 } pair.
-      - R3.3: Hard-link deduplication applies per du invocation, not per argument. A hard-linked file counted under one argument must not be counted again under a subsequent argument.
+      - R3.1:
+          text: Must track files by their device number (st_dev) and inode number (st_ino) across the entire du invocation. A file that has already been counted (same st_dev and st_ino) must not be counted again. This prevents double-counting hard-linked files, matching GNU du behavior (du.c:554 inode tracking via hash table).
+          weight: 1
+      - R3.2:
+          text: Must obtain dev and ino via pkg/sys.Stat or pkg/sys.Lstat (see R1.2 for sys.FileInfo). Use sys.FileInfo.Dev uint64 (device ID of the containing filesystem, st_dev) and sys.FileInfo.Ino uint64 (inode number, st_ino) as the deduplication key. The map is keyed by a struct{ Dev, Ino uint64 } pair.
+          weight: 1
+      - R3.3:
+          text: Hard-link deduplication applies per du invocation, not per argument. A hard-linked file counted under one argument must not be counted again under a subsequent argument.
+          weight: 1
 
   R4:
     title: Exit codes
     items:
-      - R4.1: Must exit 0 when all arguments are traversed and reported successfully.
-      - R4.2: Must exit 1 when any error occurs during traversal (cannot stat a file, cannot read a directory, permission denied). Must print a diagnostic to stderr for each error and continue processing remaining entries and arguments before exiting.
+      - R4.1:
+          text: Must exit 0 when all arguments are traversed and reported successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any error occurs during traversal (cannot stat a file, cannot read a directory, permission denied). Must print a diagnostic to stderr for each error and continue processing remaining entries and arguments before exiting.
+          weight: 1
 
   R5:
     title: Signal handling
     items:
-      - R5.1: Must install a SIGPIPE handler at startup by calling pkg/sys.InstallSIGPIPEHandler() so that piping du output to head or other truncating consumers does not produce a broken-pipe error message. InstallSIGPIPEHandler uses signal.Notify(c, syscall.SIGPIPE) with a buffered channel; a goroutine calls os.Exit(0) on receipt. Must not use signal.Ignore.
+      - R5.1:
+          text: Must install a SIGPIPE handler at startup by calling pkg/sys.InstallSIGPIPEHandler() so that piping du output to head or other truncating consumers does not produce a broken-pipe error message. InstallSIGPIPEHandler uses signal.Notify(c, syscall.SIGPIPE) with a buffered channel; a goroutine calls os.Exit(0) on receipt. Must not use signal.Ignore.
+          weight: 1
 
 non_goals:
   - --si (1000-based units) is out of scope; we support only binary (1024-based) human-readable output.

--- a/docs/specs/product-requirements/prd011-magefiles.yaml
+++ b/docs/specs/product-requirements/prd011-magefiles.yaml
@@ -16,40 +16,50 @@ requirements:
   R1:
     title: Build target (scaffold-provided)
     items:
-      - R1.1: |
-          mage build compiles every package under cmd/ to a binary in the directory
-          specified by configuration.yaml project.binary_dir (default: bin/). Provided
-          by cobbler-scaffold orchestrator.
+      - R1.1:
+          text: |
+            mage build compiles every package under cmd/ to a binary in the directory
+            specified by configuration.yaml project.binary_dir (default: bin/). Provided
+            by cobbler-scaffold orchestrator.
+          weight: 1
 
   R2:
     title: Lint target (scaffold-provided)
     items:
-      - R2.1: |
-          mage lint runs golangci-lint on all Go source directories listed in
-          configuration.yaml project.go_source_dirs. Provided by cobbler-scaffold
-          orchestrator.
+      - R2.1:
+          text: |
+            mage lint runs golangci-lint on all Go source directories listed in
+            configuration.yaml project.go_source_dirs. Provided by cobbler-scaffold
+            orchestrator.
+          weight: 1
 
   R3:
     title: Clean target (scaffold-provided)
     items:
-      - R3.1: |
-          mage clean removes the binary_dir and all its contents. If the directory
-          does not exist, the target succeeds silently. Provided by cobbler-scaffold
-          orchestrator.
+      - R3.1:
+          text: |
+            mage clean removes the binary_dir and all its contents. If the directory
+            does not exist, the target succeeds silently. Provided by cobbler-scaffold
+            orchestrator.
+          weight: 1
 
   R4:
     title: Install target (scaffold-provided)
     items:
-      - R4.1: |
-          mage install runs go install for every package under cmd/. Provided by
-          cobbler-scaffold orchestrator.
+      - R4.1:
+          text: |
+            mage install runs go install for every package under cmd/. Provided by
+            cobbler-scaffold orchestrator.
+          weight: 1
 
   R5:
     title: Configuration contract (scaffold-provided)
     items:
-      - R5.1: |
-          configuration.yaml project section must contain module_path, binary_dir,
-          go_source_dirs, and magefiles_dir fields. Populated by mage scaffold:push.
+      - R5.1:
+          text: |
+            configuration.yaml project section must contain module_path, binary_dir,
+            go_source_dirs, and magefiles_dir fields. Populated by mage scaffold:push.
+          weight: 1
 
 non_goals:
   - This PRD does not specify orchestrator, generator, scaffold, prompt, or stats targets. Those are provided by cobbler-scaffold.

--- a/docs/specs/product-requirements/prd012-yes.yaml
+++ b/docs/specs/product-requirements/prd012-yes.yaml
@@ -18,30 +18,54 @@ requirements:
   R1:
     title: Core output behavior
     items:
-      - R1.1: When no arguments are given, must output "y" followed by a newline, repeatedly, until the process is killed or a write error occurs on stdout.
-      - R1.2: When one or more arguments are given, must join them with a single space character and output the resulting string followed by a newline, repeatedly.
-      - R1.3: Arguments beginning with "-" must be passable using the "--" separator to prevent misinterpretation as flags (e.g., "yes -- --help" outputs "--help" repeatedly).
-      - R1.4: Must not read from stdin. All output goes to stdout.
+      - R1.1:
+          text: When no arguments are given, must output "y" followed by a newline, repeatedly, until the process is killed or a write error occurs on stdout.
+          weight: 1
+      - R1.2:
+          text: When one or more arguments are given, must join them with a single space character and output the resulting string followed by a newline, repeatedly.
+          weight: 1
+      - R1.3:
+          text: Arguments beginning with "-" must be passable using the "--" separator to prevent misinterpretation as flags (e.g., "yes -- --help" outputs "--help" repeatedly).
+          weight: 1
+      - R1.4:
+          text: Must not read from stdin. All output goes to stdout.
+          weight: 1
 
   R2:
     title: Output buffering and performance
     items:
-      - R2.1: Must buffer output to avoid per-line write syscalls. Use a bufio.Writer with a buffer of at least 8192 bytes or write in fixed-size blocks, matching the GNU implementation's approach of filling a large output buffer before calling write().
-      - R2.2: Must flush the output buffer before exiting on a write error so that the last partial buffer is delivered to the pipe reader.
+      - R2.1:
+          text: Must buffer output to avoid per-line write syscalls. Use a bufio.Writer with a buffer of at least 8192 bytes or write in fixed-size blocks, matching the GNU implementation's approach of filling a large output buffer before calling write().
+          weight: 1
+      - R2.2:
+          text: Must flush the output buffer before exiting on a write error so that the last partial buffer is delivered to the pipe reader.
+          weight: 1
 
   R3:
     title: Exit codes and signal handling
     items:
-      - R3.1: Must exit 0 when terminated by SIGPIPE (the normal case when piped to a program that closes its stdin).
-      - R3.2: Must exit 1 when a write error other than EPIPE occurs on stdout.
-      - R3.3: Must handle SIGPIPE gracefully without printing an error message to stderr. The default Go SIGPIPE behavior (exit silently) is acceptable if it matches the reference binary's exit code.
+      - R3.1:
+          text: Must exit 0 when terminated by SIGPIPE (the normal case when piped to a program that closes its stdin).
+          weight: 1
+      - R3.2:
+          text: Must exit 1 when a write error other than EPIPE occurs on stdout.
+          weight: 1
+      - R3.3:
+          text: Must handle SIGPIPE gracefully without printing an error message to stderr. The default Go SIGPIPE behavior (exit silently) is acceptable if it matches the reference binary's exit code.
+          weight: 1
 
   R4:
     title: Differential testing
     items:
-      - R4.1: Differential tests must pipe the output of both the Go binary and the reference binary through "head -n N" and compare the captured output byte-for-byte via pkg/testutils.
-      - R4.2: "Tests must cover: no arguments (default 'y'), single argument, multiple arguments joined with spaces, arguments after '--' separator, and empty string argument."
-      - R4.3: Tests must verify exit code behavior when stdout is closed early (SIGPIPE case).
+      - R4.1:
+          text: Differential tests must pipe the output of both the Go binary and the reference binary through "head -n N" and compare the captured output byte-for-byte via pkg/testutils.
+          weight: 1
+      - R4.2:
+          text: "Tests must cover: no arguments (default 'y'), single argument, multiple arguments joined with spaces, arguments after '--' separator, and empty string argument."
+          weight: 1
+      - R4.3:
+          text: Tests must verify exit code behavior when stdout is closed early (SIGPIPE case).
+          weight: 1
 
 non_goals:
   - cmd/yes does not implement any flags beyond --help and --version.

--- a/docs/specs/product-requirements/prd013-true.yaml
+++ b/docs/specs/product-requirements/prd013-true.yaml
@@ -15,29 +15,51 @@ requirements:
   R1:
     title: Core behavior
     items:
-      - R1.1: Must exit with status 0 when invoked with no arguments.
-      - R1.2: Must exit with status 0 when invoked with any arguments, ignoring them entirely. Arguments are not parsed, validated, or acted upon.
-      - R1.3: Must not read from stdin. Must not write to stdout or stderr under normal operation (no arguments or unrecognized arguments).
+      - R1.1:
+          text: Must exit with status 0 when invoked with no arguments.
+          weight: 1
+      - R1.2:
+          text: Must exit with status 0 when invoked with any arguments, ignoring them entirely. Arguments are not parsed, validated, or acted upon.
+          weight: 1
+      - R1.3:
+          text: Must not read from stdin. Must not write to stdout or stderr under normal operation (no arguments or unrecognized arguments).
+          weight: 1
 
   R2:
     title: Help and version output
     items:
-      - R2.1: When --help is the first argument, must print a usage message to stdout and exit 0.
-      - R2.2: When --version is the first argument, must print version information to stdout and exit 0.
-      - R2.3: If a write error occurs while printing --help or --version output, must exit 1.
+      - R2.1:
+          text: When --help is the first argument, must print a usage message to stdout and exit 0.
+          weight: 1
+      - R2.2:
+          text: When --version is the first argument, must print version information to stdout and exit 0.
+          weight: 1
+      - R2.3:
+          text: If a write error occurs while printing --help or --version output, must exit 1.
+          weight: 1
 
   R3:
     title: Exit codes
     items:
-      - R3.1: Must exit 0 in all cases except a write error during --help or --version output.
-      - R3.2: Must not exit with any status other than 0 or 1.
+      - R3.1:
+          text: Must exit 0 in all cases except a write error during --help or --version output.
+          weight: 1
+      - R3.2:
+          text: Must not exit with any status other than 0 or 1.
+          weight: 1
 
   R4:
     title: Differential testing
     items:
-      - R4.1: Differential tests must compare exit codes between the Go binary and the reference binary via pkg/testutils.
-      - R4.2: "Tests must cover: no arguments, arbitrary arguments (ignored), --help output, and --version output."
-      - R4.3: Tests must verify that no output is produced on stdout or stderr when invoked without --help or --version.
+      - R4.1:
+          text: Differential tests must compare exit codes between the Go binary and the reference binary via pkg/testutils.
+          weight: 1
+      - R4.2:
+          text: "Tests must cover: no arguments, arbitrary arguments (ignored), --help output, and --version output."
+          weight: 1
+      - R4.3:
+          text: Tests must verify that no output is produced on stdout or stderr when invoked without --help or --version.
+          weight: 1
 
 non_goals:
   - cmd/true does not implement any flags beyond --help and --version.

--- a/docs/specs/product-requirements/prd014-false.yaml
+++ b/docs/specs/product-requirements/prd014-false.yaml
@@ -15,29 +15,51 @@ requirements:
   R1:
     title: Core behavior
     items:
-      - R1.1: Must exit with status 1 when invoked with no arguments.
-      - R1.2: Must exit with status 1 when invoked with any arguments, ignoring them entirely. Arguments are not parsed, validated, or acted upon.
-      - R1.3: Must not read from stdin. Must not write to stdout or stderr under normal operation (no arguments or unrecognized arguments).
+      - R1.1:
+          text: Must exit with status 1 when invoked with no arguments.
+          weight: 1
+      - R1.2:
+          text: Must exit with status 1 when invoked with any arguments, ignoring them entirely. Arguments are not parsed, validated, or acted upon.
+          weight: 1
+      - R1.3:
+          text: Must not read from stdin. Must not write to stdout or stderr under normal operation (no arguments or unrecognized arguments).
+          weight: 1
 
   R2:
     title: Help and version output
     items:
-      - R2.1: When --help is the first argument, must print a usage message to stdout and exit 0.
-      - R2.2: When --version is the first argument, must print version information to stdout and exit 0.
-      - R2.3: If a write error occurs while printing --help or --version output, must exit 1.
+      - R2.1:
+          text: When --help is the first argument, must print a usage message to stdout and exit 0.
+          weight: 1
+      - R2.2:
+          text: When --version is the first argument, must print version information to stdout and exit 0.
+          weight: 1
+      - R2.3:
+          text: If a write error occurs while printing --help or --version output, must exit 1.
+          weight: 1
 
   R3:
     title: Exit codes
     items:
-      - R3.1: Must exit 1 in all cases except when --help or --version is given and output succeeds (exit 0).
-      - R3.2: Must not exit with any status other than 0 or 1.
+      - R3.1:
+          text: Must exit 1 in all cases except when --help or --version is given and output succeeds (exit 0).
+          weight: 1
+      - R3.2:
+          text: Must not exit with any status other than 0 or 1.
+          weight: 1
 
   R4:
     title: Differential testing
     items:
-      - R4.1: Differential tests must compare exit codes between the Go binary and the reference binary via pkg/testutils.
-      - R4.2: "Tests must cover: no arguments, arbitrary arguments (ignored), --help output, and --version output."
-      - R4.3: Tests must verify that no output is produced on stdout or stderr when invoked without --help or --version.
+      - R4.1:
+          text: Differential tests must compare exit codes between the Go binary and the reference binary via pkg/testutils.
+          weight: 1
+      - R4.2:
+          text: "Tests must cover: no arguments, arbitrary arguments (ignored), --help output, and --version output."
+          weight: 1
+      - R4.3:
+          text: Tests must verify that no output is produced on stdout or stderr when invoked without --help or --version.
+          weight: 1
 
 non_goals:
   - cmd/false does not implement any flags beyond --help and --version.

--- a/docs/specs/product-requirements/prd015-basename.yaml
+++ b/docs/specs/product-requirements/prd015-basename.yaml
@@ -18,33 +18,63 @@ requirements:
   R1:
     title: Single-argument mode (default)
     items:
-      - R1.1: "When invoked as 'basename NAME', must strip the longest prefix ending in '/' from NAME and print the result followed by a newline."
-      - R1.2: "When invoked as 'basename NAME SUFFIX', must strip the directory prefix and then remove SUFFIX from the end of the result if it matches. SUFFIX is a literal string match, not a pattern."
-      - R1.3: Must strip trailing slashes from NAME before processing. Multiple consecutive trailing slashes are all removed.
-      - R1.4: "When NAME consists entirely of slashes, must output '/'."
-      - R1.5: When NAME is an empty string, must output an empty line (newline only).
+      - R1.1:
+          text: "When invoked as 'basename NAME', must strip the longest prefix ending in '/' from NAME and print the result followed by a newline."
+          weight: 1
+      - R1.2:
+          text: "When invoked as 'basename NAME SUFFIX', must strip the directory prefix and then remove SUFFIX from the end of the result if it matches. SUFFIX is a literal string match, not a pattern."
+          weight: 1
+      - R1.3:
+          text: Must strip trailing slashes from NAME before processing. Multiple consecutive trailing slashes are all removed.
+          weight: 1
+      - R1.4:
+          text: "When NAME consists entirely of slashes, must output '/'."
+          weight: 1
+      - R1.5:
+          text: When NAME is an empty string, must output an empty line (newline only).
+          weight: 1
 
   R2:
     title: Multi-argument mode (-a, --multiple)
     items:
-      - R2.1: -a or --multiple must enable processing of multiple NAME arguments. Each NAME is processed independently and the result is printed on a separate line.
-      - R2.2: -s SUFFIX or --suffix=SUFFIX must remove SUFFIX from each result and implies -a. When -s is given, the second positional argument is treated as a NAME, not a SUFFIX.
-      - R2.3: In multi-argument mode without -s, no suffix removal is performed on any argument.
+      - R2.1:
+          text: -a or --multiple must enable processing of multiple NAME arguments. Each NAME is processed independently and the result is printed on a separate line.
+          weight: 1
+      - R2.2:
+          text: -s SUFFIX or --suffix=SUFFIX must remove SUFFIX from each result and implies -a. When -s is given, the second positional argument is treated as a NAME, not a SUFFIX.
+          weight: 1
+      - R2.3:
+          text: In multi-argument mode without -s, no suffix removal is performed on any argument.
+          weight: 1
 
   R3:
     title: Output formatting and exit codes
     items:
-      - R3.1: Each result must be followed by a newline character, or by a NUL byte (0x00) if -z or --zero is given.
-      - R3.2: Must exit 0 on success.
-      - R3.3: Must exit 1 when called with an incorrect number of arguments in single-argument mode (zero arguments or more than two without -a).
-      - R3.4: Must print an error message to stderr when argument validation fails.
+      - R3.1:
+          text: Each result must be followed by a newline character, or by a NUL byte (0x00) if -z or --zero is given.
+          weight: 1
+      - R3.2:
+          text: Must exit 0 on success.
+          weight: 1
+      - R3.3:
+          text: Must exit 1 when called with an incorrect number of arguments in single-argument mode (zero arguments or more than two without -a).
+          weight: 1
+      - R3.4:
+          text: Must print an error message to stderr when argument validation fails.
+          weight: 1
 
   R4:
     title: Differential testing
     items:
-      - R4.1: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary via pkg/testutils.
-      - R4.2: "Tests must cover: simple path (dir/file), trailing slashes, root path (/), empty string, suffix removal, multi-argument mode (-a), suffix mode (-s), and NUL-delimited output (-z)."
-      - R4.3: Tests must verify error output and exit code for invalid argument counts.
+      - R4.1:
+          text: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary via pkg/testutils.
+          weight: 1
+      - R4.2:
+          text: "Tests must cover: simple path (dir/file), trailing slashes, root path (/), empty string, suffix removal, multi-argument mode (-a), suffix mode (-s), and NUL-delimited output (-z)."
+          weight: 1
+      - R4.3:
+          text: Tests must verify error output and exit code for invalid argument counts.
+          weight: 1
 
 non_goals:
   - cmd/basename does not implement pattern-based suffix removal (glob or regex); suffix is a literal string match.

--- a/docs/specs/product-requirements/prd016-dirname.yaml
+++ b/docs/specs/product-requirements/prd016-dirname.yaml
@@ -17,31 +17,57 @@ requirements:
   R1:
     title: Core path stripping behavior
     items:
-      - R1.1: Must strip trailing slashes from NAME, then remove the last component (everything after the final '/') and print the result.
-      - R1.2: "When NAME contains no '/' after trailing-slash removal, must output '.' (the current directory)."
-      - R1.3: "When NAME is '/' or consists entirely of slashes, must output '/'."
-      - R1.4: Must strip trailing slashes from the result. If the result after stripping would be empty, output the root slash instead.
-      - R1.5: Must process multiple NAME arguments, printing one result per argument.
+      - R1.1:
+          text: Must strip trailing slashes from NAME, then remove the last component (everything after the final '/') and print the result.
+          weight: 1
+      - R1.2:
+          text: "When NAME contains no '/' after trailing-slash removal, must output '.' (the current directory)."
+          weight: 1
+      - R1.3:
+          text: "When NAME is '/' or consists entirely of slashes, must output '/'."
+          weight: 1
+      - R1.4:
+          text: Must strip trailing slashes from the result. If the result after stripping would be empty, output the root slash instead.
+          weight: 1
+      - R1.5:
+          text: Must process multiple NAME arguments, printing one result per argument.
+          weight: 1
 
   R2:
     title: Output formatting
     items:
-      - R2.1: Each result must be followed by a newline character, or by a NUL byte (0x00) if -z or --zero is given.
-      - R2.2: Results must be printed in the order the arguments are given, one per line.
+      - R2.1:
+          text: Each result must be followed by a newline character, or by a NUL byte (0x00) if -z or --zero is given.
+          weight: 1
+      - R2.2:
+          text: Results must be printed in the order the arguments are given, one per line.
+          weight: 1
 
   R3:
     title: Exit codes and error handling
     items:
-      - R3.1: Must exit 0 on success.
-      - R3.2: Must exit 1 when called with no arguments. Must print an error message to stderr.
-      - R3.3: Must exit 1 when a write error occurs on stdout.
+      - R3.1:
+          text: Must exit 0 on success.
+          weight: 1
+      - R3.2:
+          text: Must exit 1 when called with no arguments. Must print an error message to stderr.
+          weight: 1
+      - R3.3:
+          text: Must exit 1 when a write error occurs on stdout.
+          weight: 1
 
   R4:
     title: Differential testing
     items:
-      - R4.1: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary via pkg/testutils.
-      - R4.2: "Tests must cover: simple path (dir/file), nested path (a/b/c), trailing slashes, root path (/), relative path with no directory (file.txt -> '.'), dot path (.), double-dot path (..), multiple arguments, and NUL-delimited output (-z)."
-      - R4.3: Tests must verify error output and exit code when no arguments are given.
+      - R4.1:
+          text: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary via pkg/testutils.
+          weight: 1
+      - R4.2:
+          text: "Tests must cover: simple path (dir/file), nested path (a/b/c), trailing slashes, root path (/), relative path with no directory (file.txt -> '.'), dot path (.), double-dot path (..), multiple arguments, and NUL-delimited output (-z)."
+          weight: 1
+      - R4.3:
+          text: Tests must verify error output and exit code when no arguments are given.
+          weight: 1
 
 non_goals:
   - cmd/dirname does not resolve symlinks or canonicalize paths; it operates on the string representation only.

--- a/docs/specs/product-requirements/prd017-tee.yaml
+++ b/docs/specs/product-requirements/prd017-tee.yaml
@@ -18,33 +18,63 @@ requirements:
   R1:
     title: Core copy behavior
     items:
-      - R1.1: Must read all bytes from stdin and write them to stdout. Simultaneously, must write the same bytes to each named output file in the order they appear on the command line.
-      - R1.2: When no file arguments are given, must copy stdin to stdout only (passthrough mode).
-      - R1.3: Must create output files that do not exist. Must truncate existing output files to zero length before writing, unless -a is given.
-      - R1.4: When "-" appears as a file argument, must treat it as an additional reference to stdout. The data is still written to stdout once (not duplicated), matching GNU tee behavior.
-      - R1.5: Must write output in the order received from stdin. Buffering is permitted but must not reorder data.
+      - R1.1:
+          text: Must read all bytes from stdin and write them to stdout. Simultaneously, must write the same bytes to each named output file in the order they appear on the command line.
+          weight: 1
+      - R1.2:
+          text: When no file arguments are given, must copy stdin to stdout only (passthrough mode).
+          weight: 1
+      - R1.3:
+          text: Must create output files that do not exist. Must truncate existing output files to zero length before writing, unless -a is given.
+          weight: 1
+      - R1.4:
+          text: When "-" appears as a file argument, must treat it as an additional reference to stdout. The data is still written to stdout once (not duplicated), matching GNU tee behavior.
+          weight: 1
+      - R1.5:
+          text: Must write output in the order received from stdin. Buffering is permitted but must not reorder data.
+          weight: 1
 
   R2:
     title: Append mode (-a) and SIGINT suppression (-i)
     items:
-      - R2.1: -a or --append must open each output file in append mode (O_APPEND). Existing file content is preserved and new data is appended after it.
-      - R2.2: -i or --ignore-interrupts must cause tee to ignore the SIGINT signal. Without -i, SIGINT terminates tee normally. With -i, tee continues reading and writing until stdin reaches EOF or a write error occurs.
-      - R2.3: -a and -i may be combined. Their effects are independent.
+      - R2.1:
+          text: -a or --append must open each output file in append mode (O_APPEND). Existing file content is preserved and new data is appended after it.
+          weight: 1
+      - R2.2:
+          text: -i or --ignore-interrupts must cause tee to ignore the SIGINT signal. Without -i, SIGINT terminates tee normally. With -i, tee continues reading and writing until stdin reaches EOF or a write error occurs.
+          weight: 1
+      - R2.3:
+          text: -a and -i may be combined. Their effects are independent.
+          weight: 1
 
   R3:
     title: Error handling and exit codes
     items:
-      - R3.1: Must exit 0 when all output files and stdout are written successfully.
-      - R3.2: Must exit 1 when any output file cannot be opened or written. Must print a diagnostic message to stderr identifying the failed file.
-      - R3.3: When one output file fails, must continue writing to the remaining output files and stdout. A single file failure does not stop output to other destinations.
-      - R3.4: Must exit 1 when a write error occurs on stdout (e.g., broken pipe without -p mode). The default GNU tee behavior exits on EPIPE to stdout.
+      - R3.1:
+          text: Must exit 0 when all output files and stdout are written successfully.
+          weight: 1
+      - R3.2:
+          text: Must exit 1 when any output file cannot be opened or written. Must print a diagnostic message to stderr identifying the failed file.
+          weight: 1
+      - R3.3:
+          text: When one output file fails, must continue writing to the remaining output files and stdout. A single file failure does not stop output to other destinations.
+          weight: 1
+      - R3.4:
+          text: Must exit 1 when a write error occurs on stdout (e.g., broken pipe without -p mode). The default GNU tee behavior exits on EPIPE to stdout.
+          weight: 1
 
   R4:
     title: Differential testing
     items:
-      - R4.1: Differential tests must compare stdout output, output file content, and exit codes between the Go binary and the reference binary via pkg/testutils.
-      - R4.2: "Tests must cover: single file, multiple files, append mode (-a), passthrough mode (no files), SIGINT suppression (-i with a signal sent during operation), and write-error handling (output to a read-only path)."
-      - R4.3: Tests must verify that data written to each output file matches stdout byte-for-byte.
+      - R4.1:
+          text: Differential tests must compare stdout output, output file content, and exit codes between the Go binary and the reference binary via pkg/testutils.
+          weight: 1
+      - R4.2:
+          text: "Tests must cover: single file, multiple files, append mode (-a), passthrough mode (no files), SIGINT suppression (-i with a signal sent during operation), and write-error handling (output to a read-only path)."
+          weight: 1
+      - R4.3:
+          text: Tests must verify that data written to each output file matches stdout byte-for-byte.
+          weight: 1
 
 non_goals:
   - cmd/tee does not implement --output-error modes (warn, warn-nopipe, exit, exit-nopipe) or the -p flag. These are advanced error-handling modes that add complexity beyond the scope of rel02.0.

--- a/docs/specs/product-requirements/prd018-head.yaml
+++ b/docs/specs/product-requirements/prd018-head.yaml
@@ -19,35 +19,69 @@ requirements:
   R1:
     title: Line-count mode (default and -n)
     items:
-      - R1.1: When no flags are given, must print the first 10 lines of each input file.
-      - R1.2: "-n NUM or --lines=NUM must print the first NUM lines. NUM must be a positive integer or a negative integer prefixed with '-'."
-      - R1.3: "When NUM is prefixed with '-' (e.g., -n -5), must print all lines except the last NUM lines. This requires buffering the entire input to determine where to stop."
-      - R1.4: Must read from stdin when no file arguments are given or when a file argument is "-".
-      - R1.5: A line is terminated by a newline character. The last line of a file that does not end with a newline is still counted as a line.
+      - R1.1:
+          text: When no flags are given, must print the first 10 lines of each input file.
+          weight: 1
+      - R1.2:
+          text: "-n NUM or --lines=NUM must print the first NUM lines. NUM must be a positive integer or a negative integer prefixed with '-'."
+          weight: 1
+      - R1.3:
+          text: "When NUM is prefixed with '-' (e.g., -n -5), must print all lines except the last NUM lines. This requires buffering the entire input to determine where to stop."
+          weight: 1
+      - R1.4:
+          text: Must read from stdin when no file arguments are given or when a file argument is "-".
+          weight: 1
+      - R1.5:
+          text: A line is terminated by a newline character. The last line of a file that does not end with a newline is still counted as a line.
+          weight: 1
 
   R2:
     title: Byte-count mode (-c)
     items:
-      - R2.1: "-c NUM or --bytes=NUM must print the first NUM bytes of each input. -c and -n are mutually exclusive; the last one given takes precedence."
-      - R2.2: "When NUM is prefixed with '-' (e.g., -c -100), must print all bytes except the last NUM bytes."
-      - R2.3: NUM may use multiplier suffixes as defined by GNU coreutils. At minimum, must support b (512), K or KiB (1024), M or MiB (1048576), and G or GiB (1073741824).
+      - R2.1:
+          text: "-c NUM or --bytes=NUM must print the first NUM bytes of each input. -c and -n are mutually exclusive; the last one given takes precedence."
+          weight: 1
+      - R2.2:
+          text: "When NUM is prefixed with '-' (e.g., -c -100), must print all bytes except the last NUM bytes."
+          weight: 1
+      - R2.3:
+          text: NUM may use multiplier suffixes as defined by GNU coreutils. At minimum, must support b (512), K or KiB (1024), M or MiB (1048576), and G or GiB (1073741824).
+          weight: 1
 
   R3:
     title: Multi-file output and headers
     items:
-      - R3.1: "When multiple files are given, must precede each file's output with a header in the format '==> FILENAME <==' followed by a newline. A blank line separates each file's header from the previous file's output."
-      - R3.2: When a single file is given, must not print a header by default.
-      - R3.3: -q or --quiet or --silent must suppress all headers, even for multiple files.
-      - R3.4: -v or --verbose must print headers even for a single file.
-      - R3.5: When a named file cannot be opened, must print an error message to stderr and continue processing remaining files.
+      - R3.1:
+          text: "When multiple files are given, must precede each file's output with a header in the format '==> FILENAME <==' followed by a newline. A blank line separates each file's header from the previous file's output."
+          weight: 1
+      - R3.2:
+          text: When a single file is given, must not print a header by default.
+          weight: 1
+      - R3.3:
+          text: -q or --quiet or --silent must suppress all headers, even for multiple files.
+          weight: 1
+      - R3.4:
+          text: -v or --verbose must print headers even for a single file.
+          weight: 1
+      - R3.5:
+          text: When a named file cannot be opened, must print an error message to stderr and continue processing remaining files.
+          weight: 1
 
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: Must exit 0 when all input files are processed successfully.
-      - R4.2: Must exit 1 when any input file cannot be opened or read. Must still process and output content for the files that were successfully read.
-      - R4.3: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary via pkg/testutils.
-      - R4.4: "Tests must cover: default 10 lines, explicit -n count, -c byte count, negative counts (-n -5, -c -100), multi-file headers, -q (suppress headers), -v (force headers), stdin input, and error on non-existent file."
+      - R4.1:
+          text: Must exit 0 when all input files are processed successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any input file cannot be opened or read. Must still process and output content for the files that were successfully read.
+          weight: 1
+      - R4.3:
+          text: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary via pkg/testutils.
+          weight: 1
+      - R4.4:
+          text: "Tests must cover: default 10 lines, explicit -n count, -c byte count, negative counts (-n -5, -c -100), multi-file headers, -q (suppress headers), -v (force headers), stdin input, and error on non-existent file."
+          weight: 1
 
 non_goals:
   - cmd/head does not implement -z (zero-terminated lines using NUL delimiter). This flag adds complexity to the line-counting logic and is rarely used.

--- a/docs/specs/product-requirements/prd019-seq.yaml
+++ b/docs/specs/product-requirements/prd019-seq.yaml
@@ -18,35 +18,69 @@ requirements:
   R1:
     title: Argument forms and sequence generation
     items:
-      - R1.1: "Must support three argument forms: 'seq LAST' (FIRST=1, STEP=1), 'seq FIRST LAST' (STEP=1), and 'seq FIRST STEP LAST'. All three arguments are interpreted as floating-point numbers."
-      - R1.2: Must generate numbers starting at FIRST, incrementing by STEP, and stopping when the next number would exceed LAST (for positive STEP) or fall below LAST (for negative STEP).
-      - R1.3: When FIRST equals LAST, must print exactly one number (FIRST).
-      - R1.4: When STEP is positive and FIRST is greater than LAST, must produce no output and exit 0. When STEP is negative and FIRST is less than LAST, must produce no output and exit 0.
-      - R1.5: STEP must not be zero. Must exit 1 with an error message when STEP is zero.
+      - R1.1:
+          text: "Must support three argument forms: 'seq LAST' (FIRST=1, STEP=1), 'seq FIRST LAST' (STEP=1), and 'seq FIRST STEP LAST'. All three arguments are interpreted as floating-point numbers."
+          weight: 1
+      - R1.2:
+          text: Must generate numbers starting at FIRST, incrementing by STEP, and stopping when the next number would exceed LAST (for positive STEP) or fall below LAST (for negative STEP).
+          weight: 1
+      - R1.3:
+          text: When FIRST equals LAST, must print exactly one number (FIRST).
+          weight: 1
+      - R1.4:
+          text: When STEP is positive and FIRST is greater than LAST, must produce no output and exit 0. When STEP is negative and FIRST is less than LAST, must produce no output and exit 0.
+          weight: 1
+      - R1.5:
+          text: STEP must not be zero. Must exit 1 with an error message when STEP is zero.
+          weight: 1
 
   R2:
     title: Output formatting
     items:
-      - R2.1: By default, must separate each number with a newline character. The last number must also be followed by a newline.
-      - R2.2: -s STRING or --separator=STRING must use STRING as the separator between numbers instead of newline. A trailing newline is still printed after the last number.
-      - R2.3: "The default format for integer sequences (all arguments are integers with no decimal point) must produce integers with no decimal point. The default format for floating-point sequences must use the minimum precision needed to represent the values exactly, matching the precision of the input arguments."
-      - R2.4: Must handle large integers exactly up to 2^53. Beyond that range, floating-point approximation is acceptable.
+      - R2.1:
+          text: By default, must separate each number with a newline character. The last number must also be followed by a newline.
+          weight: 1
+      - R2.2:
+          text: -s STRING or --separator=STRING must use STRING as the separator between numbers instead of newline. A trailing newline is still printed after the last number.
+          weight: 1
+      - R2.3:
+          text: "The default format for integer sequences (all arguments are integers with no decimal point) must produce integers with no decimal point. The default format for floating-point sequences must use the minimum precision needed to represent the values exactly, matching the precision of the input arguments."
+          weight: 1
+      - R2.4:
+          text: Must handle large integers exactly up to 2^53. Beyond that range, floating-point approximation is acceptable.
+          weight: 1
 
   R3:
     title: Format string (-f) and equal-width (-w)
     items:
-      - R3.1: "-f FORMAT or --format=FORMAT must apply a printf-style format string to each number. FORMAT must contain exactly one floating-point conversion specifier from the set: %a, %e, %f, %g, %A, %E, %F, %G. The specifier may include flags (-+#0 and space), width, and precision fields."
-      - R3.2: Must exit 1 with an error message when the format string contains no conversion specifier, contains more than one conversion specifier, or contains an invalid specifier (not in the allowed set).
-      - R3.3: -w or --equal-width must pad each number with leading zeros so that all numbers in the sequence have the same width. The width is determined by the widest of FIRST and LAST (formatted with the default format).
-      - R3.4: -f and -w are mutually exclusive in effect. When -f is given, -w is ignored (the format string controls the output width). When only -w is given, the default format is used with zero-padding.
+      - R3.1:
+          text: "-f FORMAT or --format=FORMAT must apply a printf-style format string to each number. FORMAT must contain exactly one floating-point conversion specifier from the set: %a, %e, %f, %g, %A, %E, %F, %G. The specifier may include flags (-+#0 and space), width, and precision fields."
+          weight: 1
+      - R3.2:
+          text: Must exit 1 with an error message when the format string contains no conversion specifier, contains more than one conversion specifier, or contains an invalid specifier (not in the allowed set).
+          weight: 1
+      - R3.3:
+          text: -w or --equal-width must pad each number with leading zeros so that all numbers in the sequence have the same width. The width is determined by the widest of FIRST and LAST (formatted with the default format).
+          weight: 1
+      - R3.4:
+          text: -f and -w are mutually exclusive in effect. When -f is given, -w is ignored (the format string controls the output width). When only -w is given, the default format is used with zero-padding.
+          weight: 1
 
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: Must exit 0 on success, including when the sequence is empty (FIRST > LAST with positive STEP).
-      - R4.2: "Must exit 1 on error: zero STEP, invalid format string, non-numeric arguments, or NaN arguments."
-      - R4.3: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary via pkg/testutils.
-      - R4.4: "Tests must cover: single argument (seq 5), two arguments (seq 2 5), three arguments (seq 1 2 10), descending sequence (seq 5 -1 1), floating-point sequence (seq 0.1 0.1 0.5), equal-width (seq -w 8 12), custom separator (seq -s ', ' 1 5), format string (seq -f '%.2f' 1 3), empty sequence, zero step error, and invalid format error."
+      - R4.1:
+          text: Must exit 0 on success, including when the sequence is empty (FIRST > LAST with positive STEP).
+          weight: 1
+      - R4.2:
+          text: "Must exit 1 on error: zero STEP, invalid format string, non-numeric arguments, or NaN arguments."
+          weight: 1
+      - R4.3:
+          text: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary via pkg/testutils.
+          weight: 1
+      - R4.4:
+          text: "Tests must cover: single argument (seq 5), two arguments (seq 2 5), three arguments (seq 1 2 10), descending sequence (seq 5 -1 1), floating-point sequence (seq 0.1 0.1 0.5), equal-width (seq -w 8 12), custom separator (seq -s ', ' 1 5), format string (seq -f '%.2f' 1 3), empty sequence, zero step error, and invalid format error."
+          weight: 1
 
 non_goals:
   - cmd/seq does not implement hexadecimal integer output; use -f '%a' for hex floating-point.

--- a/docs/specs/product-requirements/prd020-echo.yaml
+++ b/docs/specs/product-requirements/prd020-echo.yaml
@@ -18,32 +18,60 @@ requirements:
   R1:
     title: Core output behavior
     items:
-      - R1.1: Must write each argument to stdout, separated by single space characters, followed by a newline character.
-      - R1.2: When given no arguments, must write only a newline character to stdout.
-      - R1.3: -n must suppress the trailing newline. Output ends at the last argument character with no newline appended.
-      - R1.4: Arguments beginning with "-" must be passed through as literal text when they are not recognized flags (-n, -e, -E). Unrecognized flags are treated as positional arguments.
+      - R1.1:
+          text: Must write each argument to stdout, separated by single space characters, followed by a newline character.
+          weight: 1
+      - R1.2:
+          text: When given no arguments, must write only a newline character to stdout.
+          weight: 1
+      - R1.3:
+          text: -n must suppress the trailing newline. Output ends at the last argument character with no newline appended.
+          weight: 1
+      - R1.4:
+          text: Arguments beginning with "-" must be passed through as literal text when they are not recognized flags (-n, -e, -E). Unrecognized flags are treated as positional arguments.
+          weight: 1
 
   R2:
     title: Escape sequence interpretation (-e, -E)
     items:
-      - R2.1: "-e must enable interpretation of the following backslash sequences: \\\\  (backslash), \\a (alert/BEL, 0x07), \\b (backspace, 0x08), \\c (suppress all further output including the trailing newline), \\e (escape, 0x1B), \\f (form feed, 0x0C), \\n (newline, 0x0A), \\r (carriage return, 0x0D), \\t (horizontal tab, 0x09), \\v (vertical tab, 0x0B), \\0NNN (octal value NNN, 1-3 digits), \\xHH (hex value HH, 1-2 digits)."
-      - R2.2: "\\c with -e terminates output immediately: no further characters, no trailing newline, regardless of remaining arguments."
-      - R2.3: -E must disable escape interpretation. When -E is active, backslash sequences are written literally. -E is the default; specifying -E explicitly is a no-op when -e has not been given.
-      - R2.4: When both -e and -E are given, the last one on the command line takes precedence.
+      - R2.1:
+          text: "-e must enable interpretation of the following backslash sequences: \\\\  (backslash), \\a (alert/BEL, 0x07), \\b (backspace, 0x08), \\c (suppress all further output including the trailing newline), \\e (escape, 0x1B), \\f (form feed, 0x0C), \\n (newline, 0x0A), \\r (carriage return, 0x0D), \\t (horizontal tab, 0x09), \\v (vertical tab, 0x0B), \\0NNN (octal value NNN, 1-3 digits), \\xHH (hex value HH, 1-2 digits)."
+          weight: 1
+      - R2.2:
+          text: "\\c with -e terminates output immediately: no further characters, no trailing newline, regardless of remaining arguments."
+          weight: 1
+      - R2.3:
+          text: -E must disable escape interpretation. When -E is active, backslash sequences are written literally. -E is the default; specifying -E explicitly is a no-op when -e has not been given.
+          weight: 1
+      - R2.4:
+          text: When both -e and -E are given, the last one on the command line takes precedence.
+          weight: 1
 
   R3:
     title: Exit codes and SIGPIPE
     items:
-      - R3.1: Must exit 0 on successful output.
-      - R3.2: Must exit 1 when a write error occurs on stdout.
-      - R3.3: Must handle SIGPIPE gracefully (exit 0) when stdout is closed by a downstream consumer, using pkg/sys.InstallSIGPIPEHandler.
+      - R3.1:
+          text: Must exit 0 on successful output.
+          weight: 1
+      - R3.2:
+          text: Must exit 1 when a write error occurs on stdout.
+          weight: 1
+      - R3.3:
+          text: Must handle SIGPIPE gracefully (exit 0) when stdout is closed by a downstream consumer, using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
 
   R4:
     title: Differential testing
     items:
-      - R4.1: Differential tests must compare Go echo output against gecho byte-for-byte via pkg/testutils.RunDiffTests.
-      - R4.2: "Tests must cover: no arguments, single argument, multiple arguments, -n flag, -e with each supported escape sequence, -E flag, combined -n -e, and arguments starting with '-'."
-      - R4.3: Tests must use LC_ALL=C to eliminate locale-dependent divergence.
+      - R4.1:
+          text: Differential tests must compare Go echo output against gecho byte-for-byte via pkg/testutils.RunDiffTests.
+          weight: 1
+      - R4.2:
+          text: "Tests must cover: no arguments, single argument, multiple arguments, -n flag, -e with each supported escape sequence, -E flag, combined -n -e, and arguments starting with '-'."
+          weight: 1
+      - R4.3:
+          text: Tests must use LC_ALL=C to eliminate locale-dependent divergence.
+          weight: 1
 
 non_goals:
   - cmd/echo does not implement --help or --version (GNU echo does not process these as flags either; they are printed as literals).

--- a/docs/specs/product-requirements/prd021-tac.yaml
+++ b/docs/specs/product-requirements/prd021-tac.yaml
@@ -18,33 +18,63 @@ requirements:
   R1:
     title: Core reversal behavior
     items:
-      - R1.1: Must read the entire input into memory, split it into records on the separator (default newline), and write the records in reverse order to stdout.
-      - R1.2: Must treat a trailing separator at the end of input as the terminator of the last record, not as a separator before an empty record. This matches gtac behavior where "a\nb\n" reversed produces "b\na\n" not "\nb\na".
-      - R1.3: Must read from stdin when no file arguments are given, or when "-" appears as a filename.
-      - R1.4: When multiple files are given, must process each file independently and write them in argument order (each file's records reversed, files not merged before reversal).
+      - R1.1:
+          text: Must read the entire input into memory, split it into records on the separator (default newline), and write the records in reverse order to stdout.
+          weight: 1
+      - R1.2:
+          text: Must treat a trailing separator at the end of input as the terminator of the last record, not as a separator before an empty record. This matches gtac behavior where "a\nb\n" reversed produces "b\na\n" not "\nb\na".
+          weight: 1
+      - R1.3:
+          text: Must read from stdin when no file arguments are given, or when "-" appears as a filename.
+          weight: 1
+      - R1.4:
+          text: When multiple files are given, must process each file independently and write them in argument order (each file's records reversed, files not merged before reversal).
+          weight: 1
 
   R2:
     title: Separator options (-s, -b, -r)
     items:
-      - R2.1: -s SEP must use SEP as the record separator instead of newline. SEP may be any string.
-      - R2.2: By default the separator follows each record. -b must place the separator before each record instead of after it.
-      - R2.3: -r must interpret the -s SEP argument as a regular expression (Go regexp syntax). Each match of the pattern becomes a record boundary.
-      - R2.4: When -s and -r are combined, the separator is a regex; records are the text between consecutive matches.
+      - R2.1:
+          text: -s SEP must use SEP as the record separator instead of newline. SEP may be any string.
+          weight: 1
+      - R2.2:
+          text: By default the separator follows each record. -b must place the separator before each record instead of after it.
+          weight: 1
+      - R2.3:
+          text: -r must interpret the -s SEP argument as a regular expression (Go regexp syntax). Each match of the pattern becomes a record boundary.
+          weight: 1
+      - R2.4:
+          text: When -s and -r are combined, the separator is a regex; records are the text between consecutive matches.
+          weight: 1
 
   R3:
     title: Exit codes and SIGPIPE
     items:
-      - R3.1: Must exit 0 when all inputs are processed successfully.
-      - R3.2: Must exit 1 when any input file cannot be opened or read, printing the error to stderr. Processing continues for remaining files.
-      - R3.3: Must exit 1 when a write error occurs on stdout.
-      - R3.4: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+      - R3.1:
+          text: Must exit 0 when all inputs are processed successfully.
+          weight: 1
+      - R3.2:
+          text: Must exit 1 when any input file cannot be opened or read, printing the error to stderr. Processing continues for remaining files.
+          weight: 1
+      - R3.3:
+          text: Must exit 1 when a write error occurs on stdout.
+          weight: 1
+      - R3.4:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
 
   R4:
     title: Differential testing
     items:
-      - R4.1: Differential tests must compare Go tac output against gtac byte-for-byte via pkg/testutils.RunDiffTests.
-      - R4.2: "Tests must cover: single-file reversal, stdin reversal, multi-file reversal, -s with a custom separator, -b flag, and a file with no trailing newline."
-      - R4.3: Tests must use LC_ALL=C to eliminate locale-dependent divergence.
+      - R4.1:
+          text: Differential tests must compare Go tac output against gtac byte-for-byte via pkg/testutils.RunDiffTests.
+          weight: 1
+      - R4.2:
+          text: "Tests must cover: single-file reversal, stdin reversal, multi-file reversal, -s with a custom separator, -b flag, and a file with no trailing newline."
+          weight: 1
+      - R4.3:
+          text: Tests must use LC_ALL=C to eliminate locale-dependent divergence.
+          weight: 1
 
 non_goals:
   - cmd/tac does not implement the block-level backward seek optimization from the C source; it buffers the full input in memory.

--- a/docs/specs/product-requirements/prd022-nl.yaml
+++ b/docs/specs/product-requirements/prd022-nl.yaml
@@ -18,34 +18,66 @@ requirements:
   R1:
     title: Default line numbering
     items:
-      - R1.1: By default, must number non-empty lines in the body section only, using right-justified numbers in a field of width 6, with a tab character separating the number from the line content.
-      - R1.2: Empty lines (containing only a newline) in the body section must not be numbered by default. They must be passed through with no number and no separator.
-      - R1.3: Must read from stdin when no file arguments are given. Must read each named file in argument order.
-      - R1.4: Line numbering must be continuous across files when multiple files are given (the counter does not reset between files unless a page delimiter is encountered).
+      - R1.1:
+          text: By default, must number non-empty lines in the body section only, using right-justified numbers in a field of width 6, with a tab character separating the number from the line content.
+          weight: 1
+      - R1.2:
+          text: Empty lines (containing only a newline) in the body section must not be numbered by default. They must be passed through with no number and no separator.
+          weight: 1
+      - R1.3:
+          text: Must read from stdin when no file arguments are given. Must read each named file in argument order.
+          weight: 1
+      - R1.4:
+          text: Line numbering must be continuous across files when multiple files are given (the counter does not reset between files unless a page delimiter is encountered).
+          weight: 1
 
   R2:
     title: Numbering style flags (-b, -h, -f)
     items:
-      - R2.1: "-b STYLE must set the body section numbering style. Styles: a (number all lines), t (number non-empty lines, default), n (number no lines), p RE (number lines matching regular expression RE)."
-      - R2.2: "-h STYLE must set the header section numbering style (default n). Same style values as -b."
-      - R2.3: "-f STYLE must set the footer section numbering style (default n). Same style values as -b."
-      - R2.4: When the style is n for a section, lines in that section must pass through with no number and no separator character.
+      - R2.1:
+          text: "-b STYLE must set the body section numbering style. Styles: a (number all lines), t (number non-empty lines, default), n (number no lines), p RE (number lines matching regular expression RE)."
+          weight: 1
+      - R2.2:
+          text: "-h STYLE must set the header section numbering style (default n). Same style values as -b."
+          weight: 1
+      - R2.3:
+          text: "-f STYLE must set the footer section numbering style (default n). Same style values as -b."
+          weight: 1
+      - R2.4:
+          text: When the style is n for a section, lines in that section must pass through with no number and no separator character.
+          weight: 1
 
   R3:
     title: Format and numbering options (-n, -w, -s, -v, -i, -l)
     items:
-      - R3.1: "-n FORMAT must set the line number format. Formats: ln (left-justified, no leading zeros), rn (right-justified, no leading zeros, default), rz (right-justified, leading zeros)."
-      - R3.2: -w N must set the line number field width to N characters (default 6).
-      - R3.3: -s SEP must use SEP as the separator between the line number and the line content (default tab). SEP may be any string.
-      - R3.4: -v N must set the initial line number to N (default 1). -i N must set the line number increment to N (default 1).
+      - R3.1:
+          text: "-n FORMAT must set the line number format. Formats: ln (left-justified, no leading zeros), rn (right-justified, no leading zeros, default), rz (right-justified, leading zeros)."
+          weight: 1
+      - R3.2:
+          text: -w N must set the line number field width to N characters (default 6).
+          weight: 1
+      - R3.3:
+          text: -s SEP must use SEP as the separator between the line number and the line content (default tab). SEP may be any string.
+          weight: 1
+      - R3.4:
+          text: -v N must set the initial line number to N (default 1). -i N must set the line number increment to N (default 1).
+          weight: 1
 
   R4:
     title: Section delimiters and page reset (-d, -p, -l)
     items:
-      - R4.1: "A line containing only the two-character sequence \\:\\:\\: (the section delimiter repeated three times) marks the start of a header section. \\:\\: marks the start of a body section. \\: marks the start of a footer section. These delimiter lines are not written to output."
-      - R4.2: Each new logical page (triggered by a header delimiter) resets the line counter to the value of -v unless -p is given.
-      - R4.3: -p must suppress line counter reset at the start of each logical page; numbering continues from the previous page's last line number.
-      - R4.4: -l N must treat N consecutive empty lines as a single empty line for the purpose of numbering with -b t. The default is 1 (each empty line counted separately). With -l 2, two or fewer consecutive empty lines are treated as one unnumbered block.
+      - R4.1:
+          text: "A line containing only the two-character sequence \\:\\:\\: (the section delimiter repeated three times) marks the start of a header section. \\:\\: marks the start of a body section. \\: marks the start of a footer section. These delimiter lines are not written to output."
+          weight: 1
+      - R4.2:
+          text: Each new logical page (triggered by a header delimiter) resets the line counter to the value of -v unless -p is given.
+          weight: 1
+      - R4.3:
+          text: -p must suppress line counter reset at the start of each logical page; numbering continues from the previous page's last line number.
+          weight: 1
+      - R4.4:
+          text: -l N must treat N consecutive empty lines as a single empty line for the purpose of numbering with -b t. The default is 1 (each empty line counted separately). With -l 2, two or fewer consecutive empty lines are treated as one unnumbered block.
+          weight: 1
 
 non_goals:
   - cmd/nl does not implement regex-based separator matching beyond the -p RE style argument.

--- a/docs/specs/product-requirements/prd023-fold.yaml
+++ b/docs/specs/product-requirements/prd023-fold.yaml
@@ -18,33 +18,63 @@ requirements:
   R1:
     title: Core line wrapping
     items:
-      - R1.1: Must read each file (or stdin when no arguments are given) and write each line wrapped to at most W characters (columns by default, bytes with -b). The default width is 80.
-      - R1.2: Lines shorter than or equal to the maximum width must be written unchanged (including the trailing newline).
-      - R1.3: Lines longer than the maximum width must be split by inserting a newline after exactly W columns (or bytes with -b). Wrapping is applied repeatedly until the remaining portion fits within the width.
-      - R1.4: The final segment of a wrapped line retains the original newline if the source line ended with one; a line without a trailing newline produces a final segment without one.
+      - R1.1:
+          text: Must read each file (or stdin when no arguments are given) and write each line wrapped to at most W characters (columns by default, bytes with -b). The default width is 80.
+          weight: 1
+      - R1.2:
+          text: Lines shorter than or equal to the maximum width must be written unchanged (including the trailing newline).
+          weight: 1
+      - R1.3:
+          text: Lines longer than the maximum width must be split by inserting a newline after exactly W columns (or bytes with -b). Wrapping is applied repeatedly until the remaining portion fits within the width.
+          weight: 1
+      - R1.4:
+          text: The final segment of a wrapped line retains the original newline if the source line ended with one; a line without a trailing newline produces a final segment without one.
+          weight: 1
 
   R2:
     title: Width and byte-mode flags (-w, -b)
     items:
-      - R2.1: -w N must set the maximum line width to N. N must be a positive integer. If N is 0 or negative, fold must exit with an error message to stderr and exit code 1.
-      - R2.2: By default, width is measured in display columns. Tab characters count as the number of columns needed to reach the next tab stop (tab stops every 8 columns). Other control characters count as one column.
-      - R2.3: -b must measure width in bytes rather than columns. Each byte counts as 1 regardless of whether it is a tab or multi-byte character. This disables tab-stop expansion for width measurement.
+      - R2.1:
+          text: -w N must set the maximum line width to N. N must be a positive integer. If N is 0 or negative, fold must exit with an error message to stderr and exit code 1.
+          weight: 1
+      - R2.2:
+          text: By default, width is measured in display columns. Tab characters count as the number of columns needed to reach the next tab stop (tab stops every 8 columns). Other control characters count as one column.
+          weight: 1
+      - R2.3:
+          text: -b must measure width in bytes rather than columns. Each byte counts as 1 regardless of whether it is a tab or multi-byte character. This disables tab-stop expansion for width measurement.
+          weight: 1
 
   R3:
     title: Space-break mode (-s)
     items:
-      - R3.1: -s must break lines at the last space character at or before the wrap column, rather than at an exact column position.
-      - R3.2: If no space character appears within the first W columns of a segment, -s must fall back to breaking at exactly W columns (same behavior as without -s).
-      - R3.3: The space character at the break point is written as the last character of the current output line before the inserted newline. The next line starts with the character immediately following the space.
-      - R3.4: -s is compatible with -b; space detection uses byte positions when -b is active.
+      - R3.1:
+          text: -s must break lines at the last space character at or before the wrap column, rather than at an exact column position.
+          weight: 1
+      - R3.2:
+          text: If no space character appears within the first W columns of a segment, -s must fall back to breaking at exactly W columns (same behavior as without -s).
+          weight: 1
+      - R3.3:
+          text: The space character at the break point is written as the last character of the current output line before the inserted newline. The next line starts with the character immediately following the space.
+          weight: 1
+      - R3.4:
+          text: -s is compatible with -b; space detection uses byte positions when -b is active.
+          weight: 1
 
   R4:
     title: Exit codes and SIGPIPE
     items:
-      - R4.1: Must exit 0 when all inputs are processed successfully.
-      - R4.2: Must exit 1 when any input file cannot be opened, printing the error to stderr. Processing continues for remaining files.
-      - R4.3: Must exit 1 when a write error occurs on stdout.
-      - R4.4: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+      - R4.1:
+          text: Must exit 0 when all inputs are processed successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any input file cannot be opened, printing the error to stderr. Processing continues for remaining files.
+          weight: 1
+      - R4.3:
+          text: Must exit 1 when a write error occurs on stdout.
+          weight: 1
+      - R4.4:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
 
 non_goals:
   - cmd/fold does not implement Unicode grapheme cluster width calculation; it treats each non-tab byte as one column, matching the GNU reference binary behavior under LC_ALL=C.

--- a/docs/specs/product-requirements/prd024-expand.yaml
+++ b/docs/specs/product-requirements/prd024-expand.yaml
@@ -17,33 +17,63 @@ requirements:
   R1:
     title: Default tab expansion (tab stop every 8 columns)
     items:
-      - R1.1: By default, tab characters must be replaced by enough spaces to advance to the next multiple-of-8 column position. Column positions are 1-indexed; a tab at column 1 advances to column 9.
-      - R1.2: Multiple consecutive tabs must each advance to the next tab stop independently.
-      - R1.3: Non-tab characters must be written unchanged. Each non-tab byte (including multi-byte UTF-8 sequences under LC_ALL=C) counts as one column.
-      - R1.4: Newline characters reset the column position to 1 for the next line.
+      - R1.1:
+          text: By default, tab characters must be replaced by enough spaces to advance to the next multiple-of-8 column position. Column positions are 1-indexed; a tab at column 1 advances to column 9.
+          weight: 1
+      - R1.2:
+          text: Multiple consecutive tabs must each advance to the next tab stop independently.
+          weight: 1
+      - R1.3:
+          text: Non-tab characters must be written unchanged. Each non-tab byte (including multi-byte UTF-8 sequences under LC_ALL=C) counts as one column.
+          weight: 1
+      - R1.4:
+          text: Newline characters reset the column position to 1 for the next line.
+          weight: 1
 
   R2:
     title: Custom tab stops (-t)
     items:
-      - R2.1: "-t N must set a uniform tab stop interval of N columns (equivalent to tab stops at N, 2N, 3N, ...). N must be a positive integer."
-      - R2.2: "-t LIST must set tab stops at the absolute column positions given in LIST (comma-separated or space-separated positive integers in strictly increasing order). A tab at or past the last explicit tab stop is replaced by a single space."
-      - R2.3: The -t option replaces the default tab stop interval of 8. If -t is given multiple times, the last value takes effect.
-      - R2.4: When LIST contains a single value, it behaves identically to -t N (uniform interval).
+      - R2.1:
+          text: "-t N must set a uniform tab stop interval of N columns (equivalent to tab stops at N, 2N, 3N, ...). N must be a positive integer."
+          weight: 1
+      - R2.2:
+          text: "-t LIST must set tab stops at the absolute column positions given in LIST (comma-separated or space-separated positive integers in strictly increasing order). A tab at or past the last explicit tab stop is replaced by a single space."
+          weight: 1
+      - R2.3:
+          text: The -t option replaces the default tab stop interval of 8. If -t is given multiple times, the last value takes effect.
+          weight: 1
+      - R2.4:
+          text: When LIST contains a single value, it behaves identically to -t N (uniform interval).
+          weight: 1
 
   R3:
     title: Exit codes and SIGPIPE
     items:
-      - R3.1: Must exit 0 when all inputs are processed successfully.
-      - R3.2: Must exit 1 when any input file cannot be opened, printing the error to stderr. Processing continues for remaining files.
-      - R3.3: Must exit 1 when a write error occurs on stdout.
-      - R3.4: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+      - R3.1:
+          text: Must exit 0 when all inputs are processed successfully.
+          weight: 1
+      - R3.2:
+          text: Must exit 1 when any input file cannot be opened, printing the error to stderr. Processing continues for remaining files.
+          weight: 1
+      - R3.3:
+          text: Must exit 1 when a write error occurs on stdout.
+          weight: 1
+      - R3.4:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
 
   R4:
     title: Differential testing
     items:
-      - R4.1: Differential tests must compare Go expand output against gexpand byte-for-byte via pkg/testutils.RunDiffTests.
-      - R4.2: "Tests must cover: default tab expansion, -t N with a single interval, -t LIST with multiple tab stops, input with no tabs (passthrough), and multiple tabs in succession."
-      - R4.3: Tests must use LC_ALL=C to eliminate locale-dependent divergence.
+      - R4.1:
+          text: Differential tests must compare Go expand output against gexpand byte-for-byte via pkg/testutils.RunDiffTests.
+          weight: 1
+      - R4.2:
+          text: "Tests must cover: default tab expansion, -t N with a single interval, -t LIST with multiple tab stops, input with no tabs (passthrough), and multiple tabs in succession."
+          weight: 1
+      - R4.3:
+          text: Tests must use LC_ALL=C to eliminate locale-dependent divergence.
+          weight: 1
 
 non_goals:
   - cmd/expand does not process backspace characters for column position adjustment (GNU expand does not adjust for backspaces either under LC_ALL=C).

--- a/docs/specs/product-requirements/prd025-unexpand.yaml
+++ b/docs/specs/product-requirements/prd025-unexpand.yaml
@@ -18,32 +18,60 @@ requirements:
   R1:
     title: Default behavior (leading whitespace only)
     items:
-      - R1.1: By default, unexpand must replace leading spaces (and mixed leading spaces and tabs) with tabs only when doing so advances to the same column position. Tabs are preferred over spaces when a run of spaces reaches a tab stop exactly.
-      - R1.2: Non-leading whitespace must be written unchanged in default mode. Characters after the first non-whitespace character on a line are not converted.
-      - R1.3: A run of spaces that does not exactly reach a tab stop must be kept as spaces; unexpand must not insert a tab that would overshoot the column.
-      - R1.4: Existing tab characters in leading whitespace count toward the column position as in expand; they do not prevent further tab substitution.
+      - R1.1:
+          text: By default, unexpand must replace leading spaces (and mixed leading spaces and tabs) with tabs only when doing so advances to the same column position. Tabs are preferred over spaces when a run of spaces reaches a tab stop exactly.
+          weight: 1
+      - R1.2:
+          text: Non-leading whitespace must be written unchanged in default mode. Characters after the first non-whitespace character on a line are not converted.
+          weight: 1
+      - R1.3:
+          text: A run of spaces that does not exactly reach a tab stop must be kept as spaces; unexpand must not insert a tab that would overshoot the column.
+          weight: 1
+      - R1.4:
+          text: Existing tab characters in leading whitespace count toward the column position as in expand; they do not prevent further tab substitution.
+          weight: 1
 
   R2:
     title: Convert all whitespace (-a)
     items:
-      - R2.1: -a must convert all runs of spaces (not just leading) where replacement with tabs aligns to a tab stop. The rule is the same as R1.1 applied at every column position in the line, not only at the start.
-      - R2.2: A single space that does not reach a tab stop must be kept as a space even with -a.
-      - R2.3: The first non-space, non-tab character on the line does not stop the conversion; -a processes the entire line.
+      - R2.1:
+          text: -a must convert all runs of spaces (not just leading) where replacement with tabs aligns to a tab stop. The rule is the same as R1.1 applied at every column position in the line, not only at the start.
+          weight: 1
+      - R2.2:
+          text: A single space that does not reach a tab stop must be kept as a space even with -a.
+          weight: 1
+      - R2.3:
+          text: The first non-space, non-tab character on the line does not stop the conversion; -a processes the entire line.
+          weight: 1
 
   R3:
     title: Custom tab stops (-t)
     items:
-      - R3.1: -t N must set a uniform tab stop interval of N columns. -t LIST must set absolute tab stop positions. Behavior mirrors prd024-expand R2.1 and R2.2 for tab stop resolution.
-      - R3.2: When past the last explicit tab stop in a LIST, remaining spaces are kept as-is (no tab can be inserted beyond the last defined stop).
-      - R3.3: -t implies -a; when custom tab stops are given, all whitespace in the line is subject to conversion, not just leading whitespace.
+      - R3.1:
+          text: -t N must set a uniform tab stop interval of N columns. -t LIST must set absolute tab stop positions. Behavior mirrors prd024-expand R2.1 and R2.2 for tab stop resolution.
+          weight: 1
+      - R3.2:
+          text: When past the last explicit tab stop in a LIST, remaining spaces are kept as-is (no tab can be inserted beyond the last defined stop).
+          weight: 1
+      - R3.3:
+          text: -t implies -a; when custom tab stops are given, all whitespace in the line is subject to conversion, not just leading whitespace.
+          weight: 1
 
   R4:
     title: Exit codes and SIGPIPE
     items:
-      - R4.1: Must exit 0 when all inputs are processed successfully.
-      - R4.2: Must exit 1 when any input file cannot be opened, printing the error to stderr. Processing continues for remaining files.
-      - R4.3: Must exit 1 when a write error occurs on stdout.
-      - R4.4: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+      - R4.1:
+          text: Must exit 0 when all inputs are processed successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any input file cannot be opened, printing the error to stderr. Processing continues for remaining files.
+          weight: 1
+      - R4.3:
+          text: Must exit 1 when a write error occurs on stdout.
+          weight: 1
+      - R4.4:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
 
 non_goals:
   - cmd/unexpand is not the exact inverse of expand for all inputs; the asymmetry (leading-only default, space-only conversion) is intentional and matches GNU behavior.

--- a/docs/specs/product-requirements/prd026-cut.yaml
+++ b/docs/specs/product-requirements/prd026-cut.yaml
@@ -18,33 +18,63 @@ requirements:
   R1:
     title: Byte and character selection (-b, -c)
     items:
-      - R1.1: -b LIST must extract the specified byte positions from each line. LIST is a comma-separated list of ranges; each range is N, N-M, N- (from N to end), or -M (from start to M). Bytes are 1-indexed.
-      - R1.2: -c LIST must extract the specified character positions. Under LC_ALL=C, -c and -b are equivalent (one byte per character). The flag is provided for compatibility.
-      - R1.3: With -b or -c, newline characters are not counted as part of the line; they are passed through to terminate each output line.
-      - R1.4: Lines shorter than the selected range produce no bytes for the out-of-range positions; only the bytes that exist are output.
+      - R1.1:
+          text: -b LIST must extract the specified byte positions from each line. LIST is a comma-separated list of ranges; each range is N, N-M, N- (from N to end), or -M (from start to M). Bytes are 1-indexed.
+          weight: 1
+      - R1.2:
+          text: -c LIST must extract the specified character positions. Under LC_ALL=C, -c and -b are equivalent (one byte per character). The flag is provided for compatibility.
+          weight: 1
+      - R1.3:
+          text: With -b or -c, newline characters are not counted as part of the line; they are passed through to terminate each output line.
+          weight: 1
+      - R1.4:
+          text: Lines shorter than the selected range produce no bytes for the out-of-range positions; only the bytes that exist are output.
+          weight: 1
 
   R2:
     title: Field selection (-f, -d, -s)
     items:
-      - R2.1: -f LIST must extract the specified fields from each line, where fields are delimited by the character given with -d (default tab). LIST uses the same range syntax as -b.
-      - R2.2: -d DELIM must set the input field delimiter to the single character DELIM. The delimiter must be exactly one byte. When the output delimiter is not explicitly set with --output-delimiter, the input delimiter is also used as the output delimiter.
-      - R2.3: -s must suppress lines that do not contain the delimiter. Without -s, lines with no delimiter are printed unchanged.
-      - R2.4: --output-delimiter STRING must use STRING as the separator between selected output fields, replacing the default (which is the input delimiter).
+      - R2.1:
+          text: -f LIST must extract the specified fields from each line, where fields are delimited by the character given with -d (default tab). LIST uses the same range syntax as -b.
+          weight: 1
+      - R2.2:
+          text: -d DELIM must set the input field delimiter to the single character DELIM. The delimiter must be exactly one byte. When the output delimiter is not explicitly set with --output-delimiter, the input delimiter is also used as the output delimiter.
+          weight: 1
+      - R2.3:
+          text: -s must suppress lines that do not contain the delimiter. Without -s, lines with no delimiter are printed unchanged.
+          weight: 1
+      - R2.4:
+          text: --output-delimiter STRING must use STRING as the separator between selected output fields, replacing the default (which is the input delimiter).
+          weight: 1
 
   R3:
     title: Complement mode (--complement)
     items:
-      - R3.1: --complement must invert the selection; the output contains the bytes, characters, or fields NOT specified by the range list.
-      - R3.2: --complement is compatible with -b, -c, and -f. It is not compatible with -s.
-      - R3.3: With --complement and -f, fields not in the list are output in their original order, separated by the output delimiter.
+      - R3.1:
+          text: --complement must invert the selection; the output contains the bytes, characters, or fields NOT specified by the range list.
+          weight: 1
+      - R3.2:
+          text: --complement is compatible with -b, -c, and -f. It is not compatible with -s.
+          weight: 1
+      - R3.3:
+          text: With --complement and -f, fields not in the list are output in their original order, separated by the output delimiter.
+          weight: 1
 
   R4:
     title: Exit codes and SIGPIPE
     items:
-      - R4.1: Must exit 0 when all inputs are processed successfully.
-      - R4.2: Must exit 1 when any input file cannot be opened, printing the error to stderr. Processing continues for remaining files.
-      - R4.3: Must exit 1 when a write error occurs on stdout.
-      - R4.4: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+      - R4.1:
+          text: Must exit 0 when all inputs are processed successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any input file cannot be opened, printing the error to stderr. Processing continues for remaining files.
+          weight: 1
+      - R4.3:
+          text: Must exit 1 when a write error occurs on stdout.
+          weight: 1
+      - R4.4:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
 
 non_goals:
   - cmd/cut does not support multi-byte delimiters; -d accepts exactly one byte.

--- a/docs/specs/product-requirements/prd027-paste.yaml
+++ b/docs/specs/product-requirements/prd027-paste.yaml
@@ -18,32 +18,60 @@ requirements:
   R1:
     title: Default parallel merge
     items:
-      - R1.1: Must open all named files simultaneously and read one line from each per output line. Lines from files are joined with the delimiter and written to stdout, followed by a newline.
-      - R1.2: When files have unequal line counts, the shorter files contribute empty fields (the delimiter is still written) until all files are exhausted. The final output line ends with a newline.
-      - R1.3: stdin is used as an input when "-" is given as a filename. Multiple "-" arguments each refer to stdin read sequentially.
-      - R1.4: When no files are given, must read from stdin and write each line followed by a newline (passthrough behavior matching gpaste with a single stdin source).
+      - R1.1:
+          text: Must open all named files simultaneously and read one line from each per output line. Lines from files are joined with the delimiter and written to stdout, followed by a newline.
+          weight: 1
+      - R1.2:
+          text: When files have unequal line counts, the shorter files contribute empty fields (the delimiter is still written) until all files are exhausted. The final output line ends with a newline.
+          weight: 1
+      - R1.3:
+          text: stdin is used as an input when "-" is given as a filename. Multiple "-" arguments each refer to stdin read sequentially.
+          weight: 1
+      - R1.4:
+          text: When no files are given, must read from stdin and write each line followed by a newline (passthrough behavior matching gpaste with a single stdin source).
+          weight: 1
 
   R2:
     title: Delimiter configuration (-d)
     items:
-      - R2.1: -d DELIM must use DELIM as the separator between fields. DELIM may be a single character or a list; if a list is given, the delimiters are cycled in order across the fields of each output line.
-      - R2.2: The escape sequences \\n (newline), \\t (tab), \\\\ (backslash), and \\0 (empty string, no delimiter) are recognized in DELIM.
-      - R2.3: When DELIM cycles back to the start for a new output line, cycling resets from the first delimiter in the list.
+      - R2.1:
+          text: -d DELIM must use DELIM as the separator between fields. DELIM may be a single character or a list; if a list is given, the delimiters are cycled in order across the fields of each output line.
+          weight: 1
+      - R2.2:
+          text: The escape sequences \\n (newline), \\t (tab), \\\\ (backslash), and \\0 (empty string, no delimiter) are recognized in DELIM.
+          weight: 1
+      - R2.3:
+          text: When DELIM cycles back to the start for a new output line, cycling resets from the first delimiter in the list.
+          weight: 1
 
   R3:
     title: Serial mode (-s)
     items:
-      - R3.1: -s must process files one at a time. All lines of the first file are joined with the delimiter and written as a single output line. Then all lines of the second file are written as a single output line, and so on.
-      - R3.2: In serial mode, the delimiter list cycles across fields within the single output line for each file. The trailing newline is always written.
-      - R3.3: -s and the default parallel mode are mutually exclusive; -s overrides parallel mode.
+      - R3.1:
+          text: -s must process files one at a time. All lines of the first file are joined with the delimiter and written as a single output line. Then all lines of the second file are written as a single output line, and so on.
+          weight: 1
+      - R3.2:
+          text: In serial mode, the delimiter list cycles across fields within the single output line for each file. The trailing newline is always written.
+          weight: 1
+      - R3.3:
+          text: -s and the default parallel mode are mutually exclusive; -s overrides parallel mode.
+          weight: 1
 
   R4:
     title: Exit codes and SIGPIPE
     items:
-      - R4.1: Must exit 0 when all inputs are processed successfully.
-      - R4.2: Must exit 1 when any input file cannot be opened, printing the error to stderr. Processing halts on the first error.
-      - R4.3: Must exit 1 when a write error occurs on stdout.
-      - R4.4: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+      - R4.1:
+          text: Must exit 0 when all inputs are processed successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any input file cannot be opened, printing the error to stderr. Processing halts on the first error.
+          weight: 1
+      - R4.3:
+          text: Must exit 1 when a write error occurs on stdout.
+          weight: 1
+      - R4.4:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
 
 non_goals:
   - cmd/paste does not buffer entire files in memory; it reads one line per file per output line in parallel mode.

--- a/docs/specs/product-requirements/prd028-uniq.yaml
+++ b/docs/specs/product-requirements/prd028-uniq.yaml
@@ -18,34 +18,66 @@ requirements:
   R1:
     title: Default deduplication
     items:
-      - R1.1: By default, must read each line and write it once, suppressing all but the first occurrence of any run of identical adjacent lines.
-      - R1.2: Lines that appear only once must be written. Lines that appear multiple times in a run must be written once. Non-adjacent duplicates are unaffected (uniq does not sort input).
-      - R1.3: Must read from stdin when no file argument is given. Must accept an optional output file as a second argument.
-      - R1.4: Comparison is case-sensitive by default. Each line includes the newline terminator in the comparison.
+      - R1.1:
+          text: By default, must read each line and write it once, suppressing all but the first occurrence of any run of identical adjacent lines.
+          weight: 1
+      - R1.2:
+          text: Lines that appear only once must be written. Lines that appear multiple times in a run must be written once. Non-adjacent duplicates are unaffected (uniq does not sort input).
+          weight: 1
+      - R1.3:
+          text: Must read from stdin when no file argument is given. Must accept an optional output file as a second argument.
+          weight: 1
+      - R1.4:
+          text: Comparison is case-sensitive by default. Each line includes the newline terminator in the comparison.
+          weight: 1
 
   R2:
     title: Output selection (-d, -D, -u, -c)
     items:
-      - R2.1: -d must print only lines that appear more than once in a run (one copy per run). Lines that appear only once are suppressed.
-      - R2.2: -D must print all lines of each run that appears more than once. Every copy of a duplicated run is written, not just the first.
-      - R2.3: -u must print only lines that appear exactly once (runs of one).
-      - R2.4: -c must prefix each output line with the count of occurrences in its run, right-justified in a field wide enough to hold the count, followed by a space and the line.
+      - R2.1:
+          text: -d must print only lines that appear more than once in a run (one copy per run). Lines that appear only once are suppressed.
+          weight: 1
+      - R2.2:
+          text: -D must print all lines of each run that appears more than once. Every copy of a duplicated run is written, not just the first.
+          weight: 1
+      - R2.3:
+          text: -u must print only lines that appear exactly once (runs of one).
+          weight: 1
+      - R2.4:
+          text: -c must prefix each output line with the count of occurrences in its run, right-justified in a field wide enough to hold the count, followed by a space and the line.
+          weight: 1
 
   R3:
     title: Comparison options (-i, -f, -s, -w)
     items:
-      - R3.1: -i must perform case-insensitive comparison. Lines that differ only in case are treated as duplicates.
-      - R3.2: -f N must skip the first N fields (whitespace-separated tokens) of each line before comparing. The skipped fields are still written to output.
-      - R3.3: -s N must skip the first N characters of each line before comparing. The skipped characters are still written to output.
-      - R3.4: -w N must compare only the first N characters of each line (after -f and -s adjustments). Characters beyond N are ignored for comparison purposes but still written.
+      - R3.1:
+          text: -i must perform case-insensitive comparison. Lines that differ only in case are treated as duplicates.
+          weight: 1
+      - R3.2:
+          text: -f N must skip the first N fields (whitespace-separated tokens) of each line before comparing. The skipped fields are still written to output.
+          weight: 1
+      - R3.3:
+          text: -s N must skip the first N characters of each line before comparing. The skipped characters are still written to output.
+          weight: 1
+      - R3.4:
+          text: -w N must compare only the first N characters of each line (after -f and -s adjustments). Characters beyond N are ignored for comparison purposes but still written.
+          weight: 1
 
   R4:
     title: Exit codes and SIGPIPE
     items:
-      - R4.1: Must exit 0 when all inputs are processed successfully.
-      - R4.2: Must exit 1 when any input file cannot be opened, printing the error to stderr.
-      - R4.3: Must exit 1 when a write error occurs on stdout.
-      - R4.4: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+      - R4.1:
+          text: Must exit 0 when all inputs are processed successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any input file cannot be opened, printing the error to stderr.
+          weight: 1
+      - R4.3:
+          text: Must exit 1 when a write error occurs on stdout.
+          weight: 1
+      - R4.4:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
 
 non_goals:
   - cmd/uniq does not sort its input; it operates only on adjacent duplicates.

--- a/docs/specs/product-requirements/prd029-comm.yaml
+++ b/docs/specs/product-requirements/prd029-comm.yaml
@@ -18,34 +18,66 @@ requirements:
   R1:
     title: Three-column comparison output
     items:
-      - R1.1: Must read file1 and file2 simultaneously, line by line. Lines present only in file1 are written in column 1 (no indentation). Lines present only in file2 are written in column 2 (one tab indent). Lines present in both are written in column 3 (two tabs indent).
-      - R1.2: Must process files in sorted order; when a line from file1 is lexicographically less than the current file2 line, it is a column-1 line. When file2's line is less, it is a column-2 line. Equal lines go to column 3.
-      - R1.3: When one file is exhausted, all remaining lines from the other file go to the appropriate column (column 1 if file1 has lines left, column 2 if file2 has lines left).
-      - R1.4: Comparison is byte-for-byte with LC_ALL=C (no locale collation). An optional newline at the end of the last line does not affect comparison.
+      - R1.1:
+          text: Must read file1 and file2 simultaneously, line by line. Lines present only in file1 are written in column 1 (no indentation). Lines present only in file2 are written in column 2 (one tab indent). Lines present in both are written in column 3 (two tabs indent).
+          weight: 1
+      - R1.2:
+          text: Must process files in sorted order; when a line from file1 is lexicographically less than the current file2 line, it is a column-1 line. When file2's line is less, it is a column-2 line. Equal lines go to column 3.
+          weight: 1
+      - R1.3:
+          text: When one file is exhausted, all remaining lines from the other file go to the appropriate column (column 1 if file1 has lines left, column 2 if file2 has lines left).
+          weight: 1
+      - R1.4:
+          text: Comparison is byte-for-byte with LC_ALL=C (no locale collation). An optional newline at the end of the last line does not affect comparison.
+          weight: 1
 
   R2:
     title: Column suppression flags (-1, -2, -3)
     items:
-      - R2.1: -1 must suppress column 1 (lines unique to file1). The remaining columns shift left in indentation.
-      - R2.2: -2 must suppress column 2 (lines unique to file2). The remaining columns shift left accordingly.
-      - R2.3: -3 must suppress column 3 (lines common to both files). Combining -1 -2 -3 produces no output.
-      - R2.4: When a column is suppressed, the tab indentation for remaining columns adjusts so that the leftmost output column has no leading tab.
+      - R2.1:
+          text: -1 must suppress column 1 (lines unique to file1). The remaining columns shift left in indentation.
+          weight: 1
+      - R2.2:
+          text: -2 must suppress column 2 (lines unique to file2). The remaining columns shift left accordingly.
+          weight: 1
+      - R2.3:
+          text: -3 must suppress column 3 (lines common to both files). Combining -1 -2 -3 produces no output.
+          weight: 1
+      - R2.4:
+          text: When a column is suppressed, the tab indentation for remaining columns adjusts so that the leftmost output column has no leading tab.
+          weight: 1
 
   R3:
     title: Order checking and output delimiter
     items:
-      - R3.1: By default, comm checks that input files are sorted. When a line is encountered that is less than the previous line in the same file, comm prints a warning to stderr and continues.
-      - R3.2: --check-order makes the ordering check fatal; comm exits non-zero if input is not sorted.
-      - R3.3: --nocheck-order disables the sorting check entirely; no warning is printed even if input is out of order.
-      - R3.4: --output-delimiter=STRING replaces the default tab character as the column separator. All column indentation levels use STRING instead of a tab.
+      - R3.1:
+          text: By default, comm checks that input files are sorted. When a line is encountered that is less than the previous line in the same file, comm prints a warning to stderr and continues.
+          weight: 1
+      - R3.2:
+          text: --check-order makes the ordering check fatal; comm exits non-zero if input is not sorted.
+          weight: 1
+      - R3.3:
+          text: --nocheck-order disables the sorting check entirely; no warning is printed even if input is out of order.
+          weight: 1
+      - R3.4:
+          text: --output-delimiter=STRING replaces the default tab character as the column separator. All column indentation levels use STRING instead of a tab.
+          weight: 1
 
   R4:
     title: Exit codes and SIGPIPE
     items:
-      - R4.1: Must exit 0 when all inputs are processed successfully and no order violations occur.
-      - R4.2: Must exit 1 when any input file cannot be opened, printing the error to stderr.
-      - R4.3: Must exit 1 when a write error occurs on stdout.
-      - R4.4: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+      - R4.1:
+          text: Must exit 0 when all inputs are processed successfully and no order violations occur.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any input file cannot be opened, printing the error to stderr.
+          weight: 1
+      - R4.3:
+          text: Must exit 1 when a write error occurs on stdout.
+          weight: 1
+      - R4.4:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
 
 non_goals:
   - cmd/comm does not sort its inputs; both files must already be sorted before invocation.

--- a/docs/specs/product-requirements/prd030-md5sum.yaml
+++ b/docs/specs/product-requirements/prd030-md5sum.yaml
@@ -18,32 +18,60 @@ requirements:
   R1:
     title: Digest computation
     items:
-      - R1.1: Must compute the MD5 digest of each named file and write one line per file in the format "HASH  FILENAME" (two spaces for text mode, one space and asterisk "HASH *FILENAME" for binary mode). The default is text mode on non-Windows systems.
-      - R1.2: Must read from stdin and print "HASH  -" when no file arguments are given or when "-" is provided as a filename.
-      - R1.3: --tag must use BSD-style output format "MD5 (FILENAME) = HASH" instead of the default GNU format.
-      - R1.4: Must exit 1 when any named file cannot be opened, printing an error to stderr, and continue processing remaining files.
+      - R1.1:
+          text: Must compute the MD5 digest of each named file and write one line per file in the format "HASH  FILENAME" (two spaces for text mode, one space and asterisk "HASH *FILENAME" for binary mode). The default is text mode on non-Windows systems.
+          weight: 1
+      - R1.2:
+          text: Must read from stdin and print "HASH  -" when no file arguments are given or when "-" is provided as a filename.
+          weight: 1
+      - R1.3:
+          text: --tag must use BSD-style output format "MD5 (FILENAME) = HASH" instead of the default GNU format.
+          weight: 1
+      - R1.4:
+          text: Must exit 1 when any named file cannot be opened, printing an error to stderr, and continue processing remaining files.
+          weight: 1
 
   R2:
     title: Checksum verification (--check, -c)
     items:
-      - R2.1: "--check FILE must read FILE line by line, parsing lines in GNU format (HASH  FILENAME or HASH *FILENAME) or BSD tag format, compute the digest for each named file, and compare it to the stored hash."
-      - R2.2: 'For each verified file, must print "FILENAME: OK" or "FILENAME: FAILED" to stdout. After processing all entries, if any failed, must exit 1.'
-      - R2.3: --warn (-w) must print a warning to stderr for each improperly formatted line in the checksum file; without --warn, malformed lines are silently skipped.
-      - R2.4: --quiet suppresses the "OK" lines; only failures are printed. --status suppresses all output; exit code conveys success/failure.
+      - R2.1:
+          text: "--check FILE must read FILE line by line, parsing lines in GNU format (HASH  FILENAME or HASH *FILENAME) or BSD tag format, compute the digest for each named file, and compare it to the stored hash."
+          weight: 1
+      - R2.2:
+          text: 'For each verified file, must print "FILENAME: OK" or "FILENAME: FAILED" to stdout. After processing all entries, if any failed, must exit 1.'
+          weight: 1
+      - R2.3:
+          text: --warn (-w) must print a warning to stderr for each improperly formatted line in the checksum file; without --warn, malformed lines are silently skipped.
+          weight: 1
+      - R2.4:
+          text: --quiet suppresses the "OK" lines; only failures are printed. --status suppresses all output; exit code conveys success/failure.
+          weight: 1
 
   R3:
     title: Binary and text mode flags
     items:
-      - R3.1: -b (--binary) marks the input as binary; the output line uses one space followed by an asterisk before the filename ("HASH *FILENAME"). On Linux/macOS there is no functional difference between binary and text mode for digest computation.
-      - R3.2: -t (--text) is the default; the output line uses two spaces before the filename ("HASH  FILENAME").
-      - R3.3: When --tag is given with -b, the output is BSD tag format; the mode flag has no effect on the tag format.
+      - R3.1:
+          text: -b (--binary) marks the input as binary; the output line uses one space followed by an asterisk before the filename ("HASH *FILENAME"). On Linux/macOS there is no functional difference between binary and text mode for digest computation.
+          weight: 1
+      - R3.2:
+          text: -t (--text) is the default; the output line uses two spaces before the filename ("HASH  FILENAME").
+          weight: 1
+      - R3.3:
+          text: When --tag is given with -b, the output is BSD tag format; the mode flag has no effect on the tag format.
+          weight: 1
 
   R4:
     title: Exit codes and SIGPIPE
     items:
-      - R4.1: Must exit 0 when all files are processed and all verified digests match.
-      - R4.2: Must exit 1 when any file cannot be opened, any digest fails verification, or the checksum file is unreadable.
-      - R4.3: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+      - R4.1:
+          text: Must exit 0 when all files are processed and all verified digests match.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any file cannot be opened, any digest fails verification, or the checksum file is unreadable.
+          weight: 1
+      - R4.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
 
 non_goals:
   - cmd/md5sum does not implement HMAC-MD5 or keyed variants; it computes raw MD5 digests only.

--- a/docs/specs/product-requirements/prd031-sha1sum.yaml
+++ b/docs/specs/product-requirements/prd031-sha1sum.yaml
@@ -18,30 +18,54 @@ requirements:
   R1:
     title: Digest computation
     items:
-      - R1.1: Must compute the SHA-1 digest of each named file and write one line per file in the format "HASH  FILENAME" (text mode) or "HASH *FILENAME" (binary mode). The default is text mode.
-      - R1.2: Must read from stdin and print "HASH  -" when no file arguments are given or when "-" is provided as a filename.
-      - R1.3: --tag must use BSD-style output format "SHA1 (FILENAME) = HASH".
-      - R1.4: Must exit 1 when any named file cannot be opened, printing an error to stderr, and continue processing remaining files.
+      - R1.1:
+          text: Must compute the SHA-1 digest of each named file and write one line per file in the format "HASH  FILENAME" (text mode) or "HASH *FILENAME" (binary mode). The default is text mode.
+          weight: 1
+      - R1.2:
+          text: Must read from stdin and print "HASH  -" when no file arguments are given or when "-" is provided as a filename.
+          weight: 1
+      - R1.3:
+          text: --tag must use BSD-style output format "SHA1 (FILENAME) = HASH".
+          weight: 1
+      - R1.4:
+          text: Must exit 1 when any named file cannot be opened, printing an error to stderr, and continue processing remaining files.
+          weight: 1
 
   R2:
     title: Checksum verification (--check, -c)
     items:
-      - R2.1: "--check FILE must read FILE, parse each line (GNU or BSD tag format), recompute the digest, and compare to the stored hash."
-      - R2.2: 'Must print "FILENAME: OK" or "FILENAME: FAILED" for each entry. Must exit 1 if any check fails.'
-      - R2.3: --warn prints a warning for each malformed line. --quiet suppresses OK lines. --status suppresses all output.
+      - R2.1:
+          text: "--check FILE must read FILE, parse each line (GNU or BSD tag format), recompute the digest, and compare to the stored hash."
+          weight: 1
+      - R2.2:
+          text: 'Must print "FILENAME: OK" or "FILENAME: FAILED" for each entry. Must exit 1 if any check fails.'
+          weight: 1
+      - R2.3:
+          text: --warn prints a warning for each malformed line. --quiet suppresses OK lines. --status suppresses all output.
+          weight: 1
 
   R3:
     title: Binary and text mode flags
     items:
-      - R3.1: -b marks input as binary; output uses "HASH *FILENAME". -t (default) uses "HASH  FILENAME". On Linux/macOS, no functional difference for digest computation.
-      - R3.2: --tag produces BSD tag format regardless of -b/-t.
+      - R3.1:
+          text: -b marks input as binary; output uses "HASH *FILENAME". -t (default) uses "HASH  FILENAME". On Linux/macOS, no functional difference for digest computation.
+          weight: 1
+      - R3.2:
+          text: --tag produces BSD tag format regardless of -b/-t.
+          weight: 1
 
   R4:
     title: Exit codes and SIGPIPE
     items:
-      - R4.1: Must exit 0 when all files are processed and all verified digests match.
-      - R4.2: Must exit 1 when any file cannot be opened, any digest fails, or the checksum file is unreadable.
-      - R4.3: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+      - R4.1:
+          text: Must exit 0 when all files are processed and all verified digests match.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any file cannot be opened, any digest fails, or the checksum file is unreadable.
+          weight: 1
+      - R4.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
 
 non_goals:
   - cmd/sha1sum does not implement HMAC-SHA1 or keyed variants.

--- a/docs/specs/product-requirements/prd032-sha256sum.yaml
+++ b/docs/specs/product-requirements/prd032-sha256sum.yaml
@@ -18,30 +18,54 @@ requirements:
   R1:
     title: Digest computation
     items:
-      - R1.1: Must compute the SHA-256 digest of each named file and write one line per file in the format "HASH  FILENAME" (text mode) or "HASH *FILENAME" (binary mode). The default is text mode.
-      - R1.2: Must read from stdin and print "HASH  -" when no file arguments are given or when "-" is provided as a filename.
-      - R1.3: --tag must use BSD-style output format "SHA256 (FILENAME) = HASH".
-      - R1.4: Must exit 1 when any named file cannot be opened, printing an error to stderr, and continue processing remaining files.
+      - R1.1:
+          text: Must compute the SHA-256 digest of each named file and write one line per file in the format "HASH  FILENAME" (text mode) or "HASH *FILENAME" (binary mode). The default is text mode.
+          weight: 1
+      - R1.2:
+          text: Must read from stdin and print "HASH  -" when no file arguments are given or when "-" is provided as a filename.
+          weight: 1
+      - R1.3:
+          text: --tag must use BSD-style output format "SHA256 (FILENAME) = HASH".
+          weight: 1
+      - R1.4:
+          text: Must exit 1 when any named file cannot be opened, printing an error to stderr, and continue processing remaining files.
+          weight: 1
 
   R2:
     title: Checksum verification (--check, -c)
     items:
-      - R2.1: "--check FILE must read FILE, parse each line (GNU or BSD tag format), recompute the SHA-256 digest, and compare to the stored hash."
-      - R2.2: 'Must print "FILENAME: OK" or "FILENAME: FAILED" for each entry. Must exit 1 if any check fails.'
-      - R2.3: --warn prints a warning for each malformed line. --quiet suppresses OK lines. --status suppresses all output.
+      - R2.1:
+          text: "--check FILE must read FILE, parse each line (GNU or BSD tag format), recompute the SHA-256 digest, and compare to the stored hash."
+          weight: 1
+      - R2.2:
+          text: 'Must print "FILENAME: OK" or "FILENAME: FAILED" for each entry. Must exit 1 if any check fails.'
+          weight: 1
+      - R2.3:
+          text: --warn prints a warning for each malformed line. --quiet suppresses OK lines. --status suppresses all output.
+          weight: 1
 
   R3:
     title: Binary and text mode flags
     items:
-      - R3.1: -b marks input as binary; output uses "HASH *FILENAME". -t (default) uses "HASH  FILENAME".
-      - R3.2: --tag produces BSD tag format regardless of -b/-t.
+      - R3.1:
+          text: -b marks input as binary; output uses "HASH *FILENAME". -t (default) uses "HASH  FILENAME".
+          weight: 1
+      - R3.2:
+          text: --tag produces BSD tag format regardless of -b/-t.
+          weight: 1
 
   R4:
     title: Exit codes and SIGPIPE
     items:
-      - R4.1: Must exit 0 when all files are processed and all verified digests match.
-      - R4.2: Must exit 1 when any file cannot be opened, any digest fails, or the checksum file is unreadable.
-      - R4.3: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+      - R4.1:
+          text: Must exit 0 when all files are processed and all verified digests match.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any file cannot be opened, any digest fails, or the checksum file is unreadable.
+          weight: 1
+      - R4.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
 
 non_goals:
   - cmd/sha256sum does not implement HMAC-SHA256 or keyed variants.

--- a/docs/specs/product-requirements/prd033-sha512sum.yaml
+++ b/docs/specs/product-requirements/prd033-sha512sum.yaml
@@ -18,30 +18,54 @@ requirements:
   R1:
     title: Digest computation
     items:
-      - R1.1: Must compute the SHA-512 digest of each named file and write one line per file in the format "HASH  FILENAME" (text mode) or "HASH *FILENAME" (binary mode). The default is text mode.
-      - R1.2: Must read from stdin and print "HASH  -" when no file arguments are given or when "-" is provided as a filename.
-      - R1.3: --tag must use BSD-style output format "SHA512 (FILENAME) = HASH".
-      - R1.4: Must exit 1 when any named file cannot be opened, printing an error to stderr, and continue processing remaining files.
+      - R1.1:
+          text: Must compute the SHA-512 digest of each named file and write one line per file in the format "HASH  FILENAME" (text mode) or "HASH *FILENAME" (binary mode). The default is text mode.
+          weight: 1
+      - R1.2:
+          text: Must read from stdin and print "HASH  -" when no file arguments are given or when "-" is provided as a filename.
+          weight: 1
+      - R1.3:
+          text: --tag must use BSD-style output format "SHA512 (FILENAME) = HASH".
+          weight: 1
+      - R1.4:
+          text: Must exit 1 when any named file cannot be opened, printing an error to stderr, and continue processing remaining files.
+          weight: 1
 
   R2:
     title: Checksum verification (--check, -c)
     items:
-      - R2.1: "--check FILE must read FILE, parse each line (GNU or BSD tag format), recompute the SHA-512 digest, and compare to the stored hash."
-      - R2.2: 'Must print "FILENAME: OK" or "FILENAME: FAILED" for each entry. Must exit 1 if any check fails.'
-      - R2.3: --warn prints a warning for each malformed line. --quiet suppresses OK lines. --status suppresses all output.
+      - R2.1:
+          text: "--check FILE must read FILE, parse each line (GNU or BSD tag format), recompute the SHA-512 digest, and compare to the stored hash."
+          weight: 1
+      - R2.2:
+          text: 'Must print "FILENAME: OK" or "FILENAME: FAILED" for each entry. Must exit 1 if any check fails.'
+          weight: 1
+      - R2.3:
+          text: --warn prints a warning for each malformed line. --quiet suppresses OK lines. --status suppresses all output.
+          weight: 1
 
   R3:
     title: Binary and text mode flags
     items:
-      - R3.1: -b marks input as binary; output uses "HASH *FILENAME". -t (default) uses "HASH  FILENAME".
-      - R3.2: --tag produces BSD tag format regardless of -b/-t.
+      - R3.1:
+          text: -b marks input as binary; output uses "HASH *FILENAME". -t (default) uses "HASH  FILENAME".
+          weight: 1
+      - R3.2:
+          text: --tag produces BSD tag format regardless of -b/-t.
+          weight: 1
 
   R4:
     title: Exit codes and SIGPIPE
     items:
-      - R4.1: Must exit 0 when all files are processed and all verified digests match.
-      - R4.2: Must exit 1 when any file cannot be opened, any digest fails, or the checksum file is unreadable.
-      - R4.3: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+      - R4.1:
+          text: Must exit 0 when all files are processed and all verified digests match.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any file cannot be opened, any digest fails, or the checksum file is unreadable.
+          weight: 1
+      - R4.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
 
 non_goals:
   - cmd/sha512sum does not implement HMAC-SHA512 or keyed variants.

--- a/docs/specs/product-requirements/prd034-mkdir.yaml
+++ b/docs/specs/product-requirements/prd034-mkdir.yaml
@@ -17,32 +17,60 @@ requirements:
   R1:
     title: Basic directory creation
     items:
-      - R1.1: Must create a single directory when invoked as 'mkdir DIR'.
-      - R1.2: Must create multiple directories when invoked with multiple DIR arguments, processing each independently.
-      - R1.3: Must exit with a non-zero status and print an error to stderr when a target directory already exists and -p is not given.
-      - R1.4: Must exit with a non-zero status and print an error to stderr when the parent of the target does not exist and -p is not given.
+      - R1.1:
+          text: Must create a single directory when invoked as 'mkdir DIR'.
+          weight: 1
+      - R1.2:
+          text: Must create multiple directories when invoked with multiple DIR arguments, processing each independently.
+          weight: 1
+      - R1.3:
+          text: Must exit with a non-zero status and print an error to stderr when a target directory already exists and -p is not given.
+          weight: 1
+      - R1.4:
+          text: Must exit with a non-zero status and print an error to stderr when the parent of the target does not exist and -p is not given.
+          weight: 1
 
   R2:
     title: Parent directory creation (-p, --parents)
     items:
-      - R2.1: -p or --parents must create intermediate parent directories as needed, similar to 'mkdir -p a/b/c' creating a, a/b, and a/b/c.
-      - R2.2: Must not report an error when the target directory already exists and -p is given.
-      - R2.3: Must not report an error when intermediate directories already exist and -p is given.
+      - R2.1:
+          text: -p or --parents must create intermediate parent directories as needed, similar to 'mkdir -p a/b/c' creating a, a/b, and a/b/c.
+          weight: 1
+      - R2.2:
+          text: Must not report an error when the target directory already exists and -p is given.
+          weight: 1
+      - R2.3:
+          text: Must not report an error when intermediate directories already exist and -p is given.
+          weight: 1
 
   R3:
     title: Mode setting (-m, --mode)
     items:
-      - R3.1: -m MODE or --mode=MODE must set the file permission bits of the created directory to MODE, where MODE is an octal value or symbolic mode string.
-      - R3.2: When -m is not given, must create directories with default permissions (0777 modified by the process umask).
-      - R3.3: When -p is combined with -m, must apply the specified mode only to the final target directory; intermediate directories must be created with default permissions modified by umask.
-      - R3.4: -v or --verbose must print a message to stdout for each directory created.
+      - R3.1:
+          text: -m MODE or --mode=MODE must set the file permission bits of the created directory to MODE, where MODE is an octal value or symbolic mode string.
+          weight: 1
+      - R3.2:
+          text: When -m is not given, must create directories with default permissions (0777 modified by the process umask).
+          weight: 1
+      - R3.3:
+          text: When -p is combined with -m, must apply the specified mode only to the final target directory; intermediate directories must be created with default permissions modified by umask.
+          weight: 1
+      - R3.4:
+          text: -v or --verbose must print a message to stdout for each directory created.
+          weight: 1
 
   R4:
     title: Differential testing
     items:
-      - R4.1: Differential tests must compare stdout, stderr, and exit codes between the Go binary and gmkdir via pkg/testutils.
-      - R4.2: "Tests must cover: single directory creation, multiple directory creation, -p with nested paths, -p on existing directory, -m with octal mode, -v verbose output, and error cases for missing parents and existing targets."
-      - R4.3: Tests must verify that permission bits match between the Go implementation and gmkdir for all -m and -p combinations.
+      - R4.1:
+          text: Differential tests must compare stdout, stderr, and exit codes between the Go binary and gmkdir via pkg/testutils.
+          weight: 1
+      - R4.2:
+          text: "Tests must cover: single directory creation, multiple directory creation, -p with nested paths, -p on existing directory, -m with octal mode, -v verbose output, and error cases for missing parents and existing targets."
+          weight: 1
+      - R4.3:
+          text: Tests must verify that permission bits match between the Go implementation and gmkdir for all -m and -p combinations.
+          weight: 1
 
 non_goals:
   - cmd/mkdir does not implement SELinux context options (-Z, --context).

--- a/docs/specs/product-requirements/prd035-rmdir.yaml
+++ b/docs/specs/product-requirements/prd035-rmdir.yaml
@@ -17,32 +17,60 @@ requirements:
   R1:
     title: Basic empty directory removal
     items:
-      - R1.1: Must remove a single empty directory when invoked as 'rmdir DIR'.
-      - R1.2: Must remove multiple empty directories when invoked with multiple DIR arguments, processing each independently.
-      - R1.3: Must exit with a non-zero status and print an error to stderr when a target directory is not empty.
-      - R1.4: Must exit with a non-zero status and print an error to stderr when a target does not exist or is not a directory.
+      - R1.1:
+          text: Must remove a single empty directory when invoked as 'rmdir DIR'.
+          weight: 1
+      - R1.2:
+          text: Must remove multiple empty directories when invoked with multiple DIR arguments, processing each independently.
+          weight: 1
+      - R1.3:
+          text: Must exit with a non-zero status and print an error to stderr when a target directory is not empty.
+          weight: 1
+      - R1.4:
+          text: Must exit with a non-zero status and print an error to stderr when a target does not exist or is not a directory.
+          weight: 1
 
   R2:
     title: Parent removal (-p, --parents)
     items:
-      - R2.1: -p or --parents must remove the target directory and then remove each successive empty parent component of the path, similar to 'rmdir -p a/b/c' removing c, then b, then a.
-      - R2.2: Must stop ascending when a parent directory is not empty and report an error for that component.
-      - R2.3: Must process each DIR argument independently when -p is combined with multiple arguments.
+      - R2.1:
+          text: -p or --parents must remove the target directory and then remove each successive empty parent component of the path, similar to 'rmdir -p a/b/c' removing c, then b, then a.
+          weight: 1
+      - R2.2:
+          text: Must stop ascending when a parent directory is not empty and report an error for that component.
+          weight: 1
+      - R2.3:
+          text: Must process each DIR argument independently when -p is combined with multiple arguments.
+          weight: 1
 
   R3:
     title: Error handling and verbosity
     items:
-      - R3.1: --ignore-fail-on-non-empty must suppress error messages and the non-zero exit status caused by a directory not being empty.
-      - R3.2: --ignore-fail-on-non-empty must not suppress errors for other failure reasons such as permission denied or non-existent target.
-      - R3.3: -v or --verbose must print a message to stdout for each directory successfully removed.
-      - R3.4: Must exit 0 when all requested directories are successfully removed, and exit non-zero when any removal fails (unless suppressed by --ignore-fail-on-non-empty).
+      - R3.1:
+          text: --ignore-fail-on-non-empty must suppress error messages and the non-zero exit status caused by a directory not being empty.
+          weight: 1
+      - R3.2:
+          text: --ignore-fail-on-non-empty must not suppress errors for other failure reasons such as permission denied or non-existent target.
+          weight: 1
+      - R3.3:
+          text: -v or --verbose must print a message to stdout for each directory successfully removed.
+          weight: 1
+      - R3.4:
+          text: Must exit 0 when all requested directories are successfully removed, and exit non-zero when any removal fails (unless suppressed by --ignore-fail-on-non-empty).
+          weight: 1
 
   R4:
     title: Differential testing
     items:
-      - R4.1: Differential tests must compare stdout, stderr, and exit codes between the Go binary and grmdir via pkg/testutils.
-      - R4.2: "Tests must cover: single empty directory removal, multiple directories, -p with nested empty directories, non-empty directory error, non-existent directory error, --ignore-fail-on-non-empty suppression, and -v verbose output."
-      - R4.3: Tests must verify that -p stops ascending correctly when a parent is not empty, matching grmdir behavior.
+      - R4.1:
+          text: Differential tests must compare stdout, stderr, and exit codes between the Go binary and grmdir via pkg/testutils.
+          weight: 1
+      - R4.2:
+          text: "Tests must cover: single empty directory removal, multiple directories, -p with nested empty directories, non-empty directory error, non-existent directory error, --ignore-fail-on-non-empty suppression, and -v verbose output."
+          weight: 1
+      - R4.3:
+          text: Tests must verify that -p stops ascending correctly when a parent is not empty, matching grmdir behavior.
+          weight: 1
 
 non_goals:
   - cmd/rmdir does not remove non-empty directories; that is the role of rm -r.

--- a/docs/specs/product-requirements/prd036-mktemp.yaml
+++ b/docs/specs/product-requirements/prd036-mktemp.yaml
@@ -18,36 +18,72 @@ requirements:
   R1:
     title: Default behavior
     items:
-      - R1.1: Must create a temporary file in the directory specified by the TMPDIR environment variable, or /tmp if TMPDIR is unset, and print the absolute path to stdout.
-      - R1.2: Must use a template of 'tmp.XXXXXXXXXX' when no template argument is provided, where each X is replaced by a random alphanumeric character.
-      - R1.3: When a TEMPLATE argument is provided, must replace the trailing sequence of X characters (minimum three) with random characters and create the file with that name.
-      - R1.4: Must create the file with permission mode 0600 (owner read-write only).
-      - R1.5: Must exit 0 on success and exit 1 on failure, printing an error to stderr on failure.
+      - R1.1:
+          text: Must create a temporary file in the directory specified by the TMPDIR environment variable, or /tmp if TMPDIR is unset, and print the absolute path to stdout.
+          weight: 1
+      - R1.2:
+          text: Must use a template of 'tmp.XXXXXXXXXX' when no template argument is provided, where each X is replaced by a random alphanumeric character.
+          weight: 1
+      - R1.3:
+          text: When a TEMPLATE argument is provided, must replace the trailing sequence of X characters (minimum three) with random characters and create the file with that name.
+          weight: 1
+      - R1.4:
+          text: Must create the file with permission mode 0600 (owner read-write only).
+          weight: 1
+      - R1.5:
+          text: Must exit 0 on success and exit 1 on failure, printing an error to stderr on failure.
+          weight: 1
 
   R2:
     title: Directory mode (-d, --directory)
     items:
-      - R2.1: -d or --directory must create a temporary directory instead of a file.
-      - R2.2: Must create the directory with permission mode 0700 (owner read-write-execute only).
-      - R2.3: Must print the absolute path of the created directory to stdout.
+      - R2.1:
+          text: -d or --directory must create a temporary directory instead of a file.
+          weight: 1
+      - R2.2:
+          text: Must create the directory with permission mode 0700 (owner read-write-execute only).
+          weight: 1
+      - R2.3:
+          text: Must print the absolute path of the created directory to stdout.
+          weight: 1
 
   R3:
     title: Template and location control
     items:
-      - R3.1: -p DIR or --tmpdir=DIR must use DIR as the parent directory for the created file or directory, overriding TMPDIR.
-      - R3.2: --tmpdir without a value must use TMPDIR or /tmp as the parent directory (same as default behavior), and interpret the next argument as a template.
-      - R3.3: --suffix=SUFF must append SUFF after the random characters in the generated name. The template must not contain a slash after the X sequence when --suffix is used.
-      - R3.4: -t must treat the template as a filename prefix in the TMPDIR directory, equivalent to legacy BSD compatibility mode in GNU mktemp.
-      - R3.5: -u or --dry-run must print the name that would be created without actually creating it, and must print a warning that the option is discouraged.
-      - R3.6: -q or --quiet must suppress error messages on failure.
+      - R3.1:
+          text: -p DIR or --tmpdir=DIR must use DIR as the parent directory for the created file or directory, overriding TMPDIR.
+          weight: 1
+      - R3.2:
+          text: --tmpdir without a value must use TMPDIR or /tmp as the parent directory (same as default behavior), and interpret the next argument as a template.
+          weight: 1
+      - R3.3:
+          text: --suffix=SUFF must append SUFF after the random characters in the generated name. The template must not contain a slash after the X sequence when --suffix is used.
+          weight: 1
+      - R3.4:
+          text: -t must treat the template as a filename prefix in the TMPDIR directory, equivalent to legacy BSD compatibility mode in GNU mktemp.
+          weight: 1
+      - R3.5:
+          text: -u or --dry-run must print the name that would be created without actually creating it, and must print a warning that the option is discouraged.
+          weight: 1
+      - R3.6:
+          text: -q or --quiet must suppress error messages on failure.
+          weight: 1
 
   R4:
     title: Differential testing
     items:
-      - R4.1: Differential tests must compare exit codes and structural properties of output between the Go binary and gmktemp via pkg/testutils.
-      - R4.2: "Tests must verify structural properties: output is a valid path in the expected directory, the file or directory exists after creation, the name matches the template pattern, and permission bits match the specification."
-      - R4.3: "Tests must cover: default file creation, -d directory creation, custom template, --suffix, -p with explicit directory, -t legacy mode, -u dry-run, and error cases for invalid templates."
-      - R4.4: Tests must not compare exact filenames between the Go binary and gmktemp, since random components will differ between invocations.
+      - R4.1:
+          text: Differential tests must compare exit codes and structural properties of output between the Go binary and gmktemp via pkg/testutils.
+          weight: 1
+      - R4.2:
+          text: "Tests must verify structural properties: output is a valid path in the expected directory, the file or directory exists after creation, the name matches the template pattern, and permission bits match the specification."
+          weight: 1
+      - R4.3:
+          text: "Tests must cover: default file creation, -d directory creation, custom template, --suffix, -p with explicit directory, -t legacy mode, -u dry-run, and error cases for invalid templates."
+          weight: 1
+      - R4.4:
+          text: Tests must not compare exact filenames between the Go binary and gmktemp, since random components will differ between invocations.
+          weight: 1
 
 non_goals:
   - cmd/mktemp does not manage the lifecycle of created files; deletion is the caller's responsibility.

--- a/docs/specs/product-requirements/prd037-ln.yaml
+++ b/docs/specs/product-requirements/prd037-ln.yaml
@@ -17,43 +17,77 @@ requirements:
   R1:
     title: Hard link creation (default)
     items:
-      - R1.1: Must create a hard link from TARGET to LINK_NAME when invoked as 'ln TARGET LINK_NAME'.
-      - R1.2: Must create hard links for multiple TARGETs in DIRECTORY when invoked as 'ln TARGET... DIRECTORY', placing each link in DIRECTORY with the same basename as the target.
-      - R1.3: Must exit with a non-zero status and print an error to stderr when attempting to create a hard link to a directory.
-      - R1.4: Must exit with a non-zero status and print an error to stderr when LINK_NAME already exists and neither -f nor -i is given.
+      - R1.1:
+          text: Must create a hard link from TARGET to LINK_NAME when invoked as 'ln TARGET LINK_NAME'.
+          weight: 1
+      - R1.2:
+          text: Must create hard links for multiple TARGETs in DIRECTORY when invoked as 'ln TARGET... DIRECTORY', placing each link in DIRECTORY with the same basename as the target.
+          weight: 1
+      - R1.3:
+          text: Must exit with a non-zero status and print an error to stderr when attempting to create a hard link to a directory.
+          weight: 1
+      - R1.4:
+          text: Must exit with a non-zero status and print an error to stderr when LINK_NAME already exists and neither -f nor -i is given.
+          weight: 1
 
   R2:
     title: Symbolic link creation (-s, --symbolic)
     items:
-      - R2.1: -s or --symbolic must create a symbolic link instead of a hard link.
-      - R2.2: Must allow symbolic links to directories, unlike hard links.
-      - R2.3: Must store the TARGET string as-is in the symlink, whether it is relative or absolute.
-      - R2.4: -r or --relative must create a symbolic link with a relative path from the link location to the target, computing the relative path automatically.
+      - R2.1:
+          text: -s or --symbolic must create a symbolic link instead of a hard link.
+          weight: 1
+      - R2.2:
+          text: Must allow symbolic links to directories, unlike hard links.
+          weight: 1
+      - R2.3:
+          text: Must store the TARGET string as-is in the symlink, whether it is relative or absolute.
+          weight: 1
+      - R2.4:
+          text: -r or --relative must create a symbolic link with a relative path from the link location to the target, computing the relative path automatically.
+          weight: 1
 
   R3:
     title: Force, safety, and verbosity flags
     items:
-      - R3.1: -f or --force must remove existing destination files before creating the link.
-      - R3.2: -n or --no-dereference must treat a destination that is a symlink to a directory as a regular file, rather than following it.
-      - R3.3: |
-          -i or --interactive must prompt the user on stderr before removing an existing
-          destination. Prompt format: 'ln: replace 'DEST'? ' where DEST is the destination
-          path. Read one line from stdin. If the response starts with 'y' or 'Y', proceed
-          with removal and link creation. Any other response (including empty) means decline;
-          do not remove the destination and do not create the link. Do not retry on invalid
-          input. When stdin is not a terminal (detected via os.Stdin.Fd() isatty check),
-          treat as decline (do not prompt, do not remove). When -f and -i are both given,
-          the last flag on the command line wins, matching GNU ln behavior.
-      - R3.4: -v or --verbose must print the name of each link created to stdout.
-      - R3.5: -b must create a backup of each existing destination file before removal, using the default backup suffix '~'. --backup=METHOD must accept numbered, existing, simple, and none as backup methods.
-      - R3.6: -S SUFFIX or --suffix=SUFFIX must use SUFFIX instead of '~' for backup file names.
+      - R3.1:
+          text: -f or --force must remove existing destination files before creating the link.
+          weight: 1
+      - R3.2:
+          text: -n or --no-dereference must treat a destination that is a symlink to a directory as a regular file, rather than following it.
+          weight: 1
+      - R3.3:
+          text: |
+            -i or --interactive must prompt the user on stderr before removing an existing
+            destination. Prompt format: 'ln: replace 'DEST'? ' where DEST is the destination
+            path. Read one line from stdin. If the response starts with 'y' or 'Y', proceed
+            with removal and link creation. Any other response (including empty) means decline;
+            do not remove the destination and do not create the link. Do not retry on invalid
+            input. When stdin is not a terminal (detected via os.Stdin.Fd() isatty check),
+            treat as decline (do not prompt, do not remove). When -f and -i are both given,
+            the last flag on the command line wins, matching GNU ln behavior.
+          weight: 1
+      - R3.4:
+          text: -v or --verbose must print the name of each link created to stdout.
+          weight: 1
+      - R3.5:
+          text: -b must create a backup of each existing destination file before removal, using the default backup suffix '~'. --backup=METHOD must accept numbered, existing, simple, and none as backup methods.
+          weight: 1
+      - R3.6:
+          text: -S SUFFIX or --suffix=SUFFIX must use SUFFIX instead of '~' for backup file names.
+          weight: 1
 
   R4:
     title: Differential testing
     items:
-      - R4.1: Differential tests must compare stdout, stderr, exit codes, and resulting filesystem state between the Go binary and gln via pkg/testutils.
-      - R4.2: "Tests must cover: hard link creation, symbolic link creation (-s), force overwrite (-f), no-dereference (-n), verbose output (-v), backup creation (-b), multiple targets into a directory, relative symlinks (-r), and error cases for hard linking directories and existing destinations."
-      - R4.3: Tests must verify that created links point to the correct target and have the correct link type (hard or symbolic), matching gln behavior.
+      - R4.1:
+          text: Differential tests must compare stdout, stderr, exit codes, and resulting filesystem state between the Go binary and gln via pkg/testutils.
+          weight: 1
+      - R4.2:
+          text: "Tests must cover: hard link creation, symbolic link creation (-s), force overwrite (-f), no-dereference (-n), verbose output (-v), backup creation (-b), multiple targets into a directory, relative symlinks (-r), and error cases for hard linking directories and existing destinations."
+          weight: 1
+      - R4.3:
+          text: Tests must verify that created links point to the correct target and have the correct link type (hard or symbolic), matching gln behavior.
+          weight: 1
 
 non_goals:
   - cmd/ln does not implement -L or -P (logical/physical) dereference modes for following symlink chains on the target.

--- a/docs/specs/product-requirements/prd038-unlink.yaml
+++ b/docs/specs/product-requirements/prd038-unlink.yaml
@@ -16,24 +16,44 @@ requirements:
   R1:
     title: Basic operation
     items:
-      - R1.1: Must call unlink(2) on exactly one FILE argument provided on the command line.
-      - R1.2: Must produce no output on stdout when the operation succeeds.
-      - R1.3: Must exit 0 on success.
+      - R1.1:
+          text: Must call unlink(2) on exactly one FILE argument provided on the command line.
+          weight: 1
+      - R1.2:
+          text: Must produce no output on stdout when the operation succeeds.
+          weight: 1
+      - R1.3:
+          text: Must exit 0 on success.
+          weight: 1
 
   R2:
     title: Error handling
     items:
-      - R2.1: Must exit with a non-zero status and print an error to stderr when called with zero arguments.
-      - R2.2: Must exit with a non-zero status and print an error to stderr when called with more than one argument.
-      - R2.3: Must exit with a non-zero status and print an error to stderr when the specified FILE does not exist.
-      - R2.4: Must exit with a non-zero status and print an error to stderr when the specified FILE is a directory, since unlink(2) does not remove directories on standard systems.
+      - R2.1:
+          text: Must exit with a non-zero status and print an error to stderr when called with zero arguments.
+          weight: 1
+      - R2.2:
+          text: Must exit with a non-zero status and print an error to stderr when called with more than one argument.
+          weight: 1
+      - R2.3:
+          text: Must exit with a non-zero status and print an error to stderr when the specified FILE does not exist.
+          weight: 1
+      - R2.4:
+          text: Must exit with a non-zero status and print an error to stderr when the specified FILE is a directory, since unlink(2) does not remove directories on standard systems.
+          weight: 1
 
   R3:
     title: Differential testing
     items:
-      - R3.1: Differential tests must compare stdout, stderr, and exit codes between the Go binary and gunlink via pkg/testutils.
-      - R3.2: "Tests must cover: successful removal of a regular file, successful removal of a symbolic link, zero-argument error, multi-argument error, non-existent file error, and directory argument error."
-      - R3.3: Tests must verify that the target file no longer exists after a successful invocation, matching gunlink behavior.
+      - R3.1:
+          text: Differential tests must compare stdout, stderr, and exit codes between the Go binary and gunlink via pkg/testutils.
+          weight: 1
+      - R3.2:
+          text: "Tests must cover: successful removal of a regular file, successful removal of a symbolic link, zero-argument error, multi-argument error, non-existent file error, and directory argument error."
+          weight: 1
+      - R3.3:
+          text: Tests must verify that the target file no longer exists after a successful invocation, matching gunlink behavior.
+          weight: 1
 
 non_goals:
   - cmd/unlink does not support any flags; it accepts exactly one positional argument.

--- a/docs/specs/product-requirements/prd039-env.yaml
+++ b/docs/specs/product-requirements/prd039-env.yaml
@@ -19,30 +19,54 @@ requirements:
   R1:
     title: Default behavior
     items:
-      - R1.1: When invoked with no arguments, must print every environment variable on its own line in NAME=VALUE format and exit 0.
-      - R1.2: When invoked with COMMAND [ARG ...], must execute COMMAND with the resulting environment after all modifications have been applied.
-      - R1.3: If COMMAND is not found, must exit 127. If COMMAND is found but cannot be executed, must exit 126.
+      - R1.1:
+          text: When invoked with no arguments, must print every environment variable on its own line in NAME=VALUE format and exit 0.
+          weight: 1
+      - R1.2:
+          text: When invoked with COMMAND [ARG ...], must execute COMMAND with the resulting environment after all modifications have been applied.
+          weight: 1
+      - R1.3:
+          text: If COMMAND is not found, must exit 127. If COMMAND is found but cannot be executed, must exit 126.
+          weight: 1
 
   R2:
     title: Environment modification
     items:
-      - R2.1: -i or --ignore-environment must start COMMAND with an empty environment. Only explicitly supplied NAME=VALUE pairs appear in the child process environment.
-      - R2.2: -u NAME or --unset=NAME must remove the variable NAME from the environment before COMMAND runs. Multiple -u flags must be supported.
-      - R2.3: Each NAME=VALUE argument (positional, before COMMAND) must set or override the variable NAME in the environment. The first argument that does not contain '=' and is not a flag is the start of COMMAND.
+      - R2.1:
+          text: -i or --ignore-environment must start COMMAND with an empty environment. Only explicitly supplied NAME=VALUE pairs appear in the child process environment.
+          weight: 1
+      - R2.2:
+          text: -u NAME or --unset=NAME must remove the variable NAME from the environment before COMMAND runs. Multiple -u flags must be supported.
+          weight: 1
+      - R2.3:
+          text: Each NAME=VALUE argument (positional, before COMMAND) must set or override the variable NAME in the environment. The first argument that does not contain '=' and is not a flag is the start of COMMAND.
+          weight: 1
 
   R3:
     title: Output formatting and exit codes
     items:
-      - R3.1: -0 or --null must terminate each output line with a NUL byte (0x00) instead of a newline when printing the environment (no COMMAND case).
-      - R3.2: When COMMAND is executed, env must exit with the same exit code as COMMAND.
-      - R3.3: Must print an error message to stderr when an invalid option is given and exit 125.
+      - R3.1:
+          text: -0 or --null must terminate each output line with a NUL byte (0x00) instead of a newline when printing the environment (no COMMAND case).
+          weight: 1
+      - R3.2:
+          text: When COMMAND is executed, env must exit with the same exit code as COMMAND.
+          weight: 1
+      - R3.3:
+          text: Must print an error message to stderr when an invalid option is given and exit 125.
+          weight: 1
 
   R4:
     title: Differential testing
     items:
-      - R4.1: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (genv) via pkg/testutils.
-      - R4.2: "Tests must cover: no-argument environment dump, NAME=VALUE setting, -u unsetting, -i empty environment, -0 NUL-delimited output, COMMAND execution with modified env, and exit code passthrough."
-      - R4.3: Tests must verify error output and exit code for invalid options and missing commands.
+      - R4.1:
+          text: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (genv) via pkg/testutils.
+          weight: 1
+      - R4.2:
+          text: "Tests must cover: no-argument environment dump, NAME=VALUE setting, -u unsetting, -i empty environment, -0 NUL-delimited output, COMMAND execution with modified env, and exit code passthrough."
+          weight: 1
+      - R4.3:
+          text: Tests must verify error output and exit code for invalid options and missing commands.
+          weight: 1
 
 non_goals:
   - cmd/env does not implement -C (change directory) or -S (split string) GNU extensions.

--- a/docs/specs/product-requirements/prd040-printenv.yaml
+++ b/docs/specs/product-requirements/prd040-printenv.yaml
@@ -19,24 +19,44 @@ requirements:
   R1:
     title: Default behavior
     items:
-      - R1.1: When invoked with no arguments, must print every environment variable on its own line in NAME=VALUE format and exit 0.
-      - R1.2: When invoked with one or more VARIABLE arguments, must print only the value (not the name or '=') of each named variable, one per line, in the order given.
-      - R1.3: If a named VARIABLE is not set in the environment, must produce no output for that variable and must not print an error message.
+      - R1.1:
+          text: When invoked with no arguments, must print every environment variable on its own line in NAME=VALUE format and exit 0.
+          weight: 1
+      - R1.2:
+          text: When invoked with one or more VARIABLE arguments, must print only the value (not the name or '=') of each named variable, one per line, in the order given.
+          weight: 1
+      - R1.3:
+          text: If a named VARIABLE is not set in the environment, must produce no output for that variable and must not print an error message.
+          weight: 1
 
   R2:
     title: Output formatting and exit codes
     items:
-      - R2.1: -0 or --null must terminate each output line with a NUL byte (0x00) instead of a newline.
-      - R2.2: Must exit 0 if all requested VARIABLE arguments are found in the environment.
-      - R2.3: Must exit 1 if any requested VARIABLE argument is not found in the environment.
-      - R2.4: When no VARIABLE arguments are given, must always exit 0 (the dump of all variables cannot fail).
+      - R2.1:
+          text: -0 or --null must terminate each output line with a NUL byte (0x00) instead of a newline.
+          weight: 1
+      - R2.2:
+          text: Must exit 0 if all requested VARIABLE arguments are found in the environment.
+          weight: 1
+      - R2.3:
+          text: Must exit 1 if any requested VARIABLE argument is not found in the environment.
+          weight: 1
+      - R2.4:
+          text: When no VARIABLE arguments are given, must always exit 0 (the dump of all variables cannot fail).
+          weight: 1
 
   R3:
     title: Differential testing
     items:
-      - R3.1: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (gprintenv) via pkg/testutils.
-      - R3.2: "Tests must cover: no-argument full dump, single existing variable, multiple existing variables, missing variable (exit 1), mix of existing and missing variables, and -0 NUL-delimited output."
-      - R3.3: Tests must verify that no error message is printed to stderr for missing variables.
+      - R3.1:
+          text: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (gprintenv) via pkg/testutils.
+          weight: 1
+      - R3.2:
+          text: "Tests must cover: no-argument full dump, single existing variable, multiple existing variables, missing variable (exit 1), mix of existing and missing variables, and -0 NUL-delimited output."
+          weight: 1
+      - R3.3:
+          text: Tests must verify that no error message is printed to stderr for missing variables.
+          weight: 1
 
 non_goals:
   - cmd/printenv does not support setting or modifying variables; it is read-only.

--- a/docs/specs/product-requirements/prd041-id.yaml
+++ b/docs/specs/product-requirements/prd041-id.yaml
@@ -19,31 +19,57 @@ requirements:
   R1:
     title: Default output
     items:
-      - R1.1: "When invoked with no flags, must print a single line in the format: uid=N(name) gid=N(name) groups=N(name),N(name),... followed by a newline."
-      - R1.2: The groups list must include all supplementary groups for the user, in the order returned by the system.
-      - R1.3: Must exit 0 on success.
+      - R1.1:
+          text: "When invoked with no flags, must print a single line in the format: uid=N(name) gid=N(name) groups=N(name),N(name),... followed by a newline."
+          weight: 1
+      - R1.2:
+          text: The groups list must include all supplementary groups for the user, in the order returned by the system.
+          weight: 1
+      - R1.3:
+          text: Must exit 0 on success.
+          weight: 1
 
   R2:
     title: Selection flags
     items:
-      - R2.1: -u or --user must print only the effective UID (numeric by default).
-      - R2.2: -g or --group must print only the effective GID (numeric by default).
-      - R2.3: -G or --groups must print all group IDs, space-separated, on a single line.
-      - R2.4: Only one of -u, -g, -G may be specified at a time. If more than one is given, must print an error to stderr and exit 1.
+      - R2.1:
+          text: -u or --user must print only the effective UID (numeric by default).
+          weight: 1
+      - R2.2:
+          text: -g or --group must print only the effective GID (numeric by default).
+          weight: 1
+      - R2.3:
+          text: -G or --groups must print all group IDs, space-separated, on a single line.
+          weight: 1
+      - R2.4:
+          text: Only one of -u, -g, -G may be specified at a time. If more than one is given, must print an error to stderr and exit 1.
+          weight: 1
 
   R3:
     title: Modifier flags and named user support
     items:
-      - R3.1: -n or --name, combined with -u, -g, or -G, must print the name instead of the numeric ID. -n without a selection flag is an error.
-      - R3.2: -r or --real, combined with -u or -g, must print the real UID or GID instead of the effective one. -r without -u or -g is an error.
-      - R3.3: When a USER operand is given, must query that user's identity information from the system instead of the current process. If the user does not exist, must print an error to stderr and exit 1.
+      - R3.1:
+          text: -n or --name, combined with -u, -g, or -G, must print the name instead of the numeric ID. -n without a selection flag is an error.
+          weight: 1
+      - R3.2:
+          text: -r or --real, combined with -u or -g, must print the real UID or GID instead of the effective one. -r without -u or -g is an error.
+          weight: 1
+      - R3.3:
+          text: When a USER operand is given, must query that user's identity information from the system instead of the current process. If the user does not exist, must print an error to stderr and exit 1.
+          weight: 1
 
   R4:
     title: Differential testing
     items:
-      - R4.1: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (gid) via pkg/testutils.
-      - R4.2: "Tests must cover: default output (no flags), -u, -g, -G, -n combined with each selection flag, -r combined with -u and -g, named user lookup, and nonexistent user error."
-      - R4.3: Tests must verify error output and exit code for conflicting flags and invalid users.
+      - R4.1:
+          text: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (gid) via pkg/testutils.
+          weight: 1
+      - R4.2:
+          text: "Tests must cover: default output (no flags), -u, -g, -G, -n combined with each selection flag, -r combined with -u and -g, named user lookup, and nonexistent user error."
+          weight: 1
+      - R4.3:
+          text: Tests must verify error output and exit code for conflicting flags and invalid users.
+          weight: 1
 
 non_goals:
   - cmd/id does not implement SELinux context output (-Z/--context).

--- a/docs/specs/product-requirements/prd042-whoami.yaml
+++ b/docs/specs/product-requirements/prd042-whoami.yaml
@@ -17,21 +17,35 @@ requirements:
   R1:
     title: Default behavior
     items:
-      - R1.1: When invoked with no arguments, must print the effective username (equivalent to id -un) followed by a newline and exit 0.
-      - R1.2: The username must reflect the effective UID, not the real UID, matching the behavior of gwhoami after su or sudo.
+      - R1.1:
+          text: When invoked with no arguments, must print the effective username (equivalent to id -un) followed by a newline and exit 0.
+          weight: 1
+      - R1.2:
+          text: The username must reflect the effective UID, not the real UID, matching the behavior of gwhoami after su or sudo.
+          weight: 1
 
   R2:
     title: Error handling
     items:
-      - R2.1: If any extra operand is provided (beyond --help and --version), must print an error message to stderr and exit 1.
-      - R2.2: Must not accept any flags other than --help and --version. Unknown flags must produce an error message to stderr and exit 1.
+      - R2.1:
+          text: If any extra operand is provided (beyond --help and --version), must print an error message to stderr and exit 1.
+          weight: 1
+      - R2.2:
+          text: Must not accept any flags other than --help and --version. Unknown flags must produce an error message to stderr and exit 1.
+          weight: 1
 
   R3:
     title: Differential testing
     items:
-      - R3.1: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (gwhoami) via pkg/testutils.
-      - R3.2: "Tests must cover: normal invocation (no arguments), extra operand error, and unknown flag error."
-      - R3.3: Tests must verify that the output matches the effective username returned by the system.
+      - R3.1:
+          text: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (gwhoami) via pkg/testutils.
+          weight: 1
+      - R3.2:
+          text: "Tests must cover: normal invocation (no arguments), extra operand error, and unknown flag error."
+          weight: 1
+      - R3.3:
+          text: Tests must verify that the output matches the effective username returned by the system.
+          weight: 1
 
 non_goals:
   - cmd/whoami does not accept a USER argument; it always reports the current process identity.

--- a/docs/specs/product-requirements/prd043-groups.yaml
+++ b/docs/specs/product-requirements/prd043-groups.yaml
@@ -18,23 +18,41 @@ requirements:
   R1:
     title: Default behavior
     items:
-      - R1.1: When invoked with no arguments, must print the group names of the current user, space-separated, on a single line followed by a newline, and exit 0.
-      - R1.2: When invoked with one or more USER arguments, must print the groups for each user on a separate line and exit 0.
-      - R1.3: If a named USER does not exist, must print an error message to stderr for that user and continue processing remaining users. Must exit 1 if any user was not found.
+      - R1.1:
+          text: When invoked with no arguments, must print the group names of the current user, space-separated, on a single line followed by a newline, and exit 0.
+          weight: 1
+      - R1.2:
+          text: When invoked with one or more USER arguments, must print the groups for each user on a separate line and exit 0.
+          weight: 1
+      - R1.3:
+          text: If a named USER does not exist, must print an error message to stderr for that user and continue processing remaining users. Must exit 1 if any user was not found.
+          weight: 1
 
   R2:
     title: Output format
     items:
-      - R2.1: When no USER argument is given, must print only the space-separated group names with no prefix.
-      - R2.2: "When USER arguments are given, each line must be formatted as: 'user : group1 group2 ...' with the user name, a space, a colon, a space, and then the space-separated group names."
-      - R2.3: Group names must appear in the order returned by the system group database.
+      - R2.1:
+          text: When no USER argument is given, must print only the space-separated group names with no prefix.
+          weight: 1
+      - R2.2:
+          text: "When USER arguments are given, each line must be formatted as: 'user : group1 group2 ...' with the user name, a space, a colon, a space, and then the space-separated group names."
+          weight: 1
+      - R2.3:
+          text: Group names must appear in the order returned by the system group database.
+          weight: 1
 
   R3:
     title: Differential testing
     items:
-      - R3.1: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (ggroups) via pkg/testutils.
-      - R3.2: "Tests must cover: no-argument current-user output, single named user, multiple named users, nonexistent user error, and mixed valid/invalid users."
-      - R3.3: Tests must verify the "user :" prefix format for named-user queries.
+      - R3.1:
+          text: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (ggroups) via pkg/testutils.
+          weight: 1
+      - R3.2:
+          text: "Tests must cover: no-argument current-user output, single named user, multiple named users, nonexistent user error, and mixed valid/invalid users."
+          weight: 1
+      - R3.3:
+          text: Tests must verify the "user :" prefix format for named-user queries.
+          weight: 1
 
 non_goals:
   - cmd/groups does not support any flags beyond --help and --version; it has no optional behavior modes.

--- a/docs/specs/product-requirements/prd044-uname.yaml
+++ b/docs/specs/product-requirements/prd044-uname.yaml
@@ -16,34 +16,66 @@ requirements:
   R1:
     title: Individual information flags
     items:
-      - R1.1: When invoked with no arguments, must print the kernel name (equivalent to -s) followed by a newline and exit 0.
-      - R1.2: "-s must print the kernel name (e.g., Darwin, Linux)."
-      - R1.3: "-n must print the network node hostname."
-      - R1.4: "-r must print the kernel release string."
-      - R1.5: "-v must print the kernel version string."
-      - R1.6: "-m must print the machine hardware name (e.g., x86_64, arm64)."
-      - R1.7: "-p must print the processor type, or \"unknown\" if not determinable."
-      - R1.8: "-i must print the hardware platform, or \"unknown\" if not determinable."
-      - R1.9: "-o must print the operating system name."
+      - R1.1:
+          text: When invoked with no arguments, must print the kernel name (equivalent to -s) followed by a newline and exit 0.
+          weight: 1
+      - R1.2:
+          text: "-s must print the kernel name (e.g., Darwin, Linux)."
+          weight: 1
+      - R1.3:
+          text: "-n must print the network node hostname."
+          weight: 1
+      - R1.4:
+          text: "-r must print the kernel release string."
+          weight: 1
+      - R1.5:
+          text: "-v must print the kernel version string."
+          weight: 1
+      - R1.6:
+          text: "-m must print the machine hardware name (e.g., x86_64, arm64)."
+          weight: 1
+      - R1.7:
+          text: "-p must print the processor type, or \"unknown\" if not determinable."
+          weight: 1
+      - R1.8:
+          text: "-i must print the hardware platform, or \"unknown\" if not determinable."
+          weight: 1
+      - R1.9:
+          text: "-o must print the operating system name."
+          weight: 1
 
   R2:
     title: Combined output
     items:
-      - R2.1: "-a must print all fields in the order: kernel name, node name, kernel release, kernel version, machine, processor, hardware platform, operating system, separated by single spaces."
-      - R2.2: When multiple individual flags are specified (e.g., -sn), must print only the requested fields in the canonical order, space-separated, followed by a newline.
+      - R2.1:
+          text: "-a must print all fields in the order: kernel name, node name, kernel release, kernel version, machine, processor, hardware platform, operating system, separated by single spaces."
+          weight: 1
+      - R2.2:
+          text: When multiple individual flags are specified (e.g., -sn), must print only the requested fields in the canonical order, space-separated, followed by a newline.
+          weight: 1
 
   R3:
     title: Error handling
     items:
-      - R3.1: Must not accept any positional operands. If an operand is provided, must print an error message to stderr and exit 1.
-      - R3.2: Unknown flags must produce an error message to stderr and exit 1.
+      - R3.1:
+          text: Must not accept any positional operands. If an operand is provided, must print an error message to stderr and exit 1.
+          weight: 1
+      - R3.2:
+          text: Unknown flags must produce an error message to stderr and exit 1.
+          weight: 1
 
   R4:
     title: Differential testing
     items:
-      - R4.1: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (guname) via pkg/testutils.
-      - R4.2: "Tests must cover: default (no flags), each individual flag (-s, -n, -r, -v, -m, -p, -i, -o), -a, combinations of flags, and error cases."
-      - R4.3: All differential tests must set LC_ALL=C in the environment.
+      - R4.1:
+          text: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (guname) via pkg/testutils.
+          weight: 1
+      - R4.2:
+          text: "Tests must cover: default (no flags), each individual flag (-s, -n, -r, -v, -m, -p, -i, -o), -a, combinations of flags, and error cases."
+          weight: 1
+      - R4.3:
+          text: All differential tests must set LC_ALL=C in the environment.
+          weight: 1
 
 non_goals:
   - cmd/uname does not set the hostname or any system information; it is read-only.

--- a/docs/specs/product-requirements/prd045-arch.yaml
+++ b/docs/specs/product-requirements/prd045-arch.yaml
@@ -16,21 +16,35 @@ requirements:
   R1:
     title: Default behavior
     items:
-      - R1.1: When invoked with no arguments, must print the machine hardware name (e.g., x86_64, arm64) followed by a newline and exit 0.
-      - R1.2: The output must be identical to guname -m on the same system.
+      - R1.1:
+          text: When invoked with no arguments, must print the machine hardware name (e.g., x86_64, arm64) followed by a newline and exit 0.
+          weight: 1
+      - R1.2:
+          text: The output must be identical to guname -m on the same system.
+          weight: 1
 
   R2:
     title: Error handling
     items:
-      - R2.1: If any extra operand is provided (beyond --help and --version), must print an error message to stderr and exit 1.
-      - R2.2: Must not accept any flags other than --help and --version. Unknown flags must produce an error message to stderr and exit 1.
+      - R2.1:
+          text: If any extra operand is provided (beyond --help and --version), must print an error message to stderr and exit 1.
+          weight: 1
+      - R2.2:
+          text: Must not accept any flags other than --help and --version. Unknown flags must produce an error message to stderr and exit 1.
+          weight: 1
 
   R3:
     title: Differential testing
     items:
-      - R3.1: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (garch) via pkg/testutils.
-      - R3.2: "Tests must cover: normal invocation (no arguments), extra operand error, and unknown flag error."
-      - R3.3: All differential tests must set LC_ALL=C in the environment.
+      - R3.1:
+          text: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (garch) via pkg/testutils.
+          weight: 1
+      - R3.2:
+          text: "Tests must cover: normal invocation (no arguments), extra operand error, and unknown flag error."
+          weight: 1
+      - R3.3:
+          text: All differential tests must set LC_ALL=C in the environment.
+          weight: 1
 
 non_goals:
   - cmd/arch does not accept any flags for selecting different information fields; use cmd/uname for that.

--- a/docs/specs/product-requirements/prd046-nproc.yaml
+++ b/docs/specs/product-requirements/prd046-nproc.yaml
@@ -16,24 +16,44 @@ requirements:
   R1:
     title: Default behavior and flags
     items:
-      - R1.1: When invoked with no arguments, must print the number of available processing units followed by a newline and exit 0.
-      - R1.2: "--all must print the number of installed processors, which may differ from the available count if CPU affinity or cgroups restrict the set."
-      - R1.3: "--ignore=N must subtract N from the processor count and print the result. The result must never be less than 1."
-      - R1.4: --all and --ignore=N may be combined. When combined, --ignore subtracts from the installed count.
+      - R1.1:
+          text: When invoked with no arguments, must print the number of available processing units followed by a newline and exit 0.
+          weight: 1
+      - R1.2:
+          text: "--all must print the number of installed processors, which may differ from the available count if CPU affinity or cgroups restrict the set."
+          weight: 1
+      - R1.3:
+          text: "--ignore=N must subtract N from the processor count and print the result. The result must never be less than 1."
+          weight: 1
+      - R1.4:
+          text: --all and --ignore=N may be combined. When combined, --ignore subtracts from the installed count.
+          weight: 1
 
   R2:
     title: Error handling
     items:
-      - R2.1: If any positional operand is provided, must print an error message to stderr and exit 1.
-      - R2.2: If --ignore is given a non-numeric value, must print an error message to stderr and exit 1.
-      - R2.3: Unknown flags must produce an error message to stderr and exit 1.
+      - R2.1:
+          text: If any positional operand is provided, must print an error message to stderr and exit 1.
+          weight: 1
+      - R2.2:
+          text: If --ignore is given a non-numeric value, must print an error message to stderr and exit 1.
+          weight: 1
+      - R2.3:
+          text: Unknown flags must produce an error message to stderr and exit 1.
+          weight: 1
 
   R3:
     title: Differential testing
     items:
-      - R3.1: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (gnproc) via pkg/testutils.
-      - R3.2: "Tests must cover: default invocation, --all, --ignore=1, --all --ignore=1, and error cases."
-      - R3.3: All differential tests must set LC_ALL=C in the environment.
+      - R3.1:
+          text: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (gnproc) via pkg/testutils.
+          weight: 1
+      - R3.2:
+          text: "Tests must cover: default invocation, --all, --ignore=1, --all --ignore=1, and error cases."
+          weight: 1
+      - R3.3:
+          text: All differential tests must set LC_ALL=C in the environment.
+          weight: 1
 
 non_goals:
   - cmd/nproc does not set CPU affinity or modify scheduling.

--- a/docs/specs/product-requirements/prd047-hostname.yaml
+++ b/docs/specs/product-requirements/prd047-hostname.yaml
@@ -16,21 +16,35 @@ requirements:
   R1:
     title: Default behavior
     items:
-      - R1.1: When invoked with no arguments, must print the system hostname followed by a newline and exit 0.
-      - R1.2: The output must be identical to the value returned by the gethostname(2) syscall on the current system.
+      - R1.1:
+          text: When invoked with no arguments, must print the system hostname followed by a newline and exit 0.
+          weight: 1
+      - R1.2:
+          text: The output must be identical to the value returned by the gethostname(2) syscall on the current system.
+          weight: 1
 
   R2:
     title: Error handling
     items:
-      - R2.1: If any extra operand is provided (beyond --help and --version), must print an error message to stderr and exit 1.
-      - R2.2: Must not accept any flags other than --help and --version. Unknown flags must produce an error message to stderr and exit 1.
+      - R2.1:
+          text: If any extra operand is provided (beyond --help and --version), must print an error message to stderr and exit 1.
+          weight: 1
+      - R2.2:
+          text: Must not accept any flags other than --help and --version. Unknown flags must produce an error message to stderr and exit 1.
+          weight: 1
 
   R3:
     title: Differential testing
     items:
-      - R3.1: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (ghostname) via pkg/testutils.
-      - R3.2: "Tests must cover: normal invocation (no arguments), extra operand error, and unknown flag error."
-      - R3.3: All differential tests must set LC_ALL=C in the environment.
+      - R3.1:
+          text: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (ghostname) via pkg/testutils.
+          weight: 1
+      - R3.2:
+          text: "Tests must cover: normal invocation (no arguments), extra operand error, and unknown flag error."
+          weight: 1
+      - R3.3:
+          text: All differential tests must set LC_ALL=C in the environment.
+          weight: 1
 
 non_goals:
   - cmd/hostname does not set the hostname; it is read-only.

--- a/docs/specs/product-requirements/prd048-hostid.yaml
+++ b/docs/specs/product-requirements/prd048-hostid.yaml
@@ -16,21 +16,35 @@ requirements:
   R1:
     title: Default behavior
     items:
-      - R1.1: When invoked with no arguments, must print the 32-bit host identifier as an 8-digit lowercase hexadecimal number followed by a newline and exit 0.
-      - R1.2: The value must be derived from the gethostid(3) syscall or equivalent system call on the current platform.
+      - R1.1:
+          text: When invoked with no arguments, must print the 32-bit host identifier as an 8-digit lowercase hexadecimal number followed by a newline and exit 0.
+          weight: 1
+      - R1.2:
+          text: The value must be derived from the gethostid(3) syscall or equivalent system call on the current platform.
+          weight: 1
 
   R2:
     title: Error handling
     items:
-      - R2.1: If any extra operand is provided (beyond --help and --version), must print an error message to stderr and exit 1.
-      - R2.2: Must not accept any flags other than --help and --version. Unknown flags must produce an error message to stderr and exit 1.
+      - R2.1:
+          text: If any extra operand is provided (beyond --help and --version), must print an error message to stderr and exit 1.
+          weight: 1
+      - R2.2:
+          text: Must not accept any flags other than --help and --version. Unknown flags must produce an error message to stderr and exit 1.
+          weight: 1
 
   R3:
     title: Differential testing
     items:
-      - R3.1: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (ghostid) via pkg/testutils.
-      - R3.2: "Tests must cover: normal invocation (no arguments), extra operand error, and unknown flag error."
-      - R3.3: All differential tests must set LC_ALL=C in the environment.
+      - R3.1:
+          text: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (ghostid) via pkg/testutils.
+          weight: 1
+      - R3.2:
+          text: "Tests must cover: normal invocation (no arguments), extra operand error, and unknown flag error."
+          weight: 1
+      - R3.3:
+          text: All differential tests must set LC_ALL=C in the environment.
+          weight: 1
 
 non_goals:
   - cmd/hostid does not set the host identifier.

--- a/docs/specs/product-requirements/prd049-realpath.yaml
+++ b/docs/specs/product-requirements/prd049-realpath.yaml
@@ -17,32 +17,60 @@ requirements:
   R1:
     title: Default behavior and existence modes
     items:
-      - R1.1: When invoked with one or more path arguments and no flags, must resolve each path to its canonical absolute form (all symlinks resolved, no . or .. components) and print one per line, exiting 0.
-      - R1.2: If the resolved path does not exist by default, must print an error to stderr and exit 1 for that operand.
-      - R1.3: "-e (--canonicalize-existing) requires that every component of the path exists. If any component is missing, must print an error to stderr and exit 1."
-      - R1.4: "-m (--canonicalize-missing) requires no component to exist. Must resolve as far as possible and construct the remainder without checking existence."
-      - R1.5: "-s (--strip, --no-symlinks) must not resolve symlinks; only clean . and .. components and prepend the working directory for relative paths."
+      - R1.1:
+          text: When invoked with one or more path arguments and no flags, must resolve each path to its canonical absolute form (all symlinks resolved, no . or .. components) and print one per line, exiting 0.
+          weight: 1
+      - R1.2:
+          text: If the resolved path does not exist by default, must print an error to stderr and exit 1 for that operand.
+          weight: 1
+      - R1.3:
+          text: "-e (--canonicalize-existing) requires that every component of the path exists. If any component is missing, must print an error to stderr and exit 1."
+          weight: 1
+      - R1.4:
+          text: "-m (--canonicalize-missing) requires no component to exist. Must resolve as far as possible and construct the remainder without checking existence."
+          weight: 1
+      - R1.5:
+          text: "-s (--strip, --no-symlinks) must not resolve symlinks; only clean . and .. components and prepend the working directory for relative paths."
+          weight: 1
 
   R2:
     title: Relative path output
     items:
-      - R2.1: "--relative-to=DIR must print each resolved path relative to DIR instead of as an absolute path."
-      - R2.2: "--relative-base=DIR must print paths relative to DIR when the resolved path starts with DIR; otherwise print the absolute path."
-      - R2.3: When both --relative-to and --relative-base are specified, --relative-to is applied only if the path starts with --relative-base.
+      - R2.1:
+          text: "--relative-to=DIR must print each resolved path relative to DIR instead of as an absolute path."
+          weight: 1
+      - R2.2:
+          text: "--relative-base=DIR must print paths relative to DIR when the resolved path starts with DIR; otherwise print the absolute path."
+          weight: 1
+      - R2.3:
+          text: When both --relative-to and --relative-base are specified, --relative-to is applied only if the path starts with --relative-base.
+          weight: 1
 
   R3:
     title: Error handling
     items:
-      - R3.1: If no operand is provided, must print a usage error to stderr and exit 1.
-      - R3.2: Unknown flags must produce an error message to stderr and exit 1.
-      - R3.3: When multiple paths are given and some fail, must print errors for the failing paths and exit 1 (but still print successful resolutions).
+      - R3.1:
+          text: If no operand is provided, must print a usage error to stderr and exit 1.
+          weight: 1
+      - R3.2:
+          text: Unknown flags must produce an error message to stderr and exit 1.
+          weight: 1
+      - R3.3:
+          text: When multiple paths are given and some fail, must print errors for the failing paths and exit 1 (but still print successful resolutions).
+          weight: 1
 
   R4:
     title: Differential testing
     items:
-      - R4.1: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (grealpath) via pkg/testutils.
-      - R4.2: "Tests must cover: default resolution, -e with existing and missing paths, -m with missing paths, -s without symlink resolution, --relative-to, --relative-base, multiple operands with mixed success, and error cases."
-      - R4.3: All differential tests must set LC_ALL=C in the environment.
+      - R4.1:
+          text: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (grealpath) via pkg/testutils.
+          weight: 1
+      - R4.2:
+          text: "Tests must cover: default resolution, -e with existing and missing paths, -m with missing paths, -s without symlink resolution, --relative-to, --relative-base, multiple operands with mixed success, and error cases."
+          weight: 1
+      - R4.3:
+          text: All differential tests must set LC_ALL=C in the environment.
+          weight: 1
 
 non_goals:
   - cmd/realpath does not create files or directories.

--- a/docs/specs/product-requirements/prd050-readlink.yaml
+++ b/docs/specs/product-requirements/prd050-readlink.yaml
@@ -16,31 +16,57 @@ requirements:
   R1:
     title: Default behavior and canonicalization
     items:
-      - R1.1: When invoked with a symlink operand and no flags, must print the immediate target of the symbolic link followed by a newline and exit 0.
-      - R1.2: If the operand is not a symbolic link (with no flags), must print nothing to stdout and exit 1.
-      - R1.3: "-f (--canonicalize) must resolve the full canonical path, following all symlinks. The final component need not exist, but the directory containing it must exist."
-      - R1.4: "-e (--canonicalize-existing) must resolve the full canonical path. Every component of the path must exist; otherwise exit 1."
-      - R1.5: "-m (--canonicalize-missing) must resolve the full canonical path. No component need exist."
-      - R1.6: "-n (--no-newline) must suppress the trailing newline when printing a single operand."
+      - R1.1:
+          text: When invoked with a symlink operand and no flags, must print the immediate target of the symbolic link followed by a newline and exit 0.
+          weight: 1
+      - R1.2:
+          text: If the operand is not a symbolic link (with no flags), must print nothing to stdout and exit 1.
+          weight: 1
+      - R1.3:
+          text: "-f (--canonicalize) must resolve the full canonical path, following all symlinks. The final component need not exist, but the directory containing it must exist."
+          weight: 1
+      - R1.4:
+          text: "-e (--canonicalize-existing) must resolve the full canonical path. Every component of the path must exist; otherwise exit 1."
+          weight: 1
+      - R1.5:
+          text: "-m (--canonicalize-missing) must resolve the full canonical path. No component need exist."
+          weight: 1
+      - R1.6:
+          text: "-n (--no-newline) must suppress the trailing newline when printing a single operand."
+          weight: 1
 
   R2:
     title: Multiple operands
     items:
-      - R2.1: When multiple operands are given, must print each result on a separate line.
-      - R2.2: When multiple operands are given with -n, -n is ignored (newlines are always printed between results).
+      - R2.1:
+          text: When multiple operands are given, must print each result on a separate line.
+          weight: 1
+      - R2.2:
+          text: When multiple operands are given with -n, -n is ignored (newlines are always printed between results).
+          weight: 1
 
   R3:
     title: Error handling
     items:
-      - R3.1: If no operand is provided, must print a usage error to stderr and exit 1.
-      - R3.2: Unknown flags must produce an error message to stderr and exit 1.
+      - R3.1:
+          text: If no operand is provided, must print a usage error to stderr and exit 1.
+          weight: 1
+      - R3.2:
+          text: Unknown flags must produce an error message to stderr and exit 1.
+          weight: 1
 
   R4:
     title: Differential testing
     items:
-      - R4.1: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (greadlink) via pkg/testutils.
-      - R4.2: "Tests must cover: symlink target, non-symlink operand, -f with existing and partial paths, -e with existing and missing paths, -m with missing paths, -n flag, multiple operands, and error cases."
-      - R4.3: All differential tests must set LC_ALL=C in the environment.
+      - R4.1:
+          text: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (greadlink) via pkg/testutils.
+          weight: 1
+      - R4.2:
+          text: "Tests must cover: symlink target, non-symlink operand, -f with existing and partial paths, -e with existing and missing paths, -m with missing paths, -n flag, multiple operands, and error cases."
+          weight: 1
+      - R4.3:
+          text: All differential tests must set LC_ALL=C in the environment.
+          weight: 1
 
 non_goals:
   - cmd/readlink does not create or modify symbolic links; use cmd/ln for that.

--- a/docs/specs/product-requirements/prd051-pwd.yaml
+++ b/docs/specs/product-requirements/prd051-pwd.yaml
@@ -16,23 +16,41 @@ requirements:
   R1:
     title: Default behavior and modes
     items:
-      - R1.1: When invoked with no arguments, must print the current working directory followed by a newline and exit 0. The default mode is -P (physical).
-      - R1.2: "-L (--logical) must print the value of the PWD environment variable if it names the current directory and contains no . or .. components. If PWD is unset or invalid, must fall back to physical mode."
-      - R1.3: "-P (--physical) must print the resolved physical path with all symlinks resolved."
-      - R1.4: When both -L and -P are given, the last one specified takes precedence.
+      - R1.1:
+          text: When invoked with no arguments, must print the current working directory followed by a newline and exit 0. The default mode is -P (physical).
+          weight: 1
+      - R1.2:
+          text: "-L (--logical) must print the value of the PWD environment variable if it names the current directory and contains no . or .. components. If PWD is unset or invalid, must fall back to physical mode."
+          weight: 1
+      - R1.3:
+          text: "-P (--physical) must print the resolved physical path with all symlinks resolved."
+          weight: 1
+      - R1.4:
+          text: When both -L and -P are given, the last one specified takes precedence.
+          weight: 1
 
   R2:
     title: Error handling
     items:
-      - R2.1: If any positional operand is provided, must print an error message to stderr and exit 1.
-      - R2.2: Unknown flags must produce an error message to stderr and exit 1.
+      - R2.1:
+          text: If any positional operand is provided, must print an error message to stderr and exit 1.
+          weight: 1
+      - R2.2:
+          text: Unknown flags must produce an error message to stderr and exit 1.
+          weight: 1
 
   R3:
     title: Differential testing
     items:
-      - R3.1: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (gpwd) via pkg/testutils.
-      - R3.2: "Tests must cover: default invocation, -L, -P, -L -P precedence, and error cases."
-      - R3.3: All differential tests must set LC_ALL=C in the environment.
+      - R3.1:
+          text: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (gpwd) via pkg/testutils.
+          weight: 1
+      - R3.2:
+          text: "Tests must cover: default invocation, -L, -P, -L -P precedence, and error cases."
+          weight: 1
+      - R3.3:
+          text: All differential tests must set LC_ALL=C in the environment.
+          weight: 1
 
 non_goals:
   - cmd/pwd does not change the working directory.

--- a/docs/specs/product-requirements/prd052-tty.yaml
+++ b/docs/specs/product-requirements/prd052-tty.yaml
@@ -16,22 +16,38 @@ requirements:
   R1:
     title: Default behavior and silent mode
     items:
-      - R1.1: When invoked with no arguments and stdin is a terminal, must print the terminal device name (e.g., /dev/ttys000) followed by a newline and exit 0.
-      - R1.2: When invoked with no arguments and stdin is not a terminal, must print "not a tty" followed by a newline and exit 1.
-      - R1.3: "-s (--silent, --quiet) must suppress all output. The exit code is 0 if stdin is a terminal, 1 otherwise."
+      - R1.1:
+          text: When invoked with no arguments and stdin is a terminal, must print the terminal device name (e.g., /dev/ttys000) followed by a newline and exit 0.
+          weight: 1
+      - R1.2:
+          text: When invoked with no arguments and stdin is not a terminal, must print "not a tty" followed by a newline and exit 1.
+          weight: 1
+      - R1.3:
+          text: "-s (--silent, --quiet) must suppress all output. The exit code is 0 if stdin is a terminal, 1 otherwise."
+          weight: 1
 
   R2:
     title: Error handling
     items:
-      - R2.1: If any extra operand is provided (beyond --help and --version), must print an error message to stderr and exit 2.
-      - R2.2: Unknown flags must produce an error message to stderr and exit 2.
+      - R2.1:
+          text: If any extra operand is provided (beyond --help and --version), must print an error message to stderr and exit 2.
+          weight: 1
+      - R2.2:
+          text: Unknown flags must produce an error message to stderr and exit 2.
+          weight: 1
 
   R3:
     title: Differential testing
     items:
-      - R3.1: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (gtty) via pkg/testutils.
-      - R3.2: "Tests must cover: stdin connected to a terminal (if available), stdin redirected from a file or pipe (not a tty), -s flag, and error cases."
-      - R3.3: All differential tests must set LC_ALL=C in the environment.
+      - R3.1:
+          text: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (gtty) via pkg/testutils.
+          weight: 1
+      - R3.2:
+          text: "Tests must cover: stdin connected to a terminal (if available), stdin redirected from a file or pipe (not a tty), -s flag, and error cases."
+          weight: 1
+      - R3.3:
+          text: All differential tests must set LC_ALL=C in the environment.
+          weight: 1
 
 non_goals:
   - cmd/tty does not configure terminal settings; use stty for that.

--- a/docs/specs/product-requirements/prd053-logname.yaml
+++ b/docs/specs/product-requirements/prd053-logname.yaml
@@ -16,22 +16,38 @@ requirements:
   R1:
     title: Default behavior
     items:
-      - R1.1: When invoked with no arguments, must print the login name followed by a newline and exit 0.
-      - R1.2: The login name must be obtained from the system login record (getlogin(3) or equivalent), not from the effective UID.
+      - R1.1:
+          text: When invoked with no arguments, must print the login name followed by a newline and exit 0.
+          weight: 1
+      - R1.2:
+          text: The login name must be obtained from the system login record (getlogin(3) or equivalent), not from the effective UID.
+          weight: 1
 
   R2:
     title: Error handling
     items:
-      - R2.1: If any extra operand is provided (beyond --help and --version), must print an error message to stderr and exit 1.
-      - R2.2: Unknown flags must produce an error message to stderr and exit 1.
-      - R2.3: If the login name cannot be determined (e.g., no controlling terminal), must print an error to stderr and exit 1.
+      - R2.1:
+          text: If any extra operand is provided (beyond --help and --version), must print an error message to stderr and exit 1.
+          weight: 1
+      - R2.2:
+          text: Unknown flags must produce an error message to stderr and exit 1.
+          weight: 1
+      - R2.3:
+          text: If the login name cannot be determined (e.g., no controlling terminal), must print an error to stderr and exit 1.
+          weight: 1
 
   R3:
     title: Differential testing
     items:
-      - R3.1: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (glogname) via pkg/testutils.
-      - R3.2: "Tests must cover: normal invocation (no arguments), extra operand error, and unknown flag error."
-      - R3.3: All differential tests must set LC_ALL=C in the environment.
+      - R3.1:
+          text: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary (glogname) via pkg/testutils.
+          weight: 1
+      - R3.2:
+          text: "Tests must cover: normal invocation (no arguments), extra operand error, and unknown flag error."
+          weight: 1
+      - R3.3:
+          text: All differential tests must set LC_ALL=C in the environment.
+          weight: 1
 
 non_goals:
   - cmd/logname does not accept a username argument.

--- a/docs/specs/product-requirements/prd053-sort.yaml
+++ b/docs/specs/product-requirements/prd053-sort.yaml
@@ -19,37 +19,75 @@ requirements:
   R1:
     title: Basic sorting and output control
     items:
-      - R1.1: When no flags are given, must sort all input lines lexicographically using byte values (LC_ALL=C).
-      - R1.2: Must read from stdin when no file arguments are given or when a file argument is "-".
-      - R1.3: Must accept multiple input files and sort their combined lines as a single stream.
-      - R1.4: "-r or --reverse must reverse the sort order."
-      - R1.5: "-u or --unique must output only the first of an equal run (based on the active sort key)."
-      - R1.6: "-o FILE or --output=FILE must write output to FILE. FILE may be the same as an input file."
-      - R1.7: "-s or --stable must preserve the input order of lines that compare equal."
+      - R1.1:
+          text: When no flags are given, must sort all input lines lexicographically using byte values (LC_ALL=C).
+          weight: 1
+      - R1.2:
+          text: Must read from stdin when no file arguments are given or when a file argument is "-".
+          weight: 1
+      - R1.3:
+          text: Must accept multiple input files and sort their combined lines as a single stream.
+          weight: 1
+      - R1.4:
+          text: "-r or --reverse must reverse the sort order."
+          weight: 1
+      - R1.5:
+          text: "-u or --unique must output only the first of an equal run (based on the active sort key)."
+          weight: 1
+      - R1.6:
+          text: "-o FILE or --output=FILE must write output to FILE. FILE may be the same as an input file."
+          weight: 1
+      - R1.7:
+          text: "-s or --stable must preserve the input order of lines that compare equal."
+          weight: 1
 
   R2:
     title: Sort modes
     items:
-      - R2.1: "-n or --numeric-sort must sort by numeric value, parsing leading whitespace and optional sign."
-      - R2.2: "-h or --human-numeric-sort must sort by numeric value with SI suffixes (K, M, G, T, P, E, Z, Y)."
-      - R2.3: "-M or --month-sort must sort by month name abbreviation (JAN < FEB < ... < DEC). Unknown strings sort before JAN."
-      - R2.4: "-V or --version-sort must sort by version number segments (natural sort)."
+      - R2.1:
+          text: "-n or --numeric-sort must sort by numeric value, parsing leading whitespace and optional sign."
+          weight: 1
+      - R2.2:
+          text: "-h or --human-numeric-sort must sort by numeric value with SI suffixes (K, M, G, T, P, E, Z, Y)."
+          weight: 1
+      - R2.3:
+          text: "-M or --month-sort must sort by month name abbreviation (JAN < FEB < ... < DEC). Unknown strings sort before JAN."
+          weight: 1
+      - R2.4:
+          text: "-V or --version-sort must sort by version number segments (natural sort)."
+          weight: 1
 
   R3:
     title: Key fields and delimiters
     items:
-      - R3.1: "-t CHAR or --field-separator=CHAR must use CHAR as the field delimiter instead of the default blank-to-non-blank transition."
-      - R3.2: "-k KEYDEF or --key=KEYDEF must sort by the specified key field. KEYDEF format is F[.C][OPTS][,F[.C][OPTS]] where F is field number, C is character position, and OPTS are modifier letters (n, r, h, M, V, b, d, f, i)."
-      - R3.3: Must support multiple -k options. Earlier keys take precedence; later keys break ties.
-      - R3.4: "-b or --ignore-leading-blanks must ignore leading blanks when finding sort keys."
+      - R3.1:
+          text: "-t CHAR or --field-separator=CHAR must use CHAR as the field delimiter instead of the default blank-to-non-blank transition."
+          weight: 1
+      - R3.2:
+          text: "-k KEYDEF or --key=KEYDEF must sort by the specified key field. KEYDEF format is F[.C][OPTS][,F[.C][OPTS]] where F is field number, C is character position, and OPTS are modifier letters (n, r, h, M, V, b, d, f, i)."
+          weight: 1
+      - R3.3:
+          text: Must support multiple -k options. Earlier keys take precedence; later keys break ties.
+          weight: 1
+      - R3.4:
+          text: "-b or --ignore-leading-blanks must ignore leading blanks when finding sort keys."
+          weight: 1
 
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: Must exit 0 when input is sorted successfully.
-      - R4.2: "-c or --check must check whether input is sorted. Exit 0 if sorted, exit 1 if not. With -C or --check=quiet, suppress the diagnostic message."
-      - R4.3: Must exit 2 on usage errors (invalid flags, conflicting options).
-      - R4.4: "Differential tests must compare stdout output and exit codes between the Go binary and the reference binary via pkg/testutils. Tests must cover: default sort, -r, -n, -h, -M, -V, -u, -s, -k with field specs, -t delimiter, -b, -c check mode, multi-file input, and stdin."
+      - R4.1:
+          text: Must exit 0 when input is sorted successfully.
+          weight: 1
+      - R4.2:
+          text: "-c or --check must check whether input is sorted. Exit 0 if sorted, exit 1 if not. With -C or --check=quiet, suppress the diagnostic message."
+          weight: 1
+      - R4.3:
+          text: Must exit 2 on usage errors (invalid flags, conflicting options).
+          weight: 1
+      - R4.4:
+          text: "Differential tests must compare stdout output and exit codes between the Go binary and the reference binary via pkg/testutils. Tests must cover: default sort, -r, -n, -h, -M, -V, -u, -s, -k with field specs, -t delimiter, -b, -c check mode, multi-file input, and stdin."
+          weight: 1
 
 non_goals:
   - cmd/sort does not implement --parallel (threaded merge sort). Single-threaded sorting is sufficient for correctness verification.

--- a/docs/specs/product-requirements/prd054-tr.yaml
+++ b/docs/specs/product-requirements/prd054-tr.yaml
@@ -19,32 +19,60 @@ requirements:
   R1:
     title: Character translation
     items:
-      - R1.1: "When two SETs are given without flags, must translate each character in SET1 to the corresponding character in SET2. If SET2 is shorter than SET1, the last character of SET2 is repeated to match SET1's length."
-      - R1.2: Must read from stdin and write translated output to stdout. tr does not accept file arguments.
-      - R1.3: "SET specifications must support: individual characters, ranges (a-z), octal escapes (\\NNN), backslash escapes (\\n, \\t, \\\\, \\a, \\b, \\f, \\r, \\v), and repetition (CHAR*N, CHAR*)."
-      - R1.4: "SET specifications must support POSIX character classes: [:alnum:], [:alpha:], [:blank:], [:cntrl:], [:digit:], [:graph:], [:lower:], [:print:], [:punct:], [:space:], [:upper:], [:xdigit:]."
+      - R1.1:
+          text: "When two SETs are given without flags, must translate each character in SET1 to the corresponding character in SET2. If SET2 is shorter than SET1, the last character of SET2 is repeated to match SET1's length."
+          weight: 1
+      - R1.2:
+          text: Must read from stdin and write translated output to stdout. tr does not accept file arguments.
+          weight: 1
+      - R1.3:
+          text: "SET specifications must support: individual characters, ranges (a-z), octal escapes (\\NNN), backslash escapes (\\n, \\t, \\\\, \\a, \\b, \\f, \\r, \\v), and repetition (CHAR*N, CHAR*)."
+          weight: 1
+      - R1.4:
+          text: "SET specifications must support POSIX character classes: [:alnum:], [:alpha:], [:blank:], [:cntrl:], [:digit:], [:graph:], [:lower:], [:print:], [:punct:], [:space:], [:upper:], [:xdigit:]."
+          weight: 1
 
   R2:
     title: Delete and squeeze modes
     items:
-      - R2.1: "-d or --delete must delete all characters in SET1 from the input. SET2 is not used with -d alone."
-      - R2.2: "-s or --squeeze-repeats must replace each run of repeated characters listed in the last SET with a single occurrence of that character."
-      - R2.3: "When -d and -s are used together, must delete characters in SET1 and squeeze characters in SET2."
-      - R2.4: "-c or -C or --complement must complement SET1, operating on all characters not in SET1."
+      - R2.1:
+          text: "-d or --delete must delete all characters in SET1 from the input. SET2 is not used with -d alone."
+          weight: 1
+      - R2.2:
+          text: "-s or --squeeze-repeats must replace each run of repeated characters listed in the last SET with a single occurrence of that character."
+          weight: 1
+      - R2.3:
+          text: "When -d and -s are used together, must delete characters in SET1 and squeeze characters in SET2."
+          weight: 1
+      - R2.4:
+          text: "-c or -C or --complement must complement SET1, operating on all characters not in SET1."
+          weight: 1
 
   R3:
     title: Character class translation pairs
     items:
-      - R3.1: "[:lower:] to [:upper:] must translate lowercase to uppercase. [:upper:] to [:lower:] must translate uppercase to lowercase."
-      - R3.2: "When translating (not deleting), SET2 must not be empty. If SET2 is omitted, must print a usage error."
-      - R3.3: "Equivalence classes [=CHAR=] must be supported in SET2 for specifying characters that sort identically."
+      - R3.1:
+          text: "[:lower:] to [:upper:] must translate lowercase to uppercase. [:upper:] to [:lower:] must translate uppercase to lowercase."
+          weight: 1
+      - R3.2:
+          text: "When translating (not deleting), SET2 must not be empty. If SET2 is omitted, must print a usage error."
+          weight: 1
+      - R3.3:
+          text: "Equivalence classes [=CHAR=] must be supported in SET2 for specifying characters that sort identically."
+          weight: 1
 
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: Must exit 0 when translation or deletion completes successfully.
-      - R4.2: Must exit 1 on usage errors (missing SET, invalid class, conflicting flags).
-      - R4.3: "Differential tests must compare stdout output and exit codes between the Go binary and the reference binary via pkg/testutils. Tests must cover: basic translation, -d delete, -s squeeze, -c complement, -ds combined, character ranges, POSIX classes, case conversion, octal escapes, and error cases."
+      - R4.1:
+          text: Must exit 0 when translation or deletion completes successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 on usage errors (missing SET, invalid class, conflicting flags).
+          weight: 1
+      - R4.3:
+          text: "Differential tests must compare stdout output and exit codes between the Go binary and the reference binary via pkg/testutils. Tests must cover: basic translation, -d delete, -s squeeze, -c complement, -ds combined, character ranges, POSIX classes, case conversion, octal escapes, and error cases."
+          weight: 1
 
 non_goals:
   - cmd/tr does not implement multibyte character support beyond single-byte encodings. All tests use LC_ALL=C.

--- a/docs/specs/product-requirements/prd055-tail.yaml
+++ b/docs/specs/product-requirements/prd055-tail.yaml
@@ -19,33 +19,63 @@ requirements:
   R1:
     title: Line-count mode (default and -n)
     items:
-      - R1.1: When no flags are given, must print the last 10 lines of each input file.
-      - R1.2: "-n NUM or --lines=NUM must print the last NUM lines. NUM must be a positive integer or prefixed with '+' to start from line NUM."
-      - R1.3: "When NUM is prefixed with '+' (e.g., -n +5), must print starting from line NUM to the end of the file. Line numbering starts at 1."
-      - R1.4: Must read from stdin when no file arguments are given or when a file argument is "-".
+      - R1.1:
+          text: When no flags are given, must print the last 10 lines of each input file.
+          weight: 1
+      - R1.2:
+          text: "-n NUM or --lines=NUM must print the last NUM lines. NUM must be a positive integer or prefixed with '+' to start from line NUM."
+          weight: 1
+      - R1.3:
+          text: "When NUM is prefixed with '+' (e.g., -n +5), must print starting from line NUM to the end of the file. Line numbering starts at 1."
+          weight: 1
+      - R1.4:
+          text: Must read from stdin when no file arguments are given or when a file argument is "-".
+          weight: 1
 
   R2:
     title: Byte-count mode (-c)
     items:
-      - R2.1: "-c NUM or --bytes=NUM must print the last NUM bytes of each input. -c and -n are mutually exclusive; the last one given takes precedence."
-      - R2.2: "When NUM is prefixed with '+' (e.g., -c +100), must print starting from byte NUM to the end. Byte numbering starts at 1."
-      - R2.3: NUM may use multiplier suffixes as defined by GNU coreutils (b, K/KiB, M/MiB, G/GiB).
+      - R2.1:
+          text: "-c NUM or --bytes=NUM must print the last NUM bytes of each input. -c and -n are mutually exclusive; the last one given takes precedence."
+          weight: 1
+      - R2.2:
+          text: "When NUM is prefixed with '+' (e.g., -c +100), must print starting from byte NUM to the end. Byte numbering starts at 1."
+          weight: 1
+      - R2.3:
+          text: NUM may use multiplier suffixes as defined by GNU coreutils (b, K/KiB, M/MiB, G/GiB).
+          weight: 1
 
   R3:
     title: Multi-file output and headers
     items:
-      - R3.1: "When multiple files are given, must precede each file's output with a header in the format '==> FILENAME <==' followed by a newline. A blank line separates each file's header from the previous file's output."
-      - R3.2: When a single file is given, must not print a header by default.
-      - R3.3: -q or --quiet or --silent must suppress all headers, even for multiple files.
-      - R3.4: -v or --verbose must print headers even for a single file.
+      - R3.1:
+          text: "When multiple files are given, must precede each file's output with a header in the format '==> FILENAME <==' followed by a newline. A blank line separates each file's header from the previous file's output."
+          weight: 1
+      - R3.2:
+          text: When a single file is given, must not print a header by default.
+          weight: 1
+      - R3.3:
+          text: -q or --quiet or --silent must suppress all headers, even for multiple files.
+          weight: 1
+      - R3.4:
+          text: -v or --verbose must print headers even for a single file.
+          weight: 1
 
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: Must exit 0 when all input files are processed successfully.
-      - R4.2: Must exit 1 when any input file cannot be opened or read. Must still process and output content for the files that were successfully read.
-      - R4.3: "Differential tests must compare stdout output and exit codes between the Go binary and the reference binary via pkg/testutils. Tests must cover: default 10 lines, explicit -n count, -c byte count, +N offset (lines and bytes), multi-file headers, -q, -v, stdin input, and error on non-existent file."
-      - R4.4: "When a named file cannot be opened, must print an error message to stderr and continue processing remaining files."
+      - R4.1:
+          text: Must exit 0 when all input files are processed successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any input file cannot be opened or read. Must still process and output content for the files that were successfully read.
+          weight: 1
+      - R4.3:
+          text: "Differential tests must compare stdout output and exit codes between the Go binary and the reference binary via pkg/testutils. Tests must cover: default 10 lines, explicit -n count, -c byte count, +N offset (lines and bytes), multi-file headers, -q, -v, stdin input, and error on non-existent file."
+          weight: 1
+      - R4.4:
+          text: "When a named file cannot be opened, must print an error message to stderr and continue processing remaining files."
+          weight: 1
 
 non_goals:
   - "cmd/tail does not implement -f or --follow (follow mode). Follow mode output is non-deterministic and cannot be verified by differential testing."

--- a/docs/specs/product-requirements/prd056-cp.yaml
+++ b/docs/specs/product-requirements/prd056-cp.yaml
@@ -19,34 +19,66 @@ requirements:
   R1:
     title: Basic file copying
     items:
-      - R1.1: "When given SOURCE DEST, must copy SOURCE to DEST. When given multiple SOURCE arguments and a DEST directory, must copy each SOURCE into DEST."
-      - R1.2: "-i or --interactive must prompt before overwriting an existing destination file."
-      - R1.3: "-f or --force must remove an existing destination file if it cannot be opened for writing, then retry the copy."
-      - R1.4: "-n or --no-clobber must not overwrite an existing destination file. When combined with -i, -n takes precedence."
+      - R1.1:
+          text: "When given SOURCE DEST, must copy SOURCE to DEST. When given multiple SOURCE arguments and a DEST directory, must copy each SOURCE into DEST."
+          weight: 1
+      - R1.2:
+          text: "-i or --interactive must prompt before overwriting an existing destination file."
+          weight: 1
+      - R1.3:
+          text: "-f or --force must remove an existing destination file if it cannot be opened for writing, then retry the copy."
+          weight: 1
+      - R1.4:
+          text: "-n or --no-clobber must not overwrite an existing destination file. When combined with -i, -n takes precedence."
+          weight: 1
 
   R2:
     title: Recursive copying and symlinks
     items:
-      - R2.1: "-r or -R or --recursive must copy directories recursively, preserving the directory structure."
-      - R2.2: "Without -r, must refuse to copy a directory and print an error to stderr."
-      - R2.3: "-L or --dereference must follow symlinks in SOURCE, copying the file they point to."
-      - R2.4: "-P or --no-dereference must preserve symlinks, copying them as symlinks rather than following them. This is the default with -r."
+      - R2.1:
+          text: "-r or -R or --recursive must copy directories recursively, preserving the directory structure."
+          weight: 1
+      - R2.2:
+          text: "Without -r, must refuse to copy a directory and print an error to stderr."
+          weight: 1
+      - R2.3:
+          text: "-L or --dereference must follow symlinks in SOURCE, copying the file they point to."
+          weight: 1
+      - R2.4:
+          text: "-P or --no-dereference must preserve symlinks, copying them as symlinks rather than following them. This is the default with -r."
+          weight: 1
 
   R3:
     title: Attribute preservation
     items:
-      - R3.1: "-p or --preserve=mode,ownership,timestamps must preserve file mode, ownership, and modification timestamps on the copy."
-      - R3.2: "-a or --archive is equivalent to -dR --preserve=all. It preserves all attributes and copies recursively without following symlinks."
-      - R3.3: "--preserve=ATTR_LIST must accept a comma-separated list of attributes to preserve. Supported attributes are mode, ownership, timestamps, and links."
-      - R3.4: "-v or --verbose must print the name of each file as it is copied."
+      - R3.1:
+          text: "-p or --preserve=mode,ownership,timestamps must preserve file mode, ownership, and modification timestamps on the copy."
+          weight: 1
+      - R3.2:
+          text: "-a or --archive is equivalent to -dR --preserve=all. It preserves all attributes and copies recursively without following symlinks."
+          weight: 1
+      - R3.3:
+          text: "--preserve=ATTR_LIST must accept a comma-separated list of attributes to preserve. Supported attributes are mode, ownership, timestamps, and links."
+          weight: 1
+      - R3.4:
+          text: "-v or --verbose must print the name of each file as it is copied."
+          weight: 1
 
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: Must exit 0 when all files are copied successfully.
-      - R4.2: Must exit 1 when any copy operation fails (permission denied, source not found, destination is a directory without -r).
-      - R4.3: "-t DIRECTORY or --target-directory=DIRECTORY must copy all SOURCE arguments into DIRECTORY."
-      - R4.4: "Differential tests must compare exit codes and resulting file system state between the Go binary and the reference binary via pkg/testutils. Tests must cover: single file copy, multi-file copy into directory, -r recursive, -i interactive (via stdin), -f force, -n no-clobber, -p preserve, -a archive, -v verbose, symlink handling, and error cases."
+      - R4.1:
+          text: Must exit 0 when all files are copied successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any copy operation fails (permission denied, source not found, destination is a directory without -r).
+          weight: 1
+      - R4.3:
+          text: "-t DIRECTORY or --target-directory=DIRECTORY must copy all SOURCE arguments into DIRECTORY."
+          weight: 1
+      - R4.4:
+          text: "Differential tests must compare exit codes and resulting file system state between the Go binary and the reference binary via pkg/testutils. Tests must cover: single file copy, multi-file copy into directory, -r recursive, -i interactive (via stdin), -f force, -n no-clobber, -p preserve, -a archive, -v verbose, symlink handling, and error cases."
+          weight: 1
 
 non_goals:
   - "cmd/cp does not implement --reflink (copy-on-write clones). Reflink support is filesystem-dependent and not available on all platforms."

--- a/docs/specs/product-requirements/prd057-mv.yaml
+++ b/docs/specs/product-requirements/prd057-mv.yaml
@@ -18,33 +18,63 @@ requirements:
   R1:
     title: Basic move and rename
     items:
-      - R1.1: "When given SOURCE DEST, must rename SOURCE to DEST if on the same filesystem, or copy and delete if on different filesystems."
-      - R1.2: "When given multiple SOURCE arguments and a DEST directory, must move each SOURCE into DEST."
-      - R1.3: Must move directories without requiring a recursive flag (unlike cp).
-      - R1.4: "When DEST exists and is a directory, must move SOURCE into DEST as DEST/SOURCE."
+      - R1.1:
+          text: "When given SOURCE DEST, must rename SOURCE to DEST if on the same filesystem, or copy and delete if on different filesystems."
+          weight: 1
+      - R1.2:
+          text: "When given multiple SOURCE arguments and a DEST directory, must move each SOURCE into DEST."
+          weight: 1
+      - R1.3:
+          text: Must move directories without requiring a recursive flag (unlike cp).
+          weight: 1
+      - R1.4:
+          text: "When DEST exists and is a directory, must move SOURCE into DEST as DEST/SOURCE."
+          weight: 1
 
   R2:
     title: Overwrite control
     items:
-      - R2.1: "-i or --interactive must prompt before overwriting an existing destination file."
-      - R2.2: "-f or --force must not prompt before overwriting. When combined with -i, the last flag given takes precedence."
-      - R2.3: "-n or --no-clobber must not overwrite an existing destination file."
-      - R2.4: "When the destination cannot be overwritten due to permissions, must print an error to stderr."
+      - R2.1:
+          text: "-i or --interactive must prompt before overwriting an existing destination file."
+          weight: 1
+      - R2.2:
+          text: "-f or --force must not prompt before overwriting. When combined with -i, the last flag given takes precedence."
+          weight: 1
+      - R2.3:
+          text: "-n or --no-clobber must not overwrite an existing destination file."
+          weight: 1
+      - R2.4:
+          text: "When the destination cannot be overwritten due to permissions, must print an error to stderr."
+          weight: 1
 
   R3:
     title: Output control and target directory
     items:
-      - R3.1: "-v or --verbose must print the name of each file as it is moved, in the format 'SOURCE -> DEST' or 'renamed SOURCE -> DEST'."
-      - R3.2: "-t DIRECTORY or --target-directory=DIRECTORY must move all SOURCE arguments into DIRECTORY."
-      - R3.3: "-T or --no-target-directory must treat DEST as a normal file, not a directory."
+      - R3.1:
+          text: "-v or --verbose must print the name of each file as it is moved, in the format 'SOURCE -> DEST' or 'renamed SOURCE -> DEST'."
+          weight: 1
+      - R3.2:
+          text: "-t DIRECTORY or --target-directory=DIRECTORY must move all SOURCE arguments into DIRECTORY."
+          weight: 1
+      - R3.3:
+          text: "-T or --no-target-directory must treat DEST as a normal file, not a directory."
+          weight: 1
 
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: Must exit 0 when all files are moved successfully.
-      - R4.2: Must exit 1 when any move operation fails (permission denied, source not found).
-      - R4.3: "When moving multiple files and one fails, must continue moving remaining files and exit 1."
-      - R4.4: "Differential tests must compare exit codes and resulting file system state between the Go binary and the reference binary via pkg/testutils. Tests must cover: single file rename, move into directory, multi-file move, -i interactive, -f force, -n no-clobber, -v verbose, -t target directory, directory move, and error cases."
+      - R4.1:
+          text: Must exit 0 when all files are moved successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any move operation fails (permission denied, source not found).
+          weight: 1
+      - R4.3:
+          text: "When moving multiple files and one fails, must continue moving remaining files and exit 1."
+          weight: 1
+      - R4.4:
+          text: "Differential tests must compare exit codes and resulting file system state between the Go binary and the reference binary via pkg/testutils. Tests must cover: single file rename, move into directory, multi-file move, -i interactive, -f force, -n no-clobber, -v verbose, -t target directory, directory move, and error cases."
+          weight: 1
 
 non_goals:
   - cmd/mv does not implement --backup (make backups of existing destination files).

--- a/docs/specs/product-requirements/prd058-rm.yaml
+++ b/docs/specs/product-requirements/prd058-rm.yaml
@@ -18,34 +18,66 @@ requirements:
   R1:
     title: Basic file removal
     items:
-      - R1.1: "When given one or more FILE arguments, must remove each file using unlink(2)."
-      - R1.2: "Without -r, must refuse to remove a directory and print an error to stderr."
-      - R1.3: "Must not remove '.' or '..' to prevent accidental directory tree destruction. Must print an error if either is specified."
-      - R1.4: "When a file cannot be removed (permission denied, in use), must print an error to stderr and continue with remaining files."
+      - R1.1:
+          text: "When given one or more FILE arguments, must remove each file using unlink(2)."
+          weight: 1
+      - R1.2:
+          text: "Without -r, must refuse to remove a directory and print an error to stderr."
+          weight: 1
+      - R1.3:
+          text: "Must not remove '.' or '..' to prevent accidental directory tree destruction. Must print an error if either is specified."
+          weight: 1
+      - R1.4:
+          text: "When a file cannot be removed (permission denied, in use), must print an error to stderr and continue with remaining files."
+          weight: 1
 
   R2:
     title: Recursive removal and force mode
     items:
-      - R2.1: "-r or -R or --recursive must remove directories and their contents recursively."
-      - R2.2: "-f or --force must ignore non-existent files and never prompt. Overrides -i and -I."
-      - R2.3: "When -r and -f are combined, must silently remove directory trees without prompting."
-      - R2.4: "-d or --dir must remove empty directories. Without -d or -r, directory removal fails."
+      - R2.1:
+          text: "-r or -R or --recursive must remove directories and their contents recursively."
+          weight: 1
+      - R2.2:
+          text: "-f or --force must ignore non-existent files and never prompt. Overrides -i and -I."
+          weight: 1
+      - R2.3:
+          text: "When -r and -f are combined, must silently remove directory trees without prompting."
+          weight: 1
+      - R2.4:
+          text: "-d or --dir must remove empty directories. Without -d or -r, directory removal fails."
+          weight: 1
 
   R3:
     title: Interactive modes and verbose output
     items:
-      - R3.1: "-i must prompt before every removal."
-      - R3.2: "-I must prompt once before removing more than three files or when removing recursively."
-      - R3.3: "-v or --verbose must print the name of each file as it is removed."
-      - R3.4: "--interactive=WHEN must control prompting. WHEN is 'never' (like -f), 'once' (like -I), or 'always' (like -i)."
+      - R3.1:
+          text: "-i must prompt before every removal."
+          weight: 1
+      - R3.2:
+          text: "-I must prompt once before removing more than three files or when removing recursively."
+          weight: 1
+      - R3.3:
+          text: "-v or --verbose must print the name of each file as it is removed."
+          weight: 1
+      - R3.4:
+          text: "--interactive=WHEN must control prompting. WHEN is 'never' (like -f), 'once' (like -I), or 'always' (like -i)."
+          weight: 1
 
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: Must exit 0 when all files are removed successfully.
-      - R4.2: Must exit 1 when any removal fails. Must continue removing remaining files.
-      - R4.3: "With -f, must exit 0 even when specified files do not exist."
-      - R4.4: "Differential tests must compare exit codes and resulting file system state between the Go binary and the reference binary via pkg/testutils. Tests must cover: single file removal, multi-file removal, -r recursive, -f force on non-existent, -d empty directory, -v verbose, error on directory without -r, error on permission denied, and refusing to remove '.' or '..'."
+      - R4.1:
+          text: Must exit 0 when all files are removed successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any removal fails. Must continue removing remaining files.
+          weight: 1
+      - R4.3:
+          text: "With -f, must exit 0 even when specified files do not exist."
+          weight: 1
+      - R4.4:
+          text: "Differential tests must compare exit codes and resulting file system state between the Go binary and the reference binary via pkg/testutils. Tests must cover: single file removal, multi-file removal, -r recursive, -f force on non-existent, -d empty directory, -v verbose, error on directory without -r, error on permission denied, and refusing to remove '.' or '..'."
+          weight: 1
 
 non_goals:
   - cmd/rm does not implement --one-file-system (skip directories on different filesystems during recursive removal).

--- a/docs/specs/product-requirements/prd059-version.yaml
+++ b/docs/specs/product-requirements/prd059-version.yaml
@@ -17,27 +17,37 @@ requirements:
   R1:
     title: cmd/version binary
     items:
-      - R1.1: |
-          Must provide a cmd/version/ package that compiles to a standalone binary. When
-          invoked with no arguments, the binary prints the version string to stdout followed
-          by a newline and exits 0.
-      - R1.2: |
-          The version string must be set at build time via -ldflags "-X main.version=<tag>".
-          When the linker variable is not set (development builds), the binary must print
-          "dev" as the version string.
-      - R1.3: |
-          The mage build target must resolve the version tag by running
-          git describe --tags --abbrev=0 --match "v[0-9]*" and passing the result to the
-          linker. If the git command fails (no tags, not a git repository), the build must
-          succeed with the version set to "dev".
-      - R1.4: |
-          When invoked with --version or -v, the binary must print the same version string
-          as the no-argument invocation. Any other flag must cause the binary to print a
-          usage message to stderr and exit 2.
-      - R1.5: |
-          The version package must export a variable or function so that other cmd/ packages
-          can import and report the same version string without duplicating the ldflags
-          mechanism.
+      - R1.1:
+          text: |
+            Must provide a cmd/version/ package that compiles to a standalone binary. When
+            invoked with no arguments, the binary prints the version string to stdout followed
+            by a newline and exits 0.
+          weight: 1
+      - R1.2:
+          text: |
+            The version string must be set at build time via -ldflags "-X main.version=<tag>".
+            When the linker variable is not set (development builds), the binary must print
+            "dev" as the version string.
+          weight: 1
+      - R1.3:
+          text: |
+            The mage build target must resolve the version tag by running
+            git describe --tags --abbrev=0 --match "v[0-9]*" and passing the result to the
+            linker. If the git command fails (no tags, not a git repository), the build must
+            succeed with the version set to "dev".
+          weight: 1
+      - R1.4:
+          text: |
+            When invoked with --version or -v, the binary must print the same version string
+            as the no-argument invocation. Any other flag must cause the binary to print a
+            usage message to stderr and exit 2.
+          weight: 1
+      - R1.5:
+          text: |
+            The version package must export a variable or function so that other cmd/ packages
+            can import and report the same version string without duplicating the ldflags
+            mechanism.
+          weight: 1
 
 non_goals:
   - cmd/version does not parse LS_COLORS, handle signals, or do anything beyond printing a version string.

--- a/docs/specs/product-requirements/prd060-date.yaml
+++ b/docs/specs/product-requirements/prd060-date.yaml
@@ -19,34 +19,66 @@ requirements:
   R1:
     title: Default behavior and format strings
     items:
-      - R1.1: When invoked with no arguments, must print the current date and time in the default format and exit 0.
-      - R1.2: When a +FORMAT argument is given, must format the date according to the strftime-style format string and print the result followed by a newline.
-      - R1.3: Must support all standard strftime conversion specifications including %Y (year), %m (month), %d (day), %H (hour), %M (minute), %S (second), %Z (timezone name), %s (seconds since epoch), %N (nanoseconds), %A (weekday name), %B (month name), %j (day of year), %u (day of week 1-7), and %w (day of week 0-6).
-      - R1.4: Must support GNU extensions including %P (lowercase am/pm) and padding modifiers (%-d for no padding, %_d for space padding, %0d for zero padding).
+      - R1.1:
+          text: When invoked with no arguments, must print the current date and time in the default format and exit 0.
+          weight: 1
+      - R1.2:
+          text: When a +FORMAT argument is given, must format the date according to the strftime-style format string and print the result followed by a newline.
+          weight: 1
+      - R1.3:
+          text: Must support all standard strftime conversion specifications including %Y (year), %m (month), %d (day), %H (hour), %M (minute), %S (second), %Z (timezone name), %s (seconds since epoch), %N (nanoseconds), %A (weekday name), %B (month name), %j (day of year), %u (day of week 1-7), and %w (day of week 0-6).
+          weight: 1
+      - R1.4:
+          text: Must support GNU extensions including %P (lowercase am/pm) and padding modifiers (%-d for no padding, %_d for space padding, %0d for zero padding).
+          weight: 1
 
   R2:
     title: Date string parsing (-d/--date)
     items:
-      - R2.1: "-d STRING or --date=STRING must display the date described by STRING instead of the current time."
-      - R2.2: "Must parse epoch timestamps prefixed with @ (e.g., -d @1234567890)."
-      - R2.3: "Must parse ISO 8601 date strings (e.g., -d '2024-01-15 10:30:00')."
-      - R2.4: "When the date string cannot be parsed, must print an error to stderr and exit 1."
+      - R2.1:
+          text: "-d STRING or --date=STRING must display the date described by STRING instead of the current time."
+          weight: 1
+      - R2.2:
+          text: "Must parse epoch timestamps prefixed with @ (e.g., -d @1234567890)."
+          weight: 1
+      - R2.3:
+          text: "Must parse ISO 8601 date strings (e.g., -d '2024-01-15 10:30:00')."
+          weight: 1
+      - R2.4:
+          text: "When the date string cannot be parsed, must print an error to stderr and exit 1."
+          weight: 1
 
   R3:
     title: UTC mode and reference time
     items:
-      - R3.1: "-u or --utc or --universal must display the date in UTC instead of the local timezone."
-      - R3.2: "-r FILE or --reference=FILE must display the last modification time of FILE instead of the current time."
-      - R3.3: "When the referenced file does not exist, must print an error to stderr and exit 1."
-      - R3.4: Must not read from stdin. Must write formatted output to stdout only.
+      - R3.1:
+          text: "-u or --utc or --universal must display the date in UTC instead of the local timezone."
+          weight: 1
+      - R3.2:
+          text: "-r FILE or --reference=FILE must display the last modification time of FILE instead of the current time."
+          weight: 1
+      - R3.3:
+          text: "When the referenced file does not exist, must print an error to stderr and exit 1."
+          weight: 1
+      - R3.4:
+          text: Must not read from stdin. Must write formatted output to stdout only.
+          weight: 1
 
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: Must exit 0 when the date is displayed successfully.
-      - R4.2: Must exit 1 when an invalid date string is given or a referenced file does not exist.
-      - R4.3: "Differential tests must compare stdout and exit codes between the Go binary and the reference binary via pkg/testutils. Tests must use fixed dates via -d @EPOCH to ensure deterministic output."
-      - R4.4: "Tests must cover: default output with fixed epoch, +FORMAT with various conversion specs, -d with epoch and ISO strings, -u UTC mode, -r reference file, padding modifiers, and error cases (invalid date, missing file)."
+      - R4.1:
+          text: Must exit 0 when the date is displayed successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when an invalid date string is given or a referenced file does not exist.
+          weight: 1
+      - R4.3:
+          text: "Differential tests must compare stdout and exit codes between the Go binary and the reference binary via pkg/testutils. Tests must use fixed dates via -d @EPOCH to ensure deterministic output."
+          weight: 1
+      - R4.4:
+          text: "Tests must cover: default output with fixed epoch, +FORMAT with various conversion specs, -d with epoch and ISO strings, -u UTC mode, -r reference file, padding modifiers, and error cases (invalid date, missing file)."
+          weight: 1
 
 non_goals:
   - cmd/date does not implement -s/--set to set the system clock.

--- a/docs/specs/product-requirements/prd061-sleep.yaml
+++ b/docs/specs/product-requirements/prd061-sleep.yaml
@@ -17,34 +17,66 @@ requirements:
   R1:
     title: Core sleep behavior
     items:
-      - R1.1: Must pause for NUMBER seconds when given a single numeric argument, then exit 0.
-      - R1.2: Must support fractional seconds (e.g., sleep 0.5 pauses for 500 milliseconds).
-      - R1.3: Must support suffix multipliers s (seconds, default), m (minutes, x60), h (hours, x3600), d (days, x86400). The suffix is case-sensitive and lowercase only.
-      - R1.4: When multiple arguments are given, must sum all durations and sleep for the total.
+      - R1.1:
+          text: Must pause for NUMBER seconds when given a single numeric argument, then exit 0.
+          weight: 1
+      - R1.2:
+          text: Must support fractional seconds (e.g., sleep 0.5 pauses for 500 milliseconds).
+          weight: 1
+      - R1.3:
+          text: Must support suffix multipliers s (seconds, default), m (minutes, x60), h (hours, x3600), d (days, x86400). The suffix is case-sensitive and lowercase only.
+          weight: 1
+      - R1.4:
+          text: When multiple arguments are given, must sum all durations and sleep for the total.
+          weight: 1
 
   R2:
     title: Input validation and error handling
     items:
-      - R2.1: Must accept zero as a valid duration and return immediately with exit 0.
-      - R2.2: When no arguments are given, must print a usage error to stderr and exit 1.
-      - R2.3: When a non-numeric or negative argument is given, must print an error to stderr and exit 1.
-      - R2.4: "Must support infinity (or inf) as a duration, sleeping indefinitely until interrupted."
+      - R2.1:
+          text: Must accept zero as a valid duration and return immediately with exit 0.
+          weight: 1
+      - R2.2:
+          text: When no arguments are given, must print a usage error to stderr and exit 1.
+          weight: 1
+      - R2.3:
+          text: When a non-numeric or negative argument is given, must print an error to stderr and exit 1.
+          weight: 1
+      - R2.4:
+          text: "Must support infinity (or inf) as a duration, sleeping indefinitely until interrupted."
+          weight: 1
 
   R3:
     title: Signal handling and output
     items:
-      - R3.1: Must not produce any output to stdout or stderr under normal operation.
-      - R3.2: Must not read from stdin.
-      - R3.3: When --help is the first argument, must print a usage message to stdout and exit 0.
-      - R3.4: When --version is the first argument, must print version information to stdout and exit 0.
+      - R3.1:
+          text: Must not produce any output to stdout or stderr under normal operation.
+          weight: 1
+      - R3.2:
+          text: Must not read from stdin.
+          weight: 1
+      - R3.3:
+          text: When --help is the first argument, must print a usage message to stdout and exit 0.
+          weight: 1
+      - R3.4:
+          text: When --version is the first argument, must print version information to stdout and exit 0.
+          weight: 1
 
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: Must exit 0 after sleeping for the requested duration.
-      - R4.2: Must exit 1 when given invalid arguments (no args, non-numeric, negative).
-      - R4.3: "Differential tests must compare exit codes between the Go binary and the reference binary via pkg/testutils. Tests must use short durations (0 or 0.01) to avoid slow test execution."
-      - R4.4: "Tests must cover: zero duration, fractional seconds, suffix multipliers (s, m, h, d), multiple arguments summed, error on no args, error on invalid arg, and error on negative arg."
+      - R4.1:
+          text: Must exit 0 after sleeping for the requested duration.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when given invalid arguments (no args, non-numeric, negative).
+          weight: 1
+      - R4.3:
+          text: "Differential tests must compare exit codes between the Go binary and the reference binary via pkg/testutils. Tests must use short durations (0 or 0.01) to avoid slow test execution."
+          weight: 1
+      - R4.4:
+          text: "Tests must cover: zero duration, fractional seconds, suffix multipliers (s, m, h, d), multiple arguments summed, error on no args, error on invalid arg, and error on negative arg."
+          weight: 1
 
 non_goals:
   - cmd/sleep does not implement signal-based early wake (SIGALRM or similar).

--- a/docs/specs/product-requirements/prd062-touch.yaml
+++ b/docs/specs/product-requirements/prd062-touch.yaml
@@ -17,34 +17,66 @@ requirements:
   R1:
     title: Default behavior and file creation
     items:
-      - R1.1: When given one or more FILE arguments, must update the access and modification times of each file to the current time.
-      - R1.2: When a named file does not exist, must create it as an empty file with default permissions.
-      - R1.3: "-c or --no-create must suppress file creation. If the file does not exist, must not create it and must not report an error."
-      - R1.4: Must support multiple file arguments, processing each in order.
+      - R1.1:
+          text: When given one or more FILE arguments, must update the access and modification times of each file to the current time.
+          weight: 1
+      - R1.2:
+          text: When a named file does not exist, must create it as an empty file with default permissions.
+          weight: 1
+      - R1.3:
+          text: "-c or --no-create must suppress file creation. If the file does not exist, must not create it and must not report an error."
+          weight: 1
+      - R1.4:
+          text: Must support multiple file arguments, processing each in order.
+          weight: 1
 
   R2:
     title: Timestamp selection and explicit times
     items:
-      - R2.1: "-a must change only the access time."
-      - R2.2: "-m must change only the modification time."
-      - R2.3: "When neither -a nor -m is given, must change both access and modification times."
-      - R2.4: "-t STAMP must use the timestamp [[CC]YY]MMDDhhmm[.ss] instead of the current time."
+      - R2.1:
+          text: "-a must change only the access time."
+          weight: 1
+      - R2.2:
+          text: "-m must change only the modification time."
+          weight: 1
+      - R2.3:
+          text: "When neither -a nor -m is given, must change both access and modification times."
+          weight: 1
+      - R2.4:
+          text: "-t STAMP must use the timestamp [[CC]YY]MMDDhhmm[.ss] instead of the current time."
+          weight: 1
 
   R3:
     title: Reference file and date string
     items:
-      - R3.1: "-r FILE or --reference=FILE must use the timestamps of FILE instead of the current time."
-      - R3.2: "-d STRING or --date=STRING must parse the date string and use it instead of the current time."
-      - R3.3: "When a reference file does not exist, must print an error to stderr and exit 1."
-      - R3.4: "-h or --no-dereference must affect the symbolic link itself rather than the file it points to."
+      - R3.1:
+          text: "-r FILE or --reference=FILE must use the timestamps of FILE instead of the current time."
+          weight: 1
+      - R3.2:
+          text: "-d STRING or --date=STRING must parse the date string and use it instead of the current time."
+          weight: 1
+      - R3.3:
+          text: "When a reference file does not exist, must print an error to stderr and exit 1."
+          weight: 1
+      - R3.4:
+          text: "-h or --no-dereference must affect the symbolic link itself rather than the file it points to."
+          weight: 1
 
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: Must exit 0 when all files are processed successfully.
-      - R4.2: Must exit 1 when an error occurs (invalid timestamp, missing reference file, permission denied). Must continue processing remaining files after an error.
-      - R4.3: "Differential tests must compare exit codes and resulting file timestamps between the Go binary and the reference binary via pkg/testutils."
-      - R4.4: "Tests must cover: create new file, update existing file, -c no-create, -a access only, -m modification only, -t explicit timestamp, -d date string, -r reference file, multiple files, and error cases (invalid timestamp, missing reference file)."
+      - R4.1:
+          text: Must exit 0 when all files are processed successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when an error occurs (invalid timestamp, missing reference file, permission denied). Must continue processing remaining files after an error.
+          weight: 1
+      - R4.3:
+          text: "Differential tests must compare exit codes and resulting file timestamps between the Go binary and the reference binary via pkg/testutils."
+          weight: 1
+      - R4.4:
+          text: "Tests must cover: create new file, update existing file, -c no-create, -a access only, -m modification only, -t explicit timestamp, -d date string, -r reference file, multiple files, and error cases (invalid timestamp, missing reference file)."
+          weight: 1
 
 non_goals:
   - cmd/touch does not implement the obsolescent -t format with two-digit years outside the [[CC]YY]MMDDhhmm[.ss] specification.

--- a/docs/specs/product-requirements/prd063-timeout.yaml
+++ b/docs/specs/product-requirements/prd063-timeout.yaml
@@ -18,34 +18,66 @@ requirements:
   R1:
     title: Core timeout behavior
     items:
-      - R1.1: "Must run COMMAND with optional ARGS and kill it with SIGTERM if it does not exit within DURATION seconds."
-      - R1.2: Must support fractional durations (e.g., timeout 0.5 command).
-      - R1.3: Must support suffix multipliers s (seconds, default), m (minutes), h (hours), d (days).
-      - R1.4: "When DURATION is 0, must not impose a time limit (the command runs indefinitely)."
+      - R1.1:
+          text: "Must run COMMAND with optional ARGS and kill it with SIGTERM if it does not exit within DURATION seconds."
+          weight: 1
+      - R1.2:
+          text: Must support fractional durations (e.g., timeout 0.5 command).
+          weight: 1
+      - R1.3:
+          text: Must support suffix multipliers s (seconds, default), m (minutes), h (hours), d (days).
+          weight: 1
+      - R1.4:
+          text: "When DURATION is 0, must not impose a time limit (the command runs indefinitely)."
+          weight: 1
 
   R2:
     title: Signal selection and kill-after
     items:
-      - R2.1: "-s SIGNAL or --signal=SIGNAL must send the specified signal instead of SIGTERM. Must accept signal names (e.g., KILL, HUP) and numeric signal values."
-      - R2.2: "-k DURATION or --kill-after=DURATION must send SIGKILL if the command is still running DURATION seconds after the initial signal."
-      - R2.3: "--foreground must not create a separate process group, allowing the command to use the terminal."
-      - R2.4: "--preserve-status must exit with the same status as the command, even on timeout, instead of the timeout-specific exit code 124."
+      - R2.1:
+          text: "-s SIGNAL or --signal=SIGNAL must send the specified signal instead of SIGTERM. Must accept signal names (e.g., KILL, HUP) and numeric signal values."
+          weight: 1
+      - R2.2:
+          text: "-k DURATION or --kill-after=DURATION must send SIGKILL if the command is still running DURATION seconds after the initial signal."
+          weight: 1
+      - R2.3:
+          text: "--foreground must not create a separate process group, allowing the command to use the terminal."
+          weight: 1
+      - R2.4:
+          text: "--preserve-status must exit with the same status as the command, even on timeout, instead of the timeout-specific exit code 124."
+          weight: 1
 
   R3:
     title: Exit codes
     items:
-      - R3.1: "When the command exits before the timeout, must exit with the command's exit status."
-      - R3.2: "When the command is killed due to timeout, must exit 124 (unless --preserve-status is given)."
-      - R3.3: "When the command is killed by a signal not sent by timeout, must exit 128+signum."
-      - R3.4: "When the timeout command itself fails (invalid arguments, command not found), must exit 125 for internal error or 126/127 for command execution failure."
+      - R3.1:
+          text: "When the command exits before the timeout, must exit with the command's exit status."
+          weight: 1
+      - R3.2:
+          text: "When the command is killed due to timeout, must exit 124 (unless --preserve-status is given)."
+          weight: 1
+      - R3.3:
+          text: "When the command is killed by a signal not sent by timeout, must exit 128+signum."
+          weight: 1
+      - R3.4:
+          text: "When the timeout command itself fails (invalid arguments, command not found), must exit 125 for internal error or 126/127 for command execution failure."
+          weight: 1
 
   R4:
     title: Differential testing
     items:
-      - R4.1: "Differential tests must compare exit codes between the Go binary and the reference binary via pkg/testutils."
-      - R4.2: "Tests must cover: command completes before timeout (exit with command status), command exceeds timeout (exit 124), duration 0 (no limit), -s with named and numeric signals, -k kill-after escalation, --preserve-status, and error cases (no args, invalid duration, command not found)."
-      - R4.3: "Tests must use fast commands (true, false, sleep 0) and short durations to avoid slow test execution."
-      - R4.4: "Tests must verify that the timed-out process is actually killed and does not remain as an orphan."
+      - R4.1:
+          text: "Differential tests must compare exit codes between the Go binary and the reference binary via pkg/testutils."
+          weight: 1
+      - R4.2:
+          text: "Tests must cover: command completes before timeout (exit with command status), command exceeds timeout (exit 124), duration 0 (no limit), -s with named and numeric signals, -k kill-after escalation, --preserve-status, and error cases (no args, invalid duration, command not found)."
+          weight: 1
+      - R4.3:
+          text: "Tests must use fast commands (true, false, sleep 0) and short durations to avoid slow test execution."
+          weight: 1
+      - R4.4:
+          text: "Tests must verify that the timed-out process is actually killed and does not remain as an orphan."
+          weight: 1
 
 non_goals:
   - cmd/timeout does not implement --verbose or any diagnostic output beyond error messages.

--- a/docs/specs/product-requirements/prd064-shuf.yaml
+++ b/docs/specs/product-requirements/prd064-shuf.yaml
@@ -20,34 +20,66 @@ requirements:
   R1:
     title: Default shuffle behavior
     items:
-      - R1.1: When given one or more FILE arguments, must read all lines from each file, randomly permute them, and write the result to stdout.
-      - R1.2: When no file arguments are given or when "-" is given as a filename, must read from stdin.
-      - R1.3: Must output each input line exactly once in a random order (a permutation, not sampling with replacement) unless -r is given.
-      - R1.4: Must treat each line as terminated by a newline. The last line need not end with a newline, but must be included in the shuffle.
+      - R1.1:
+          text: When given one or more FILE arguments, must read all lines from each file, randomly permute them, and write the result to stdout.
+          weight: 1
+      - R1.2:
+          text: When no file arguments are given or when "-" is given as a filename, must read from stdin.
+          weight: 1
+      - R1.3:
+          text: Must output each input line exactly once in a random order (a permutation, not sampling with replacement) unless -r is given.
+          weight: 1
+      - R1.4:
+          text: Must treat each line as terminated by a newline. The last line need not end with a newline, but must be included in the shuffle.
+          weight: 1
 
   R2:
     title: Range mode and output control
     items:
-      - R2.1: "-i LO-HI or --input-range=LO-HI must generate and shuffle integers from LO to HI inclusive, one per line. Must not be combined with file arguments."
-      - R2.2: "-n COUNT or --head-count=COUNT must output at most COUNT lines."
-      - R2.3: "-r or --repeat must allow output lines to repeat (sampling with replacement). Without -n, runs indefinitely."
-      - R2.4: "-o FILE or --output=FILE must write output to FILE instead of stdout."
+      - R2.1:
+          text: "-i LO-HI or --input-range=LO-HI must generate and shuffle integers from LO to HI inclusive, one per line. Must not be combined with file arguments."
+          weight: 1
+      - R2.2:
+          text: "-n COUNT or --head-count=COUNT must output at most COUNT lines."
+          weight: 1
+      - R2.3:
+          text: "-r or --repeat must allow output lines to repeat (sampling with replacement). Without -n, runs indefinitely."
+          weight: 1
+      - R2.4:
+          text: "-o FILE or --output=FILE must write output to FILE instead of stdout."
+          weight: 1
 
   R3:
     title: Random source and zero-delimiter
     items:
-      - R3.1: "--random-source=FILE must read random bytes from FILE instead of the system random source."
-      - R3.2: "-z or --zero-terminated must use NUL (\\0) as the line delimiter instead of newline, for both input and output."
-      - R3.3: "-e or --echo must treat each ARG as an input line instead of reading from files."
-      - R3.4: Must handle empty input (zero lines) by producing no output and exiting 0.
+      - R3.1:
+          text: "--random-source=FILE must read random bytes from FILE instead of the system random source."
+          weight: 1
+      - R3.2:
+          text: "-z or --zero-terminated must use NUL (\\0) as the line delimiter instead of newline, for both input and output."
+          weight: 1
+      - R3.3:
+          text: "-e or --echo must treat each ARG as an input line instead of reading from files."
+          weight: 1
+      - R3.4:
+          text: Must handle empty input (zero lines) by producing no output and exiting 0.
+          weight: 1
 
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: Must exit 0 on successful operation.
-      - R4.2: Must exit 1 on error (invalid range, conflicting options, write error).
-      - R4.3: "Differential tests must verify structural properties rather than exact output: correct line count, values within range for -i, no duplicates without -r, duplicates allowed with -r."
-      - R4.4: "Tests must cover: shuffle stdin lines, shuffle file lines, -i range mode, -n head count, -r repeat mode, -e echo mode, -z zero-terminated, empty input, and error cases (invalid range, -i with files)."
+      - R4.1:
+          text: Must exit 0 on successful operation.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 on error (invalid range, conflicting options, write error).
+          weight: 1
+      - R4.3:
+          text: "Differential tests must verify structural properties rather than exact output: correct line count, values within range for -i, no duplicates without -r, duplicates allowed with -r."
+          weight: 1
+      - R4.4:
+          text: "Tests must cover: shuffle stdin lines, shuffle file lines, -i range mode, -n head count, -r repeat mode, -e echo mode, -z zero-terminated, empty input, and error cases (invalid range, -i with files)."
+          weight: 1
 
 non_goals:
   - cmd/shuf does not guarantee a specific PRNG algorithm or reproducible output for a given random seed.

--- a/docs/specs/product-requirements/prd065-factor.yaml
+++ b/docs/specs/product-requirements/prd065-factor.yaml
@@ -18,34 +18,66 @@ requirements:
   R1:
     title: Core factorization behavior
     items:
-      - R1.1: "For each integer argument, must print a line in the format 'NUMBER: FACTOR FACTOR ...' where factors are in ascending order with repetition for multiplicity (e.g., '12: 2 2 3')."
-      - R1.2: "For the number 1, must print '1:' with no factors."
-      - R1.3: Must handle prime numbers by printing the number itself as the sole factor.
-      - R1.4: Must process multiple arguments in order, printing one factorization line per argument.
+      - R1.1:
+          text: "For each integer argument, must print a line in the format 'NUMBER: FACTOR FACTOR ...' where factors are in ascending order with repetition for multiplicity (e.g., '12: 2 2 3')."
+          weight: 1
+      - R1.2:
+          text: "For the number 1, must print '1:' with no factors."
+          weight: 1
+      - R1.3:
+          text: Must handle prime numbers by printing the number itself as the sole factor.
+          weight: 1
+      - R1.4:
+          text: Must process multiple arguments in order, printing one factorization line per argument.
+          weight: 1
 
   R2:
     title: Stdin mode and input handling
     items:
-      - R2.1: When no arguments are given, must read integers from stdin, one per line, and factorize each.
-      - R2.2: Must accept integers up to at least 2^63-1 (the Go int64 maximum).
-      - R2.3: Must skip blank lines in stdin mode without producing output or error.
-      - R2.4: When a non-integer or negative input is encountered, must print an error to stderr and continue processing remaining inputs.
+      - R2.1:
+          text: When no arguments are given, must read integers from stdin, one per line, and factorize each.
+          weight: 1
+      - R2.2:
+          text: Must accept integers up to at least 2^63-1 (the Go int64 maximum).
+          weight: 1
+      - R2.3:
+          text: Must skip blank lines in stdin mode without producing output or error.
+          weight: 1
+      - R2.4:
+          text: When a non-integer or negative input is encountered, must print an error to stderr and continue processing remaining inputs.
+          weight: 1
 
   R3:
     title: Help, version, and output
     items:
-      - R3.1: When --help is the first argument, must print a usage message to stdout and exit 0.
-      - R3.2: When --version is the first argument, must print version information to stdout and exit 0.
-      - R3.3: Must write factorization output to stdout, one line per integer.
-      - R3.4: Must write error messages to stderr without stopping processing of remaining inputs.
+      - R3.1:
+          text: When --help is the first argument, must print a usage message to stdout and exit 0.
+          weight: 1
+      - R3.2:
+          text: When --version is the first argument, must print version information to stdout and exit 0.
+          weight: 1
+      - R3.3:
+          text: Must write factorization output to stdout, one line per integer.
+          weight: 1
+      - R3.4:
+          text: Must write error messages to stderr without stopping processing of remaining inputs.
+          weight: 1
 
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: Must exit 0 when all inputs are valid and factorized successfully.
-      - R4.2: Must exit 1 when any input is invalid (non-integer, negative, overflow).
-      - R4.3: "Differential tests must compare stdout and exit codes between the Go binary and the reference binary via pkg/testutils."
-      - R4.4: "Tests must cover: single number, multiple numbers, primes, composites, 1, large numbers, stdin mode, error on non-integer, and error on negative number."
+      - R4.1:
+          text: Must exit 0 when all inputs are valid and factorized successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any input is invalid (non-integer, negative, overflow).
+          weight: 1
+      - R4.3:
+          text: "Differential tests must compare stdout and exit codes between the Go binary and the reference binary via pkg/testutils."
+          weight: 1
+      - R4.4:
+          text: "Tests must cover: single number, multiple numbers, primes, composites, 1, large numbers, stdin mode, error on non-integer, and error on negative number."
+          weight: 1
 
 non_goals:
   - cmd/factor does not implement arbitrary-precision factorization beyond int64 range.

--- a/docs/specs/product-requirements/prd066-expr.yaml
+++ b/docs/specs/product-requirements/prd066-expr.yaml
@@ -17,34 +17,66 @@ requirements:
   R1:
     title: Arithmetic and comparison operators
     items:
-      - R1.1: "Must support integer arithmetic operators: + (add), - (subtract), * (multiply), / (integer divide), % (modulo). Each operator and operand is a separate argument."
-      - R1.2: "Must support comparison operators: < (less), <= (less-equal), = (equal), != (not-equal), >= (greater-equal), > (greater). Comparisons on two integers use numeric comparison; otherwise use lexicographic comparison. Must return 1 for true and 0 for false."
-      - R1.3: "Must support logical operators: | (or) returns the first argument if it is nonzero/non-empty, else the second; & (and) returns the first argument if both are nonzero/non-empty, else 0."
-      - R1.4: "Must support parentheses for grouping: ( and ) override default precedence. Parentheses are separate arguments."
+      - R1.1:
+          text: "Must support integer arithmetic operators: + (add), - (subtract), * (multiply), / (integer divide), % (modulo). Each operator and operand is a separate argument."
+          weight: 1
+      - R1.2:
+          text: "Must support comparison operators: < (less), <= (less-equal), = (equal), != (not-equal), >= (greater-equal), > (greater). Comparisons on two integers use numeric comparison; otherwise use lexicographic comparison. Must return 1 for true and 0 for false."
+          weight: 1
+      - R1.3:
+          text: "Must support logical operators: | (or) returns the first argument if it is nonzero/non-empty, else the second; & (and) returns the first argument if both are nonzero/non-empty, else 0."
+          weight: 1
+      - R1.4:
+          text: "Must support parentheses for grouping: ( and ) override default precedence. Parentheses are separate arguments."
+          weight: 1
 
   R2:
     title: String operations
     items:
-      - R2.1: "match STRING REGEXP or STRING : REGEXP must anchor the pattern at the beginning of STRING and return the matched substring if the pattern contains \\( \\), or the number of matched characters otherwise."
-      - R2.2: "substr STRING POS LENGTH must return a substring of STRING starting at position POS (1-based) with length LENGTH."
-      - R2.3: "index STRING CHARS must return the position (1-based) of the first character in STRING that is also in CHARS, or 0 if none."
-      - R2.4: "length STRING must return the number of characters in STRING."
+      - R2.1:
+          text: "match STRING REGEXP or STRING : REGEXP must anchor the pattern at the beginning of STRING and return the matched substring if the pattern contains \\( \\), or the number of matched characters otherwise."
+          weight: 1
+      - R2.2:
+          text: "substr STRING POS LENGTH must return a substring of STRING starting at position POS (1-based) with length LENGTH."
+          weight: 1
+      - R2.3:
+          text: "index STRING CHARS must return the position (1-based) of the first character in STRING that is also in CHARS, or 0 if none."
+          weight: 1
+      - R2.4:
+          text: "length STRING must return the number of characters in STRING."
+          weight: 1
 
   R3:
     title: Special tokens and precedence
     items:
-      - R3.1: "+ TOKEN must interpret TOKEN as a string even if it is a keyword (match, substr, index, length) or operator. The + is consumed and not part of the value."
-      - R3.2: "Operator precedence from lowest to highest: | , & , comparisons (< <= = != >= >), + - (arithmetic), * / %."
-      - R3.3: "All binary operators are left-associative."
-      - R3.4: "Division by zero must print an error to stderr and exit 2."
+      - R3.1:
+          text: "+ TOKEN must interpret TOKEN as a string even if it is a keyword (match, substr, index, length) or operator. The + is consumed and not part of the value."
+          weight: 1
+      - R3.2:
+          text: "Operator precedence from lowest to highest: | , & , comparisons (< <= = != >= >), + - (arithmetic), * / %."
+          weight: 1
+      - R3.3:
+          text: "All binary operators are left-associative."
+          weight: 1
+      - R3.4:
+          text: "Division by zero must print an error to stderr and exit 2."
+          weight: 1
 
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: "Must exit 0 when the expression evaluates to a non-null, non-zero value."
-      - R4.2: "Must exit 1 when the expression evaluates to null or 0."
-      - R4.3: "Must exit 2 on syntax error (invalid expression, missing operand, division by zero). Must exit 3 on internal error."
-      - R4.4: "Differential tests must compare stdout, stderr emptiness, and exit codes between the Go binary and the reference binary via pkg/testutils. Tests must cover: integer arithmetic (all operators), comparisons (numeric and string), logical operators, string operations (match, substr, index, length), parentheses, + escaping, division by zero, and missing operand errors."
+      - R4.1:
+          text: "Must exit 0 when the expression evaluates to a non-null, non-zero value."
+          weight: 1
+      - R4.2:
+          text: "Must exit 1 when the expression evaluates to null or 0."
+          weight: 1
+      - R4.3:
+          text: "Must exit 2 on syntax error (invalid expression, missing operand, division by zero). Must exit 3 on internal error."
+          weight: 1
+      - R4.4:
+          text: "Differential tests must compare stdout, stderr emptiness, and exit codes between the Go binary and the reference binary via pkg/testutils. Tests must cover: integer arithmetic (all operators), comparisons (numeric and string), logical operators, string operations (match, substr, index, length), parentheses, + escaping, division by zero, and missing operand errors."
+          weight: 1
 
 non_goals:
   - cmd/expr does not implement GNU expr's --help and --version when they appear as the sole argument and could be confused with an expression operand.

--- a/docs/specs/product-requirements/prd067-split.yaml
+++ b/docs/specs/product-requirements/prd067-split.yaml
@@ -19,34 +19,66 @@ requirements:
   R1:
     title: Default behavior and line-based splitting
     items:
-      - R1.1: When invoked with no options, must split the input into pieces of 1000 lines each, writing to files named xaa, xab, xac, etc.
-      - R1.2: "When a PREFIX argument is given, must use PREFIX instead of 'x' as the output filename prefix."
-      - R1.3: "-l N or --lines=N must split the input into pieces of N lines each."
-      - R1.4: When reading from stdin or when FILE is "-", must read from stdin.
+      - R1.1:
+          text: When invoked with no options, must split the input into pieces of 1000 lines each, writing to files named xaa, xab, xac, etc.
+          weight: 1
+      - R1.2:
+          text: "When a PREFIX argument is given, must use PREFIX instead of 'x' as the output filename prefix."
+          weight: 1
+      - R1.3:
+          text: "-l N or --lines=N must split the input into pieces of N lines each."
+          weight: 1
+      - R1.4:
+          text: When reading from stdin or when FILE is "-", must read from stdin.
+          weight: 1
 
   R2:
     title: Byte-based and chunk-based splitting
     items:
-      - R2.1: "-b N or --bytes=N must split the input into pieces of N bytes each. N may have a suffix (K, M, G, T, P, E, Z, Y for powers of 1024, or KB, MB, etc. for powers of 1000)."
-      - R2.2: "-C N or --line-bytes=N must split the input into pieces of at most N bytes each, breaking only at line boundaries. Lines longer than N bytes are written to their own piece."
-      - R2.3: "-n CHUNKS or --number=CHUNKS must split the input into CHUNKS pieces of roughly equal size. Must support N (by bytes), l/N (by lines), and r/N (round-robin by lines) forms."
-      - R2.4: "Must not split in more than one mode simultaneously; conflicting split options must produce an error and exit 1."
+      - R2.1:
+          text: "-b N or --bytes=N must split the input into pieces of N bytes each. N may have a suffix (K, M, G, T, P, E, Z, Y for powers of 1024, or KB, MB, etc. for powers of 1000)."
+          weight: 1
+      - R2.2:
+          text: "-C N or --line-bytes=N must split the input into pieces of at most N bytes each, breaking only at line boundaries. Lines longer than N bytes are written to their own piece."
+          weight: 1
+      - R2.3:
+          text: "-n CHUNKS or --number=CHUNKS must split the input into CHUNKS pieces of roughly equal size. Must support N (by bytes), l/N (by lines), and r/N (round-robin by lines) forms."
+          weight: 1
+      - R2.4:
+          text: "Must not split in more than one mode simultaneously; conflicting split options must produce an error and exit 1."
+          weight: 1
 
   R3:
     title: Suffix control and additional options
     items:
-      - R3.1: "-a N or --suffix-length=N must use suffixes of length N (default 2)."
-      - R3.2: "-d or --numeric-suffixes must use numeric suffixes (00, 01, 02, ...) instead of alphabetic."
-      - R3.3: "--additional-suffix=SUFFIX must append SUFFIX to each output filename after the alphabetic or numeric suffix."
-      - R3.4: "--filter=COMMAND must write each piece to the given shell COMMAND via a pipe, with the output filename available as $FILE in the command."
+      - R3.1:
+          text: "-a N or --suffix-length=N must use suffixes of length N (default 2)."
+          weight: 1
+      - R3.2:
+          text: "-d or --numeric-suffixes must use numeric suffixes (00, 01, 02, ...) instead of alphabetic."
+          weight: 1
+      - R3.3:
+          text: "--additional-suffix=SUFFIX must append SUFFIX to each output filename after the alphabetic or numeric suffix."
+          weight: 1
+      - R3.4:
+          text: "--filter=COMMAND must write each piece to the given shell COMMAND via a pipe, with the output filename available as $FILE in the command."
+          weight: 1
 
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: Must exit 0 when the input is split successfully.
-      - R4.2: Must exit 1 when an invalid option, conflicting options, or write error occurs.
-      - R4.3: "Differential tests must compare output file contents and exit codes between the Go binary and the reference binary via pkg/testutils."
-      - R4.4: "Tests must cover: default 1000-line split, -l with custom line count, -b byte split with and without suffixes, -C line-bytes, -n chunk modes, -a suffix length, -d numeric suffixes, --additional-suffix, stdin input, custom prefix, and error cases (conflicting options, invalid counts)."
+      - R4.1:
+          text: Must exit 0 when the input is split successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when an invalid option, conflicting options, or write error occurs.
+          weight: 1
+      - R4.3:
+          text: "Differential tests must compare output file contents and exit codes between the Go binary and the reference binary via pkg/testutils."
+          weight: 1
+      - R4.4:
+          text: "Tests must cover: default 1000-line split, -l with custom line count, -b byte split with and without suffixes, -C line-bytes, -n chunk modes, -a suffix length, -d numeric suffixes, --additional-suffix, stdin input, custom prefix, and error cases (conflicting options, invalid counts)."
+          weight: 1
 
 non_goals:
   - cmd/split does not implement --verbose output mode.

--- a/docs/specs/product-requirements/prd068-csplit.yaml
+++ b/docs/specs/product-requirements/prd068-csplit.yaml
@@ -19,34 +19,66 @@ requirements:
   R1:
     title: Pattern-based splitting
     items:
-      - R1.1: "Must accept one or more PATTERN arguments. Each pattern is applied in order to split the input at the matching boundary."
-      - R1.2: "/REGEXP/ must split at the next line matching REGEXP. The matching line becomes the first line of the next piece."
-      - R1.3: "%REGEXP% must skip to the next line matching REGEXP without creating an output file for the skipped content."
-      - R1.4: "INTEGER must split at the given line number. The specified line becomes the first line of the next piece."
+      - R1.1:
+          text: "Must accept one or more PATTERN arguments. Each pattern is applied in order to split the input at the matching boundary."
+          weight: 1
+      - R1.2:
+          text: "/REGEXP/ must split at the next line matching REGEXP. The matching line becomes the first line of the next piece."
+          weight: 1
+      - R1.3:
+          text: "%REGEXP% must skip to the next line matching REGEXP without creating an output file for the skipped content."
+          weight: 1
+      - R1.4:
+          text: "INTEGER must split at the given line number. The specified line becomes the first line of the next piece."
+          weight: 1
 
   R2:
     title: Repeat counts and offset
     items:
-      - R2.1: "{N} appended to a pattern must repeat that pattern N additional times (total N+1 applications)."
-      - R2.2: "{*} appended to a pattern must repeat that pattern as many times as possible until end of input."
-      - R2.3: "/REGEXP/+N and /REGEXP/-N must split N lines after or before the matching line, respectively."
-      - R2.4: When a pattern does not match, must print an error to stderr. With --suppress-matched this is not an error if at least one split occurred.
+      - R2.1:
+          text: "{N} appended to a pattern must repeat that pattern N additional times (total N+1 applications)."
+          weight: 1
+      - R2.2:
+          text: "{*} appended to a pattern must repeat that pattern as many times as possible until end of input."
+          weight: 1
+      - R2.3:
+          text: "/REGEXP/+N and /REGEXP/-N must split N lines after or before the matching line, respectively."
+          weight: 1
+      - R2.4:
+          text: When a pattern does not match, must print an error to stderr. With --suppress-matched this is not an error if at least one split occurred.
+          weight: 1
 
   R3:
     title: Output control and prefix options
     items:
-      - R3.1: "Must write output files named xx00, xx01, xx02, etc. by default."
-      - R3.2: "-f PREFIX or --prefix=PREFIX must use PREFIX instead of 'xx' for output filenames."
-      - R3.3: "-n DIGITS or --digits=DIGITS must use DIGITS-wide numeric suffixes (default 2)."
-      - R3.4: "-z or --elide-empty-files must suppress creation of empty output files."
+      - R3.1:
+          text: "Must write output files named xx00, xx01, xx02, etc. by default."
+          weight: 1
+      - R3.2:
+          text: "-f PREFIX or --prefix=PREFIX must use PREFIX instead of 'xx' for output filenames."
+          weight: 1
+      - R3.3:
+          text: "-n DIGITS or --digits=DIGITS must use DIGITS-wide numeric suffixes (default 2)."
+          weight: 1
+      - R3.4:
+          text: "-z or --elide-empty-files must suppress creation of empty output files."
+          weight: 1
 
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: Must exit 0 when the input is split successfully.
-      - R4.2: Must exit 1 when a pattern fails to match (unless suppressed) or an invalid option is given.
-      - R4.3: "Differential tests must compare output file contents and exit codes between the Go binary and the reference binary via pkg/testutils."
-      - R4.4: "Tests must cover: regex split, line number split, skip patterns (%), repeat counts ({N} and {*}), offset (+N/-N), -f custom prefix, -n digit width, -z elide empty, stdin input, and error cases (no match, invalid regex)."
+      - R4.1:
+          text: Must exit 0 when the input is split successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when a pattern fails to match (unless suppressed) or an invalid option is given.
+          weight: 1
+      - R4.3:
+          text: "Differential tests must compare output file contents and exit codes between the Go binary and the reference binary via pkg/testutils."
+          weight: 1
+      - R4.4:
+          text: "Tests must cover: regex split, line number split, skip patterns (%), repeat counts ({N} and {*}), offset (+N/-N), -f custom prefix, -n digit width, -z elide empty, stdin input, and error cases (no match, invalid regex)."
+          weight: 1
 
 non_goals:
   - cmd/csplit does not implement --suppress-matched beyond the basic behavior.

--- a/docs/specs/product-requirements/prd069-join.yaml
+++ b/docs/specs/product-requirements/prd069-join.yaml
@@ -20,34 +20,66 @@ requirements:
   R1:
     title: Default join behavior
     items:
-      - R1.1: "Must read two sorted files and join lines where the join field (default: first field) matches. Must print one output line per matching pair."
-      - R1.2: "Fields in each line are separated by whitespace (runs of blanks and tabs) by default. The output separator is a single space by default."
-      - R1.3: "Lines that do not pair (present in one file but not the other) are suppressed by default."
-      - R1.4: "When one of the file arguments is '-', must read that file from stdin."
+      - R1.1:
+          text: "Must read two sorted files and join lines where the join field (default: first field) matches. Must print one output line per matching pair."
+          weight: 1
+      - R1.2:
+          text: "Fields in each line are separated by whitespace (runs of blanks and tabs) by default. The output separator is a single space by default."
+          weight: 1
+      - R1.3:
+          text: "Lines that do not pair (present in one file but not the other) are suppressed by default."
+          weight: 1
+      - R1.4:
+          text: "When one of the file arguments is '-', must read that file from stdin."
+          weight: 1
 
   R2:
     title: Field selection and output format
     items:
-      - R2.1: "-1 FIELD must join on field FIELD of file 1 (fields are numbered from 1). -2 FIELD must join on field FIELD of file 2."
-      - R2.2: "-j FIELD must set the join field for both files simultaneously."
-      - R2.3: "-o FORMAT must select and order output fields. FORMAT is a comma-separated or space-separated list of FILENUM.FIELDNUM specifiers (e.g., 1.2,2.1) or '0' for the join field."
-      - R2.4: "-t CHAR must use CHAR as both the input and output field separator."
+      - R2.1:
+          text: "-1 FIELD must join on field FIELD of file 1 (fields are numbered from 1). -2 FIELD must join on field FIELD of file 2."
+          weight: 1
+      - R2.2:
+          text: "-j FIELD must set the join field for both files simultaneously."
+          weight: 1
+      - R2.3:
+          text: "-o FORMAT must select and order output fields. FORMAT is a comma-separated or space-separated list of FILENUM.FIELDNUM specifiers (e.g., 1.2,2.1) or '0' for the join field."
+          weight: 1
+      - R2.4:
+          text: "-t CHAR must use CHAR as both the input and output field separator."
+          weight: 1
 
   R3:
     title: Unpairable lines and header mode
     items:
-      - R3.1: "-a FILENUM must also print unpairable lines from file FILENUM (1 or 2). May be specified twice (-a 1 -a 2) to print unpairable lines from both files."
-      - R3.2: "-v FILENUM must print only unpairable lines from file FILENUM, suppressing paired lines."
-      - R3.3: "-e STRING must replace missing input fields with STRING in the output."
-      - R3.4: "--header must treat the first line of each input file as a header line, joining them regardless of sort order and printing the result before data lines."
+      - R3.1:
+          text: "-a FILENUM must also print unpairable lines from file FILENUM (1 or 2). May be specified twice (-a 1 -a 2) to print unpairable lines from both files."
+          weight: 1
+      - R3.2:
+          text: "-v FILENUM must print only unpairable lines from file FILENUM, suppressing paired lines."
+          weight: 1
+      - R3.3:
+          text: "-e STRING must replace missing input fields with STRING in the output."
+          weight: 1
+      - R3.4:
+          text: "--header must treat the first line of each input file as a header line, joining them regardless of sort order and printing the result before data lines."
+          weight: 1
 
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: Must exit 0 when the join completes successfully.
-      - R4.2: Must exit 1 when an invalid option is given or a file cannot be opened.
-      - R4.3: "Differential tests must compare stdout and exit codes between the Go binary and the reference binary via pkg/testutils. Tests must use LC_ALL=C for deterministic collation."
-      - R4.4: "Tests must cover: default join on first field, -1/-2 field selection, -j combined field, -t custom separator, -o output format, -a unpairable lines, -v unpairable only, -e empty replacement, --header, stdin as one input, and error cases (unsorted input with --check-order, missing file)."
+      - R4.1:
+          text: Must exit 0 when the join completes successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when an invalid option is given or a file cannot be opened.
+          weight: 1
+      - R4.3:
+          text: "Differential tests must compare stdout and exit codes between the Go binary and the reference binary via pkg/testutils. Tests must use LC_ALL=C for deterministic collation."
+          weight: 1
+      - R4.4:
+          text: "Tests must cover: default join on first field, -1/-2 field selection, -j combined field, -t custom separator, -o output format, -a unpairable lines, -v unpairable only, -e empty replacement, --header, stdin as one input, and error cases (unsorted input with --check-order, missing file)."
+          weight: 1
 
 non_goals:
   - cmd/join does not implement locale-aware collation beyond LC_ALL=C behavior.

--- a/docs/specs/product-requirements/prd070-fmt.yaml
+++ b/docs/specs/product-requirements/prd070-fmt.yaml
@@ -18,18 +18,34 @@ requirements:
   R1:
     title: Default formatting behavior
     items:
-      - R1.1: When invoked with no options, must reformat each paragraph of input text to fit within 75 characters (the GNU default width).
-      - R1.2: Must treat blank lines as paragraph separators. Must not merge text across blank lines.
-      - R1.3: Must preserve the indentation of the first line of each paragraph. Subsequent lines in the same paragraph are filled to match the second line's indentation (or the first if only one line).
-      - R1.4: When given one or more FILE arguments, must read and format each file in order. When no file is given or "-" is given, must read from stdin.
+      - R1.1:
+          text: When invoked with no options, must reformat each paragraph of input text to fit within 75 characters (the GNU default width).
+          weight: 1
+      - R1.2:
+          text: Must treat blank lines as paragraph separators. Must not merge text across blank lines.
+          weight: 1
+      - R1.3:
+          text: Must preserve the indentation of the first line of each paragraph. Subsequent lines in the same paragraph are filled to match the second line's indentation (or the first if only one line).
+          weight: 1
+      - R1.4:
+          text: When given one or more FILE arguments, must read and format each file in order. When no file is given or "-" is given, must read from stdin.
+          weight: 1
 
   R2:
     title: Width control and goal width
     items:
-      - R2.1: "-w WIDTH or --width=WIDTH must set the maximum line width (default 75)."
-      - R2.2: "-g GOAL or --goal=GOAL must set the goal line width. Lines are filled to approximately GOAL characters. Default goal is 93% of width."
-      - R2.3: Must break lines at word boundaries (spaces). Must not break in the middle of a word unless the word exceeds the maximum width.
-      - R2.4: Must collapse multiple spaces between words to a single space, except after sentence-ending punctuation (. ! ?) where two spaces are preserved.
+      - R2.1:
+          text: "-w WIDTH or --width=WIDTH must set the maximum line width (default 75)."
+          weight: 1
+      - R2.2:
+          text: "-g GOAL or --goal=GOAL must set the goal line width. Lines are filled to approximately GOAL characters. Default goal is 93% of width."
+          weight: 1
+      - R2.3:
+          text: Must break lines at word boundaries (spaces). Must not break in the middle of a word unless the word exceeds the maximum width.
+          weight: 1
+      - R2.4:
+          text: Must collapse multiple spaces between words to a single space, except after sentence-ending punctuation (. ! ?) where two spaces are preserved.
+          weight: 1
 
   # R3 (formatting options: -s, -u, -p, -t) deferred to release 99.0.
   # Timed out at 15 minutes in run 37. See GH-2938.
@@ -37,10 +53,18 @@ requirements:
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: Must exit 0 when formatting completes successfully.
-      - R4.2: Must exit 1 when an invalid option is given or a file cannot be opened.
-      - R4.3: "Differential tests must compare stdout and exit codes between the Go binary and the reference binary via pkg/testutils."
-      - R4.4: "Tests must cover: default 75-char formatting, -w custom width, -g goal width, -s split-only, -u uniform spacing, -p prefix mode, -t tagged paragraph, multi-file input, stdin input, blank line paragraph boundaries, indentation preservation, and error cases (invalid width, missing file)."
+      - R4.1:
+          text: Must exit 0 when formatting completes successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when an invalid option is given or a file cannot be opened.
+          weight: 1
+      - R4.3:
+          text: "Differential tests must compare stdout and exit codes between the Go binary and the reference binary via pkg/testutils."
+          weight: 1
+      - R4.4:
+          text: "Tests must cover: default 75-char formatting, -w custom width, -g goal width, -s split-only, -u uniform spacing, -p prefix mode, -t tagged paragraph, multi-file input, stdin input, blank line paragraph boundaries, indentation preservation, and error cases (invalid width, missing file)."
+          weight: 1
 
 non_goals:
   - cmd/fmt does not implement crown margin mode (-c) beyond the default indentation behavior.

--- a/docs/specs/product-requirements/prd071-numfmt.yaml
+++ b/docs/specs/product-requirements/prd071-numfmt.yaml
@@ -20,34 +20,66 @@ requirements:
   R1:
     title: Default behavior and output conversion
     items:
-      - R1.1: "When given --to=UNIT, must convert each input number to a human-readable string with the appropriate suffix. UNIT is one of: si (powers of 1000), iec (powers of 1024), iec-i (powers of 1024 with 'i' suffix), or none."
-      - R1.2: "When given --from=UNIT, must interpret each input number as a human-readable string with suffixes and convert to a raw number. UNIT values are the same as --to."
-      - R1.3: When neither --from nor --to is given, must pass numbers through unchanged.
-      - R1.4: Must read numbers from stdin (one per line) when no operands are given, or process command-line operands directly.
+      - R1.1:
+          text: "When given --to=UNIT, must convert each input number to a human-readable string with the appropriate suffix. UNIT is one of: si (powers of 1000), iec (powers of 1024), iec-i (powers of 1024 with 'i' suffix), or none."
+          weight: 1
+      - R1.2:
+          text: "When given --from=UNIT, must interpret each input number as a human-readable string with suffixes and convert to a raw number. UNIT values are the same as --to."
+          weight: 1
+      - R1.3:
+          text: When neither --from nor --to is given, must pass numbers through unchanged.
+          weight: 1
+      - R1.4:
+          text: Must read numbers from stdin (one per line) when no operands are given, or process command-line operands directly.
+          weight: 1
 
   R2:
     title: Format control
     items:
-      - R2.1: "--format=FORMAT must use a printf-style format string for output (e.g., '%10f', '%.2f'). Must support width, precision, and left-alignment."
-      - R2.2: "--padding=N must pad the output to N characters. Positive N right-aligns; negative N left-aligns."
-      - R2.3: "--round=METHOD must control rounding: up (ceiling), down (floor), from-zero (away from zero), towards-zero (truncation), or nearest (default)."
-      - R2.4: "--suffix=SUFFIX must append SUFFIX to the output after the numeric value and any unit suffix."
+      - R2.1:
+          text: "--format=FORMAT must use a printf-style format string for output (e.g., '%10f', '%.2f'). Must support width, precision, and left-alignment."
+          weight: 1
+      - R2.2:
+          text: "--padding=N must pad the output to N characters. Positive N right-aligns; negative N left-aligns."
+          weight: 1
+      - R2.3:
+          text: "--round=METHOD must control rounding: up (ceiling), down (floor), from-zero (away from zero), towards-zero (truncation), or nearest (default)."
+          weight: 1
+      - R2.4:
+          text: "--suffix=SUFFIX must append SUFFIX to the output after the numeric value and any unit suffix."
+          weight: 1
 
   R3:
     title: Field selection and header
     items:
-      - R3.1: "--field=FIELDS must convert only the specified fields (1-indexed, comma-separated ranges like cut). Other fields are passed through unchanged."
-      - R3.2: "-d DELIM or --delimiter=DELIM must use DELIM as the field delimiter for --field processing."
-      - R3.3: "--header[=N] must pass through the first N lines (default 1) without conversion, treating them as headers."
-      - R3.4: "--to-unit=N must scale the output by dividing by N before applying --to conversion. --from-unit=N must scale the input by multiplying by N before applying --from conversion."
+      - R3.1:
+          text: "--field=FIELDS must convert only the specified fields (1-indexed, comma-separated ranges like cut). Other fields are passed through unchanged."
+          weight: 1
+      - R3.2:
+          text: "-d DELIM or --delimiter=DELIM must use DELIM as the field delimiter for --field processing."
+          weight: 1
+      - R3.3:
+          text: "--header[=N] must pass through the first N lines (default 1) without conversion, treating them as headers."
+          weight: 1
+      - R3.4:
+          text: "--to-unit=N must scale the output by dividing by N before applying --to conversion. --from-unit=N must scale the input by multiplying by N before applying --from conversion."
+          weight: 1
 
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: Must exit 0 when all conversions complete successfully.
-      - R4.2: Must exit 2 when an invalid number is encountered (unless --invalid=ignore or --invalid=warn is set).
-      - R4.3: "Differential tests must compare stdout and exit codes between the Go binary and the reference binary via pkg/testutils."
-      - R4.4: "Tests must cover: --to si/iec/iec-i, --from si/iec, --format with width and precision, --padding, --round modes, --suffix, --field selection, --delimiter, --header, --to-unit/--from-unit, stdin and operand input, and error cases (invalid number, unknown suffix)."
+      - R4.1:
+          text: Must exit 0 when all conversions complete successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 2 when an invalid number is encountered (unless --invalid=ignore or --invalid=warn is set).
+          weight: 1
+      - R4.3:
+          text: "Differential tests must compare stdout and exit codes between the Go binary and the reference binary via pkg/testutils."
+          weight: 1
+      - R4.4:
+          text: "Tests must cover: --to si/iec/iec-i, --from si/iec, --format with width and precision, --padding, --round modes, --suffix, --field selection, --delimiter, --header, --to-unit/--from-unit, stdin and operand input, and error cases (invalid number, unknown suffix)."
+          weight: 1
 
 non_goals:
   - cmd/numfmt does not implement locale-aware digit grouping (e.g., thousands separators).

--- a/docs/specs/product-requirements/prd072-od.yaml
+++ b/docs/specs/product-requirements/prd072-od.yaml
@@ -18,34 +18,66 @@ requirements:
   R1:
     title: Default behavior and type specifiers
     items:
-      - R1.1: "When invoked with no type options, must display input in the default format: octal 2-byte words (equivalent to -t o2), with an octal address offset in the left column."
-      - R1.2: "-t TYPE or --format=TYPE must display input in the given format. TYPE consists of a format letter (a for named characters, c for C-style characters, d for signed decimal, f for floating point, o for octal, u for unsigned decimal, x for hexadecimal) optionally followed by a size in bytes."
-      - R1.3: Multiple -t options may be given; each produces an additional line of output per input block.
-      - R1.4: Must read from FILE arguments in order, or from stdin when no file is given or "-" is specified.
+      - R1.1:
+          text: "When invoked with no type options, must display input in the default format: octal 2-byte words (equivalent to -t o2), with an octal address offset in the left column."
+          weight: 1
+      - R1.2:
+          text: "-t TYPE or --format=TYPE must display input in the given format. TYPE consists of a format letter (a for named characters, c for C-style characters, d for signed decimal, f for floating point, o for octal, u for unsigned decimal, x for hexadecimal) optionally followed by a size in bytes."
+          weight: 1
+      - R1.3:
+          text: Multiple -t options may be given; each produces an additional line of output per input block.
+          weight: 1
+      - R1.4:
+          text: Must read from FILE arguments in order, or from stdin when no file is given or "-" is specified.
+          weight: 1
 
   R2:
     title: Address format and byte range
     items:
-      - R2.1: "-A RADIX or --address-radix=RADIX must set the address offset format. RADIX is d (decimal), o (octal), x (hexadecimal), or n (no addresses)."
-      - R2.2: "-j BYTES or --skip-bytes=BYTES must skip BYTES input bytes before formatting. BYTES may have a multiplier suffix (b for 512, k for 1024, m for 1048576)."
-      - R2.3: "-N BYTES or --read-bytes=BYTES must format at most BYTES input bytes."
-      - R2.4: "Must display a final line containing only the address of the byte past the last byte read (the file size offset)."
+      - R2.1:
+          text: "-A RADIX or --address-radix=RADIX must set the address offset format. RADIX is d (decimal), o (octal), x (hexadecimal), or n (no addresses)."
+          weight: 1
+      - R2.2:
+          text: "-j BYTES or --skip-bytes=BYTES must skip BYTES input bytes before formatting. BYTES may have a multiplier suffix (b for 512, k for 1024, m for 1048576)."
+          weight: 1
+      - R2.3:
+          text: "-N BYTES or --read-bytes=BYTES must format at most BYTES input bytes."
+          weight: 1
+      - R2.4:
+          text: "Must display a final line containing only the address of the byte past the last byte read (the file size offset)."
+          weight: 1
 
   R3:
     title: Output width and traditional options
     items:
-      - R3.1: "-w[N] or --width[=N] must set the number of input bytes per output line (default 16). When -w is given without a value, must use 32."
-      - R3.2: Must support traditional short options as aliases for type specifiers. -b is equivalent to -t o1, -c is -t c, -d is -t u2, -o is -t o2, -s is -t d2, -x is -t x2.
-      - R3.3: "Duplicate bytes in multi-line output must be replaced with '*' on a line by itself to indicate repetition, matching GNU od behavior."
-      - R3.4: "-v or --output-duplicates must print all input data, disabling the '*' duplicate suppression."
+      - R3.1:
+          text: "-w[N] or --width[=N] must set the number of input bytes per output line (default 16). When -w is given without a value, must use 32."
+          weight: 1
+      - R3.2:
+          text: Must support traditional short options as aliases for type specifiers. -b is equivalent to -t o1, -c is -t c, -d is -t u2, -o is -t o2, -s is -t d2, -x is -t x2.
+          weight: 1
+      - R3.3:
+          text: "Duplicate bytes in multi-line output must be replaced with '*' on a line by itself to indicate repetition, matching GNU od behavior."
+          weight: 1
+      - R3.4:
+          text: "-v or --output-duplicates must print all input data, disabling the '*' duplicate suppression."
+          weight: 1
 
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: Must exit 0 when the dump completes successfully.
-      - R4.2: Must exit 1 when an invalid option is given or a file cannot be opened.
-      - R4.3: "Differential tests must compare stdout and exit codes between the Go binary and the reference binary via pkg/testutils."
-      - R4.4: "Tests must cover: default octal dump, -t with each format letter (a, c, d, f, o, u, x) and size variants, -A address radix modes, -j skip bytes, -N read bytes, -w output width, -v output duplicates, traditional short options (-b, -c, -d, -o, -s, -x), multiple -t options, duplicate suppression with '*', stdin input, multi-file input, and error cases (invalid type, missing file)."
+      - R4.1:
+          text: Must exit 0 when the dump completes successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when an invalid option is given or a file cannot be opened.
+          weight: 1
+      - R4.3:
+          text: "Differential tests must compare stdout and exit codes between the Go binary and the reference binary via pkg/testutils."
+          weight: 1
+      - R4.4:
+          text: "Tests must cover: default octal dump, -t with each format letter (a, c, d, f, o, u, x) and size variants, -A address radix modes, -j skip bytes, -N read bytes, -w output width, -v output duplicates, traditional short options (-b, -c, -d, -o, -s, -x), multiple -t options, duplicate suppression with '*', stdin input, multi-file input, and error cases (invalid type, missing file)."
+          weight: 1
 
 non_goals:
   - cmd/od does not implement --strings (-S) string extraction mode.

--- a/docs/specs/product-requirements/prd073-printf.yaml
+++ b/docs/specs/product-requirements/prd073-printf.yaml
@@ -19,34 +19,66 @@ requirements:
   R1:
     title: Format string and conversion specifiers
     items:
-      - R1.1: "Must interpret FORMAT as a printf-style format string containing literal text and conversion specifiers. Must print the formatted result to stdout with no trailing newline unless the format includes \\n."
-      - R1.2: "Must support integer conversion specifiers: %d (signed decimal), %i (signed decimal), %o (octal), %u (unsigned decimal), %x (lowercase hex), %X (uppercase hex)."
-      - R1.3: "Must support floating-point conversion specifiers: %f (decimal notation), %e (scientific notation), %g (shorter of %f and %e), and their uppercase variants %F, %E, %G."
-      - R1.4: "Must support string conversion specifier %s and character conversion specifier %c. %b must interpret backslash escapes in the argument string (like echo -e)."
+      - R1.1:
+          text: "Must interpret FORMAT as a printf-style format string containing literal text and conversion specifiers. Must print the formatted result to stdout with no trailing newline unless the format includes \\n."
+          weight: 1
+      - R1.2:
+          text: "Must support integer conversion specifiers: %d (signed decimal), %i (signed decimal), %o (octal), %u (unsigned decimal), %x (lowercase hex), %X (uppercase hex)."
+          weight: 1
+      - R1.3:
+          text: "Must support floating-point conversion specifiers: %f (decimal notation), %e (scientific notation), %g (shorter of %f and %e), and their uppercase variants %F, %E, %G."
+          weight: 1
+      - R1.4:
+          text: "Must support string conversion specifier %s and character conversion specifier %c. %b must interpret backslash escapes in the argument string (like echo -e)."
+          weight: 1
 
   R2:
     title: Width, precision, and flags
     items:
-      - R2.1: "Must support field width and precision in conversion specifiers (e.g., %10d, %.5f, %10.3f). Width specifies minimum field width; precision specifies digits after decimal for floats or maximum characters for strings."
-      - R2.2: "Must support flag characters: '-' (left-align), '+' (always show sign), ' ' (space before positive numbers), '0' (zero-pad), '#' (alternate form)."
-      - R2.3: "Must support '*' for width and precision, taking the value from the next argument."
-      - R2.4: "Must support '%%' as a literal percent character in the format string."
+      - R2.1:
+          text: "Must support field width and precision in conversion specifiers (e.g., %10d, %.5f, %10.3f). Width specifies minimum field width; precision specifies digits after decimal for floats or maximum characters for strings."
+          weight: 1
+      - R2.2:
+          text: "Must support flag characters: '-' (left-align), '+' (always show sign), ' ' (space before positive numbers), '0' (zero-pad), '#' (alternate form)."
+          weight: 1
+      - R2.3:
+          text: "Must support '*' for width and precision, taking the value from the next argument."
+          weight: 1
+      - R2.4:
+          text: "Must support '%%' as a literal percent character in the format string."
+          weight: 1
 
   R3:
     title: Escape sequences and argument handling
     items:
-      - R3.1: "Must interpret C-style escape sequences in FORMAT: \\\\, \\a, \\b, \\f, \\n, \\r, \\t, \\v, \\NNN (octal), \\xHH (hex), \\uHHHH (Unicode), \\UHHHHHHHH (Unicode)."
-      - R3.2: "When more arguments remain than the format consumes, must reuse the format string for the remaining arguments, repeating until all arguments are consumed."
-      - R3.3: "When fewer arguments are provided than the format requires, must use 0 for numeric specifiers and empty string for string specifiers."
-      - R3.4: "When a numeric argument starts with a single or double quote (e.g., '\"A' or \"'A\"), must use the numeric value of the character that follows the quote."
+      - R3.1:
+          text: "Must interpret C-style escape sequences in FORMAT: \\\\, \\a, \\b, \\f, \\n, \\r, \\t, \\v, \\NNN (octal), \\xHH (hex), \\uHHHH (Unicode), \\UHHHHHHHH (Unicode)."
+          weight: 1
+      - R3.2:
+          text: "When more arguments remain than the format consumes, must reuse the format string for the remaining arguments, repeating until all arguments are consumed."
+          weight: 1
+      - R3.3:
+          text: "When fewer arguments are provided than the format requires, must use 0 for numeric specifiers and empty string for string specifiers."
+          weight: 1
+      - R3.4:
+          text: "When a numeric argument starts with a single or double quote (e.g., '\"A' or \"'A\"), must use the numeric value of the character that follows the quote."
+          weight: 1
 
   R4:
     title: Exit codes and differential testing
     items:
-      - R4.1: Must exit 0 when formatting and printing complete successfully.
-      - R4.2: Must exit 1 when an invalid format directive is encountered or a numeric conversion fails. Must still produce partial output before the error.
-      - R4.3: "Differential tests must compare stdout and exit codes between the Go binary and the reference binary via pkg/testutils."
-      - R4.4: "Tests must cover: %d/%i/%o/%u/%x/%X integer formats, %f/%e/%g float formats, %s string, %c character, %b backslash-interpreted string, width and precision, all flag characters, '*' width/precision, argument recycling, escape sequences (\\n, \\t, \\NNN, \\xHH), character value arguments (quote prefix), missing arguments, and error cases (invalid format, non-numeric argument for %d)."
+      - R4.1:
+          text: Must exit 0 when formatting and printing complete successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when an invalid format directive is encountered or a numeric conversion fails. Must still produce partial output before the error.
+          weight: 1
+      - R4.3:
+          text: "Differential tests must compare stdout and exit codes between the Go binary and the reference binary via pkg/testutils."
+          weight: 1
+      - R4.4:
+          text: "Tests must cover: %d/%i/%o/%u/%x/%X integer formats, %f/%e/%g float formats, %s string, %c character, %b backslash-interpreted string, width and precision, all flag characters, '*' width/precision, argument recycling, escape sequences (\\n, \\t, \\NNN, \\xHH), character value arguments (quote prefix), missing arguments, and error cases (invalid format, non-numeric argument for %d)."
+          weight: 1
 
 non_goals:
   - cmd/printf does not implement %q (shell-escaped string) which is a bash extension not in GNU coreutils printf.


### PR DESCRIPTION
## Summary

Converts all 73 PRD files from the simple string-based requirement format to the weighted object format with `weight: 1` (uniform baseline). This enables the measure agent to use `max_weight_per_task` budgeting for variable batch sizing (cobbler-scaffold#1832).

## Changes

- 73 PRD files in `docs/specs/product-requirements/` converted from `- R1.1: text` to `- R1.1: { text: ..., weight: 1 }`
- Multi-line block scalars preserved with correct indentation
- No requirement text altered — structural wrapper only

## Stats

- 73 files changed, 3,431 insertions, 1,269 deletions
- Go LOC: 0 (sources reset, no delta)
- Spec words: PRD 54,666 / use case 21,688 / test suite 21,499

## Test plan

- [x] `mage analyze` passes (schema validation 0 errors, semantic model 0 errors, uncovered R-items 0)
- [x] All pre-existing warnings unchanged from main
- [x] Spot-checked converted files for correct YAML structure

Closes #3134