### PR TITLE
GH-2938: Restore prd004-ts R6 with weighted requirement groups

### DIFF
--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -263,12 +263,9 @@ releases:
       depends_on: ["00.0"]
       description: |
         Deferred items from run 37 that could not complete due to stitch timeouts
-        or rate limits. prd004-ts R6: multi-format date parser exceeded stitch time
-        budget. prd072-od: rate-limited out of every attempt.
-        See GH-2938, cobbler-scaffold#1805.
+        or rate limits. prd072-od: rate-limited out of every attempt.
+        See cobbler-scaffold#1805.
       use_cases:
-        - id: rel99.0-uc001-ts
-          status: spec_complete
         - id: rel99.0-uc002-od
           status: spec_complete
     - version: "06.0"

--- a/docs/specs/product-requirements/prd004-ts.yaml
+++ b/docs/specs/product-requirements/prd004-ts.yaml
@@ -98,9 +98,28 @@ requirements:
           text: When -m is active, the timestamp must not jump backwards or exhibit discontinuities if the wall clock is adjusted (e.g., by NTP) while ts is running.
           weight: 1
 
-  # R6 (relative-time conversion mode) deferred to release 99.0.
-  # Repeatedly exceeded the 15-minute stitch timeout in run 37 due to
-  # multi-format date parsing complexity. See GH-2938, cobbler-scaffold#1697, #1699.
+  R6:
+    title: Relative-time parsing and age output
+    items:
+      - R6.1:
+          text: -r must scan each input line for known timestamp patterns and replace each match with a human-readable relative age string (e.g., "15m5s ago").
+          weight: 3
+      - R6.2:
+          text: 'Must recognize the following timestamp patterns from the Perl source regex: syslog format ("Jan  5 14:30:00"), ISO-8601 ("2024-01-05T14:30:00.000Z"), RFC 2822 with optional day ("16 Jun 94 07:29:35 GMT"), lastlog format ("Mon Jan  5 14:30").'
+          weight: 3
+
+  R10:
+    title: Relative-time format override and integration
+    items:
+      - R10.1:
+          text: When -r and a format string are both given, must convert matched timestamps to the specified format via strftime rather than to a relative string.
+          weight: 2
+      - R10.2:
+          text: Lines with no recognizable timestamp must be passed through unchanged.
+          weight: 1
+      - R10.3:
+          text: -r is mutually exclusive with -i and -s; passing both must print a usage error to stderr and exit non-zero.
+          weight: 1
 
   R7:
     title: Exit codes and error handling
@@ -111,7 +130,9 @@ requirements:
       - R7.2:
           text: Must exit non-zero and print a usage message to stderr when an unrecognized flag is given.
           weight: 1
-      # R7.3 deferred with R6 (references -r mode)
+      - R7.3:
+          text: Must exit non-zero when -r mode is requested but the timestamp parsing dependency (equivalent of Date::Parse) is unavailable. In the Go implementation this means the parsing library must be compiled in, so this condition cannot arise; document the invariant in the implementation.
+          weight: 1
 
   R8:
     title: Environment
@@ -139,7 +160,6 @@ non_goals:
   - cmd/ts does not read from files; it reads only from stdin.
   - cmd/ts does not support localized date parsing in -r mode (the Perl source explicitly notes this limitation).
   - cmd/ts does not implement --help or --version flags beyond a usage string on bad input.
-  - "R6 (relative-time conversion mode, -r flag) is deferred to release 99.0. The multi-format date parser and relative-age formatter exceed the stitch time budget. See GH-2938."
 
 acceptance_criteria:
   - id: AC1
@@ -175,7 +195,7 @@ acceptance_criteria:
       - R4.2
       - R4.3
       - R5.2
-      - R6.5
+      - R10.3
       - R7.1
       - R8.1
       - R8.2
@@ -185,7 +205,7 @@ acceptance_criteria:
     criterion: "ts with an invalid flag prints a usage message to stderr and exits non-zero."
     traces:
       - R3.4
-      - R6.5
+      - R10.3
       - R7.2
   - id: AC5
     criterion: "Empty stdin (immediate EOF) produces no output and exits 0."
@@ -193,10 +213,10 @@ acceptance_criteria:
       - R1.1
       - R1.6
       - R3.4
-      - R6.5
+      - R10.3
       - R7.1
       - R7.2
-      # R7.3 deferred with R6
+      - R7.3
       - R9.2
   - id: AC6
     criterion: "cmd/ts compiles with no warnings under golangci-lint."
@@ -221,10 +241,15 @@ acceptance_criteria:
       - R5.1
       - R5.2
       - R5.3
+      - R6.1
+      - R6.2
       - R7.1
       - R7.2
-      # R7.3 deferred with R6
+      - R7.3
       - R8.1
       - R8.2
       - R9.1
       - R9.2
+      - R10.1
+      - R10.2
+      - R10.3

--- a/docs/specs/test-suites/test-rel05.5.yaml
+++ b/docs/specs/test-suites/test-rel05.5.yaml
@@ -11,6 +11,7 @@ traces:
   - prd004-ts R5
   - prd004-ts R6
   - prd004-ts R7
+  - prd004-ts R10
 
 preconditions:
   - ./bin/ts exists (built via mage build).
@@ -181,7 +182,7 @@ test_cases:
       stdout: "no timestamp here\n"
       stderr: ""
     traces:
-      - prd004-ts R6.4
+      - prd004-ts R10.2
 
   - name: invalid_flag
     description: Unrecognized flag must produce a usage error and non-zero exit.

--- a/docs/specs/use-cases/rel05.5-uc001-ts.yaml
+++ b/docs/specs/use-cases/rel05.5-uc001-ts.yaml
@@ -33,7 +33,7 @@ flow:
       before comparison, replacing wall-clock timestamps with a fixed placeholder.
 
 touchpoints:
-  - T1: "cmd/ts — timestamp prefix logic, all flag modes (prd004-ts R1, R2, R3, R4, R5, R6, R7, R8)"
+  - T1: "cmd/ts — timestamp prefix logic, all flag modes (prd004-ts R1, R2, R3, R4, R5, R6, R7, R8, R10)"
   - T2: "pkg/testutils — RunDiffTests, TimestampNormalizer, binary execution and comparison (rel00.0 infrastructure)"
   - T3: "Human Operator — triggers use case via do-work after prd004-ts is complete"
 


### PR DESCRIPTION
## Summary

Restores the deferred R6 relative-time conversion mode (-r) to prd004-ts.yaml, split into two weighted groups so the measure agent batches them into separate stitch tasks that fit within the 15-minute budget. Also restores R7.3 and removes ts from rel99.0.

## Changes

- `docs/specs/product-requirements/prd004-ts.yaml`: R6 (parsing weight 3 each), R10 (integration weight 1-2), R7.3 restored, deferral removed from non_goals, AC traces updated
- `docs/specs/use-cases/rel05.5-uc001-ts.yaml`: Added R10 to touchpoints
- `docs/road-map.yaml`: Removed ts from rel99.0
- `docs/specs/test-suites/test-rel05.5.yaml`: Added R10 to traces, R6.4→R10.2

## Stats

- PRD words: 58,215 (+140 from restored requirements)
- Test suite words: 21,505 (+3)
- Use case words: 21,696 (+1)
- Go LOC: 0 (spec restoration only)

## Test plan

- [x] `mage analyze` — schema 0 errors, semantic 0 errors
- [x] Broken citations reduced from 1 to 0 (all resolved)
- [x] Requirement weights set for stitch budget compliance

Closes #2938