### PR TITLE
GH-3108: Restore prd070-fmt R3 with weighted requirement groups

### DIFF
--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -264,14 +264,12 @@ releases:
       description: |
         Deferred items from run 37 that could not complete due to stitch timeouts
         or rate limits. prd004-ts R6: multi-format date parser exceeded stitch time
-        budget. prd070-fmt R3: formatting options exceeded stitch time budget.
-        prd072-od: rate-limited out of every attempt. See GH-2938, cobbler-scaffold#1805.
+        budget. prd072-od: rate-limited out of every attempt.
+        See GH-2938, cobbler-scaffold#1805.
       use_cases:
         - id: rel99.0-uc001-ts
           status: spec_complete
         - id: rel99.0-uc002-od
-          status: spec_complete
-        - id: rel99.0-uc003-fmt-r3
           status: spec_complete
     - version: "06.0"
       name: "Batch 6.0 — file/directory creation and removal (mkdir, rmdir, mktemp, ln, unlink)"
@@ -401,7 +399,7 @@ releases:
         - id: rel08.1-uc003-join
           status: spec_complete
         - id: rel08.1-uc004-fmt
-          status: code_complete  # R3 deferred to rel99.0, see GH-3108
+          status: spec_complete
         - id: rel08.1-uc005-numfmt
           status: spec_complete
         - id: rel08.1-uc006-od

--- a/docs/specs/product-requirements/prd070-fmt.yaml
+++ b/docs/specs/product-requirements/prd070-fmt.yaml
@@ -47,29 +47,45 @@ requirements:
           text: Must collapse multiple spaces between words to a single space, except after sentence-ending punctuation (. ! ?) where two spaces are preserved.
           weight: 1
 
-  # R3 (formatting options: -s, -u, -p, -t) deferred to release 99.0.
-  # Timed out at 15 minutes in run 37. See GH-2938.
+  R3:
+    title: Split-only and uniform-spacing modes
+    items:
+      - R3.1:
+          text: "-s or --split-only must split long lines but not join short lines. Lines shorter than the goal width are left as-is."
+          weight: 2
+      - R3.2:
+          text: "-u or --uniform-spacing must use one space between words and two spaces after sentence-ending punctuation uniformly."
+          weight: 2
 
   R4:
-    title: Exit codes and differential testing
+    title: Prefix mode and tagged-paragraph
     items:
       - R4.1:
+          text: "-p PREFIX or --prefix=PREFIX must only reformat lines beginning with PREFIX (after optional whitespace). Must remove the prefix before formatting and re-add it afterward."
+          weight: 3
+      - R4.2:
+          text: "-t or --tagged-paragraph must treat the first line of each paragraph as having a different indentation from subsequent lines, preserving the tagged-paragraph format."
+          weight: 3
+
+  R5:
+    title: Exit codes and differential testing
+    items:
+      - R5.1:
           text: Must exit 0 when formatting completes successfully.
           weight: 1
-      - R4.2:
+      - R5.2:
           text: Must exit 1 when an invalid option is given or a file cannot be opened.
           weight: 1
-      - R4.3:
+      - R5.3:
           text: "Differential tests must compare stdout and exit codes between the Go binary and the reference binary via pkg/testutils."
           weight: 1
-      - R4.4:
+      - R5.4:
           text: "Tests must cover: default 75-char formatting, -w custom width, -g goal width, -s split-only, -u uniform spacing, -p prefix mode, -t tagged paragraph, multi-file input, stdin input, blank line paragraph boundaries, indentation preservation, and error cases (invalid width, missing file)."
           weight: 1
 
 non_goals:
   - cmd/fmt does not implement crown margin mode (-c) beyond the default indentation behavior.
   - cmd/fmt does not implement locale-aware line breaking.
-  - "R3 (formatting options: -s split-only, -u uniform-spacing, -p prefix, -t tagged-paragraph) deferred to release 99.0. Exceeded stitch time budget in run 37. See GH-2938."
 
 acceptance_criteria:
   - id: AC1
@@ -82,13 +98,28 @@ acceptance_criteria:
     traces:
       - R2.1
       - R2.3
-  # AC3 and AC4 deferred with R3
-  - id: AC5
-    criterion: "Differential test against gfmt passes for all flag combinations listed in R4.4."
+  - id: AC3
+    criterion: "go run ./cmd/fmt -s on text with long and short lines splits long lines without joining short ones, matching gfmt."
     traces:
-      - R4.3
-      - R4.4
+      - R3.1
+  - id: AC4
+    criterion: "go run ./cmd/fmt -u on text with inconsistent spacing normalizes to uniform spacing, matching gfmt."
+    traces:
+      - R3.2
+  - id: AC5
+    criterion: "go run ./cmd/fmt -p '>' on text with prefixed and non-prefixed lines reformats only prefixed lines, matching gfmt."
+    traces:
+      - R4.1
   - id: AC6
+    criterion: "go run ./cmd/fmt -t on text with tagged paragraphs preserves first-line indentation, matching gfmt."
+    traces:
+      - R4.2
+  - id: AC7
+    criterion: "Differential test against gfmt passes for all flag combinations listed in R5.4."
+    traces:
+      - R5.3
+      - R5.4
+  - id: AC8
     criterion: "cmd/fmt compiles with no warnings under golangci-lint."
     traces:
       - R1.1
@@ -99,7 +130,11 @@ acceptance_criteria:
       - R2.2
       - R2.3
       - R2.4
+      - R3.1
+      - R3.2
       - R4.1
       - R4.2
-      - R4.3
-      - R4.4
+      - R5.1
+      - R5.2
+      - R5.3
+      - R5.4

--- a/docs/specs/test-suites/test-rel-08.1.yaml
+++ b/docs/specs/test-suites/test-rel-08.1.yaml
@@ -26,6 +26,7 @@ traces:
   - prd070-fmt R2
   - prd070-fmt R3
   - prd070-fmt R4
+  - prd070-fmt R5
   - prd071-numfmt R1
   - prd071-numfmt R2
   - prd071-numfmt R3

--- a/docs/specs/use-cases/rel08.1-uc004-fmt.yaml
+++ b/docs/specs/use-cases/rel08.1-uc004-fmt.yaml
@@ -27,7 +27,7 @@ flow:
       compare stdout and exit codes under LC_ALL=C.
 
 touchpoints:
-  - T1: "cmd/fmt — paragraph formatting, width control, split-only, prefix mode (prd070-fmt R1, R2, R3, R4)"
+  - T1: "cmd/fmt — paragraph formatting, width control, split-only, uniform-spacing, prefix mode, tagged-paragraph (prd070-fmt R1, R2, R3, R4, R5)"
   - T2: "pkg/testutils — RunDiffTests, stdout and exit code comparison"
 
 success_criteria:
@@ -43,6 +43,8 @@ success_criteria:
       - AC3
       - AC4
       - AC5
+      - AC6
+      - AC7
 
 out_of_scope:
   - Crown margin mode (-c) is excluded per the PRD.


### PR DESCRIPTION
## Summary

Restores the deferred R3 formatting options (-s, -u, -p, -t) to prd070-fmt.yaml, split into two weighted requirement groups so the measure agent batches them into separate stitch tasks that fit within the 15-minute budget.

## Changes

- `docs/specs/product-requirements/prd070-fmt.yaml`: R3 (split-only weight 2, uniform-spacing weight 2), R4 (prefix weight 3, tagged-paragraph weight 3), old R4→R5. Restored AC3/AC4, added AC5/AC6, renumbered AC7/AC8. Removed deferral from non_goals.
- `docs/specs/use-cases/rel08.1-uc004-fmt.yaml`: Updated touchpoints (R1-R5) and AC traces (AC1-AC7)
- `docs/road-map.yaml`: Removed fmt from rel99.0, reset rel08.1 fmt status to spec_complete
- `docs/specs/test-suites/test-rel-08.1.yaml`: Added R5 to traces list

## Stats

- PRD words: 58,075 (+3,409 from restored requirements)
- Use case words: 21,695 (+7)
- Test suite words: 21,502 (+3)
- Go LOC: 0 (no code changes — spec restoration only)

## Test plan

- [x] `mage analyze` — schema 0 errors, semantic 0 errors
- [x] Broken citations reduced from 2 to 1 (remaining is prd004-ts R6, tracked by #2938)
- [x] All R-items covered, requirement weights set for stitch budget compliance

Closes #3108