### PR TITLE
GH-3138: Increase requirement weights for PRDs with slow stitch tasks

### DIFF
--- a/docs/specs/product-requirements/prd008-ls.yaml
+++ b/docs/specs/product-requirements/prd008-ls.yaml
@@ -28,19 +28,19 @@ requirements:
       - R1.1:
           text: |
             When stdout is a TTY and no format flag is given, must produce multi-column output sorted vertically (down columns, then across). Terminal width is obtained by calling pkg/sys.TerminalWidth() (int, error) — returns the current terminal column count via TIOCGWINSZ ioctl on stdout; returns an error when stdout is not a terminal. Entries are laid out by calling pkg/format.Columns(entries []string, termWidth int) [][]string — distributes entries into the maximum number of columns fitting within termWidth, with column widths computed as per-column maxima of entry lengths.
-          weight: 1
+          weight: 2
       - R1.2:
           text: When stdout is not a TTY (pipe, file redirect) and no format flag is given, must produce single-column output with one entry per line. This matches GNU ls behavior (ls.c detects stdout is not a TTY and sets format to single-column).
-          weight: 1
+          weight: 2
       - R1.3:
           text: Must sort entries in the C locale order (LC_COLLATE=C). Differential tests must set LC_ALL=C to eliminate locale-dependent sort divergence.
-          weight: 1
+          weight: 2
       - R1.4:
           text: Must not list entries whose names start with "." unless -a or -A is given. This is the default filter behavior matching GNU ls.
-          weight: 1
+          weight: 2
       - R1.5:
           text: -1 must produce single-column output with one entry per line regardless of whether stdout is a TTY. This overrides the default multi-column layout.
-          weight: 1
+          weight: 2
       - R1.6:
           text: |
             -l flag skeleton and permission string. When -l is given, produce long-format output. Field order (left to right): permissions (10 chars), nlink, owner, group, size, mtime, name. Fields separated by a single space. Numeric fields (nlink, size) are right-aligned in columns wide enough for the largest value in the listing.
@@ -50,7 +50,7 @@ requirements:
             - Positions 1-3 (owner rwx): 'r'/'- ' for bit 0o400, 'w'/'-' for 0o200, 'x'/'-' for 0o100. If setuid (fi.Mode&os.ModeSetuid != 0): replace 'x' with 's', or replace '-' with 'S'.
             - Positions 4-6 (group rwx): bits 0o040, 0o020, 0o010. If setgid (fi.Mode&os.ModeSetgid != 0): replace 'x' with 's', or replace '-' with 'S'.
             - Positions 7-9 (other rwx): bits 0o004, 0o002, 0o001. If sticky (fi.Mode&os.ModeSticky != 0): replace 'x' with 't', or replace '-' with 'T'.
-          weight: 1
+          weight: 2
       - R1.7:
           text: |
             File metadata via pkg/sys.Lstat. Obtain metadata for each listed entry by calling pkg/sys.Lstat(path string) (*sys.FileInfo, error) — does not follow symbolic links; returns the symlink's own metadata when path is a symlink.
@@ -72,178 +72,178 @@ requirements:
               }
 
             In long format: print fi.Nlink (uint64) right-aligned; print fi.Size (int64, bytes) right-aligned. Both columns sized to the widest value across all listed entries.
-          weight: 1
+          weight: 2
       - R1.8:
           text: |
             Owner and group name resolution in long format. Resolve owner name by calling os/user.LookupId(strconv.Itoa(int(fi.Uid))); on success use u.Username; on error (user not found or lookup fails) fall back to strconv.FormatUint(uint64(fi.Uid), 10). Resolve group name by calling os/user.LookupGroupId(strconv.Itoa(int(fi.Gid))); on success use g.Name; on error fall back to strconv.FormatUint(uint64(fi.Gid), 10). Owner and group fields are left-padded to column width for alignment.
-          weight: 1
+          weight: 2
       - R1.9:
           text: |
             Modification time formatting in long format. Use fi.ModTime (time.Time from sys.FileInfo). If time.Since(fi.ModTime) < 6*30*24*time.Hour (approximately six months), format as fi.ModTime.Format("Jan _2 15:04"). Otherwise format as fi.ModTime.Format("Jan _2  2006"). Both patterns produce a 12-character field.
-          weight: 1
+          weight: 2
       - R1.10:
           text: |
             Total block count line and symlink display. Before the directory listing, print "total N\n" where N = sum(fi.Blocks for all listed entries) / 2. The division converts 512-byte st_blocks units to 1K-block units matching GNU ls. N is a plain integer (no trailing suffix) unless -h is active (see R3).
 
             Symlink display: when fi.Mode&os.ModeSymlink != 0, read the link target with os.Readlink(path) and append " -> " + target to the entry name field. Use Lstat (not Stat) so the symlink's own fi.Size and fi.Nlink are used, not the target's.
-          weight: 1
+          weight: 2
       - R1.11:
           text: |
             -C must force multi-column output regardless of whether stdout is a TTY. Layout uses pkg/format.Columns(entries []string, termWidth int) [][]string. When stdout is not a TTY, -C must use a default width of 80 columns (matching GNU ls behavior when stdout is not a TTY and -C is given without -w).
-          weight: 1
+          weight: 2
       - R1.12:
           text: -C must sort entries vertically (down columns, then across to the next column). This is the same sort direction as the default multi-column mode in R1.1.
-          weight: 1
+          weight: 2
       - R1.13:
           text: -x must produce multi-column output with entries sorted horizontally (across columns, then down to the next row). This differs from -C which sorts vertically.
-          weight: 1
+          weight: 2
       - R1.14:
           text: -C and -x are mutually exclusive with -l and -1. If -l or -1 appears after -C or -x on the command line, it overrides the multi-column mode. If -C or -x appears after -l or -1, it overrides the long or single-column format. The last format flag wins, matching GNU ls behavior.
-          weight: 1
+          weight: 2
 
   R2:
     title: Filtering, sorting, and metadata display (-a, -A, -d, -t, -S, -r, -U, -v, -i, -s, -n)
     items:
       - R2.1:
           text: -a must include entries whose names start with "." including the special entries "." and ".." in the listing.
-          weight: 1
+          weight: 2
       - R2.2:
           text: -A must include entries whose names start with "." except for "." and "..". -A is the "almost all" filter.
-          weight: 1
+          weight: 2
       - R2.3:
           text: -d must list directory entries themselves rather than their contents. When a directory is given as an argument with -d, must print the directory name (or its long-format entry with -l) without descending into it.
-          weight: 1
+          weight: 2
       - R2.4:
           text: When both -a and -A are given, the last one on the command line takes precedence, matching GNU ls behavior.
-          weight: 1
+          weight: 2
       - R2.5:
           text: |
             -t must sort entries by modification time, newest first. Obtain metadata via pkg/sys.Lstat(path string) (*sys.FileInfo, error); use sys.FileInfo.ModTime time.Time for comparison (fi.ModTime.After(fj.ModTime) for newest-first ordering). Entries with the same modification time must be sorted by name in C locale order as a tiebreaker.
-          weight: 1
+          weight: 2
       - R2.6:
           text: |
             -S must sort entries by file size (st_size), largest first. Obtain file size from sys.FileInfo.Size int64 — apparent file size in bytes (st_size). Entries with the same size must be sorted by name in C locale order as a tiebreaker.
-          weight: 1
+          weight: 2
       - R2.7:
           text: -r must reverse the current sort order. -r applies to whichever sort is active (name sort by default, -t for time, -S for size, -v for version). -r with the default sort produces reverse alphabetical order.
-          weight: 1
+          weight: 2
       - R2.8:
           text: -U must disable sorting entirely and list entries in directory order (the order returned by readdir). -U overrides -t, -S, and -v. -r with -U has no defined effect (directory order is not reversible in a meaningful way), but must be accepted without error.
-          weight: 1
+          weight: 2
       - R2.9:
           text: -v must sort entries using natural version sort semantics (strverscmp behavior). Runs of digits within filenames are compared numerically rather than lexicographically, so "file2" sorts before "file10". Must be implemented without external libraries.
-          weight: 1
+          weight: 2
       - R2.10:
           text: When multiple sort flags are given, the last one on the command line takes precedence, matching GNU ls behavior.
-          weight: 1
+          weight: 2
       - R2.11:
           text: |
             -i must prepend the inode number of each entry before the entry name (or before the permissions in -l mode). Obtain the inode number via pkg/sys.Lstat(path string) (*sys.FileInfo, error) and read sys.FileInfo.Ino uint64 — inode number (st_ino). The inode number is right-aligned in a column wide enough for the largest inode in the listing.
-          weight: 1
+          weight: 2
       - R2.12:
           text: |
             -s must prepend the allocated block count for each entry before the entry name (or before the permissions in -l mode). Obtain the block count via pkg/sys.Lstat(path string) (*sys.FileInfo, error) and read sys.FileInfo.Blocks int64 — number of 512-byte blocks allocated (st_blocks). Report in 1024-byte block units: fi.Blocks / 2. The block count is right-aligned in a column wide enough for the largest count in the listing.
-          weight: 1
+          weight: 2
       - R2.13:
           text: -s with -l must also modify the "total N" line to include block counts in the selected unit. The total is the sum of all listed entries' block allocations.
-          weight: 1
+          weight: 2
       - R2.14:
           text: |
             -n must activate long format (implies -l) and display numeric UID and GID instead of resolving owner and group names. Format UID as strconv.FormatUint(uint64(fi.Uid), 10) and GID as strconv.FormatUint(uint64(fi.Gid), 10), where fi.Uid uint32 and fi.Gid uint32 come from pkg/sys.Lstat. Do not call os/user.LookupId or os/user.LookupGroupId.
-          weight: 1
+          weight: 2
       - R2.15:
           text: -i and -s may be combined. When both are given, inode is printed first, then block count, then the entry (or the long-format fields).
-          weight: 1
+          weight: 2
 
   R3:
     title: Display features (--color, -h, -F, -R)
     items:
       - R3.1:
           text: Must support --color=always, --color=auto, and --color=never. When --color is given without a value, it must default to "always".
-          weight: 1
+          weight: 2
       - R3.2:
           text: |
             --color=auto must colorize output only when stdout is a TTY. TTY detection: call pkg/sys.IsTerminal(os.Stdout) — returns true when os.Stdout's file descriptor is a terminal (detected via golang.org/x/sys/unix.IoctlGetWinsize with TIOCGWINSZ), false otherwise. When stdout is not a TTY, --color=auto must behave like --color=never.
-          weight: 1
+          weight: 2
       - R3.3:
           text: |
             Colorized output uses GNU LS_COLORS default color assignments via pkg/format. Call pkg/format.FileTypeColor(mode os.FileMode) string to obtain the ANSI escape sequence for a given file type, and pkg/format.Reset() string for the reset sequence. Executable detection: fi.Mode&0o111 != 0 (any execute bit set). Each entry name is wrapped as: colorCode + name + resetCode. When color is suppressed, both codes are empty strings so no ANSI sequences appear in output.
 
             Set the process-global color mode based on the --color flag value: call pkg/format.SetColorEnabled(true) for --color=always, pkg/format.SetColorEnabled(false) for --color=never. For --color=auto, call pkg/sys.IsTerminal(os.Stdout.Fd()) and pass the result to pkg/format.SetColorEnabled. When color is disabled, pkg/format.FileTypeColor returns empty strings.
-          weight: 1
+          weight: 2
       - R3.4:
           text: When --color=never or when color is suppressed (non-TTY with auto), must not emit any ANSI escape sequences in the output.
-          weight: 1
+          weight: 2
       - R3.5:
           text: |
             -h must only take effect with -l (long format). When -h is given with -l, file sizes (fi.Size int64) must be displayed via pkg/format.HumanSize(bytes int64, opts HumanSizeOpts) string with opts.Binary = true (1024-base units, suffixes K/M/G/T/P/E). Without -l, -h must have no visible effect on output.
-          weight: 1
+          weight: 2
       - R3.6:
           text: -h must also apply to the "total N" block count line in long format. When -h is active, convert the total block count (sum(fi.Blocks)/2 as int64) to a human-readable string using the same binary algorithm before printing "total X\n".
-          weight: 1
+          weight: 2
       - R3.7:
           text: |
             -h must apply to -s block counts when both -s and -h are given, converting
             block counts to human-readable form. Use pkg/format.HumanSize(bytes int64,
             opts HumanSizeOpts) string with opts.Binary = true, consistent with R3.5.
             Do not duplicate the HumanSize algorithm inline.
-          weight: 1
+          weight: 2
       - R3.8:
           text: -F must append a type indicator character after each entry name. The indicators are "/" for directories, "*" for executable regular files, "@" for symbolic links, "|" for named pipes (FIFOs), "=" for sockets. Regular non-executable files receive no indicator.
-          weight: 1
+          weight: 2
       - R3.9:
           text: Executable is defined as having any execute bit set (owner, group, or other) in the file's permission mode.
-          weight: 1
+          weight: 2
       - R3.10:
           text: -F must work with all output formats (-l, -1, -C, -x) and with color output. When color is enabled, the indicator character is printed after the ANSI reset sequence so it is not colorized.
-          weight: 1
+          weight: 2
       - R3.11:
           text: -R must recursively list the contents of each subdirectory encountered during the listing. Each subdirectory's contents are printed under a header line in the format "PATH:" followed by a blank line, then the directory contents, then a blank line before the next entry.
-          weight: 1
+          weight: 2
       - R3.12:
           text: -R must respect the current format mode. With -l, each subdirectory's contents are listed in long format including the "total N" block line. With -C or default mode, each subdirectory's contents use multi-column layout.
-          weight: 1
+          weight: 2
       - R3.13:
           text: -R must not follow symbolic links to directories. Only real subdirectories are recursed into.
-          weight: 1
+          weight: 2
       - R3.14:
           text: -R must apply the current filter flags (-a, -A) to each subdirectory. Dotfiles in subdirectories are shown only if -a or -A is given.
-          weight: 1
+          weight: 2
       - R3.15:
           text: -R must list directories in the same sort order as entries within a directory. If -t is active, subdirectories are recursed into in modification-time order.
-          weight: 1
+          weight: 2
 
   R4:
     title: Exit codes, signal handling, and flag interactions
     items:
       - R4.1:
           text: Must exit 0 when all listed paths are accessed and output is written successfully.
-          weight: 1
+          weight: 2
       - R4.2:
           text: Must exit 1 when a minor problem occurs, such as failing to access a file or directory given as an argument (e.g., permission denied, file not found). Must still list the remaining accessible entries before exiting. Must print a diagnostic to stderr for each inaccessible entry.
-          weight: 1
+          weight: 2
       - R4.3:
           text: Must exit 2 when a serious problem occurs, such as an invalid command-line option. This matches GNU ls (ls.c:5638 exit(status) where status is set to EXIT_FAILURE=2 for bad options at ls.c:2026).
-          weight: 1
+          weight: 2
       - R4.4:
           text: |
             Must install a SIGPIPE handler at startup so that piping ls output to head or other truncating consumers does not produce a broken-pipe error message. Implementation: call pkg/sys.InstallSIGPIPEHandler() — this uses signal.Notify(c, syscall.SIGPIPE) with a buffered channel of size 1; a dedicated goroutine calls os.Exit(0) when the channel receives. Must not use signal.Ignore (deferred cleanup functions must not run on SIGPIPE, matching GNU ls behavior).
-          weight: 1
+          weight: 2
       - R4.5:
           text: Must install a SIGWINCH handler via pkg/sys.OnTerminalResize(callback func(width int)) that re-queries the terminal width and updates the column layout. pkg/sys.OnTerminalResize registers a SIGWINCH listener that calls pkg/sys.TerminalWidth() and invokes the callback with the new width; multiple callbacks may be registered. This allows ls to adapt column layout if the terminal is resized during a long listing.
-          weight: 1
+          weight: 2
       - R4.6:
           text: -n implies -l. When -n is given without -l, the output must be in long format with numeric UID/GID.
-          weight: 1
+          weight: 2
       - R4.7:
           text: -C and -x are mutually exclusive with -l and -1. The last format flag on the command line wins (see R1.14).
-          weight: 1
+          weight: 2
       - R4.8:
           text: -R with -l must produce a "total N" block line for each subdirectory listing, matching GNU ls -lR output.
-          weight: 1
+          weight: 2
       - R4.9:
           text: -i, -s, and -F may all be combined with -R. Each subdirectory listing applies the same metadata display and classification options.
-          weight: 1
+          weight: 2
 
 non_goals:
   - --hyperlink (terminal hyperlinks) is out of scope for this project.

--- a/docs/specs/product-requirements/prd019-seq.yaml
+++ b/docs/specs/product-requirements/prd019-seq.yaml
@@ -20,67 +20,67 @@ requirements:
     items:
       - R1.1:
           text: "Must support three argument forms: 'seq LAST' (FIRST=1, STEP=1), 'seq FIRST LAST' (STEP=1), and 'seq FIRST STEP LAST'. All three arguments are interpreted as floating-point numbers."
-          weight: 1
+          weight: 2
       - R1.2:
           text: Must generate numbers starting at FIRST, incrementing by STEP, and stopping when the next number would exceed LAST (for positive STEP) or fall below LAST (for negative STEP).
-          weight: 1
+          weight: 2
       - R1.3:
           text: When FIRST equals LAST, must print exactly one number (FIRST).
-          weight: 1
+          weight: 2
       - R1.4:
           text: When STEP is positive and FIRST is greater than LAST, must produce no output and exit 0. When STEP is negative and FIRST is less than LAST, must produce no output and exit 0.
-          weight: 1
+          weight: 2
       - R1.5:
           text: STEP must not be zero. Must exit 1 with an error message when STEP is zero.
-          weight: 1
+          weight: 2
 
   R2:
     title: Output formatting
     items:
       - R2.1:
           text: By default, must separate each number with a newline character. The last number must also be followed by a newline.
-          weight: 1
+          weight: 2
       - R2.2:
           text: -s STRING or --separator=STRING must use STRING as the separator between numbers instead of newline. A trailing newline is still printed after the last number.
-          weight: 1
+          weight: 2
       - R2.3:
           text: "The default format for integer sequences (all arguments are integers with no decimal point) must produce integers with no decimal point. The default format for floating-point sequences must use the minimum precision needed to represent the values exactly, matching the precision of the input arguments."
-          weight: 1
+          weight: 2
       - R2.4:
           text: Must handle large integers exactly up to 2^53. Beyond that range, floating-point approximation is acceptable.
-          weight: 1
+          weight: 2
 
   R3:
     title: Format string (-f) and equal-width (-w)
     items:
       - R3.1:
           text: "-f FORMAT or --format=FORMAT must apply a printf-style format string to each number. FORMAT must contain exactly one floating-point conversion specifier from the set: %a, %e, %f, %g, %A, %E, %F, %G. The specifier may include flags (-+#0 and space), width, and precision fields."
-          weight: 1
+          weight: 2
       - R3.2:
           text: Must exit 1 with an error message when the format string contains no conversion specifier, contains more than one conversion specifier, or contains an invalid specifier (not in the allowed set).
-          weight: 1
+          weight: 2
       - R3.3:
           text: -w or --equal-width must pad each number with leading zeros so that all numbers in the sequence have the same width. The width is determined by the widest of FIRST and LAST (formatted with the default format).
-          weight: 1
+          weight: 2
       - R3.4:
           text: -f and -w are mutually exclusive in effect. When -f is given, -w is ignored (the format string controls the output width). When only -w is given, the default format is used with zero-padding.
-          weight: 1
+          weight: 2
 
   R4:
     title: Exit codes and differential testing
     items:
       - R4.1:
           text: Must exit 0 on success, including when the sequence is empty (FIRST > LAST with positive STEP).
-          weight: 1
+          weight: 2
       - R4.2:
           text: "Must exit 1 on error: zero STEP, invalid format string, non-numeric arguments, or NaN arguments."
-          weight: 1
+          weight: 2
       - R4.3:
           text: Differential tests must compare stdout output and exit codes between the Go binary and the reference binary via pkg/testutils.
-          weight: 1
+          weight: 2
       - R4.4:
           text: "Tests must cover: single argument (seq 5), two arguments (seq 2 5), three arguments (seq 1 2 10), descending sequence (seq 5 -1 1), floating-point sequence (seq 0.1 0.1 0.5), equal-width (seq -w 8 12), custom separator (seq -s ', ' 1 5), format string (seq -f '%.2f' 1 3), empty sequence, zero step error, and invalid format error."
-          weight: 1
+          weight: 2
 
 non_goals:
   - cmd/seq does not implement hexadecimal integer output; use -f '%a' for hex floating-point.

--- a/docs/specs/product-requirements/prd022-nl.yaml
+++ b/docs/specs/product-requirements/prd022-nl.yaml
@@ -20,64 +20,64 @@ requirements:
     items:
       - R1.1:
           text: By default, must number non-empty lines in the body section only, using right-justified numbers in a field of width 6, with a tab character separating the number from the line content.
-          weight: 1
+          weight: 2
       - R1.2:
           text: Empty lines (containing only a newline) in the body section must not be numbered by default. They must be passed through with no number and no separator.
-          weight: 1
+          weight: 2
       - R1.3:
           text: Must read from stdin when no file arguments are given. Must read each named file in argument order.
-          weight: 1
+          weight: 2
       - R1.4:
           text: Line numbering must be continuous across files when multiple files are given (the counter does not reset between files unless a page delimiter is encountered).
-          weight: 1
+          weight: 2
 
   R2:
     title: Numbering style flags (-b, -h, -f)
     items:
       - R2.1:
           text: "-b STYLE must set the body section numbering style. Styles: a (number all lines), t (number non-empty lines, default), n (number no lines), p RE (number lines matching regular expression RE)."
-          weight: 1
+          weight: 2
       - R2.2:
           text: "-h STYLE must set the header section numbering style (default n). Same style values as -b."
-          weight: 1
+          weight: 2
       - R2.3:
           text: "-f STYLE must set the footer section numbering style (default n). Same style values as -b."
-          weight: 1
+          weight: 2
       - R2.4:
           text: When the style is n for a section, lines in that section must pass through with no number and no separator character.
-          weight: 1
+          weight: 2
 
   R3:
     title: Format and numbering options (-n, -w, -s, -v, -i, -l)
     items:
       - R3.1:
           text: "-n FORMAT must set the line number format. Formats: ln (left-justified, no leading zeros), rn (right-justified, no leading zeros, default), rz (right-justified, leading zeros)."
-          weight: 1
+          weight: 2
       - R3.2:
           text: -w N must set the line number field width to N characters (default 6).
-          weight: 1
+          weight: 2
       - R3.3:
           text: -s SEP must use SEP as the separator between the line number and the line content (default tab). SEP may be any string.
-          weight: 1
+          weight: 2
       - R3.4:
           text: -v N must set the initial line number to N (default 1). -i N must set the line number increment to N (default 1).
-          weight: 1
+          weight: 2
 
   R4:
     title: Section delimiters and page reset (-d, -p, -l)
     items:
       - R4.1:
           text: "A line containing only the two-character sequence \\:\\:\\: (the section delimiter repeated three times) marks the start of a header section. \\:\\: marks the start of a body section. \\: marks the start of a footer section. These delimiter lines are not written to output."
-          weight: 1
+          weight: 2
       - R4.2:
           text: Each new logical page (triggered by a header delimiter) resets the line counter to the value of -v unless -p is given.
-          weight: 1
+          weight: 2
       - R4.3:
           text: -p must suppress line counter reset at the start of each logical page; numbering continues from the previous page's last line number.
-          weight: 1
+          weight: 2
       - R4.4:
           text: -l N must treat N consecutive empty lines as a single empty line for the purpose of numbering with -b t. The default is 1 (each empty line counted separately). With -l 2, two or fewer consecutive empty lines are treated as one unnumbered block.
-          weight: 1
+          weight: 2
 
 non_goals:
   - cmd/nl does not implement regex-based separator matching beyond the -p RE style argument.

--- a/docs/specs/product-requirements/prd037-ln.yaml
+++ b/docs/specs/product-requirements/prd037-ln.yaml
@@ -19,42 +19,42 @@ requirements:
     items:
       - R1.1:
           text: Must create a hard link from TARGET to LINK_NAME when invoked as 'ln TARGET LINK_NAME'.
-          weight: 1
+          weight: 2
       - R1.2:
           text: Must create hard links for multiple TARGETs in DIRECTORY when invoked as 'ln TARGET... DIRECTORY', placing each link in DIRECTORY with the same basename as the target.
-          weight: 1
+          weight: 2
       - R1.3:
           text: Must exit with a non-zero status and print an error to stderr when attempting to create a hard link to a directory.
-          weight: 1
+          weight: 2
       - R1.4:
           text: Must exit with a non-zero status and print an error to stderr when LINK_NAME already exists and neither -f nor -i is given.
-          weight: 1
+          weight: 2
 
   R2:
     title: Symbolic link creation (-s, --symbolic)
     items:
       - R2.1:
           text: -s or --symbolic must create a symbolic link instead of a hard link.
-          weight: 1
+          weight: 2
       - R2.2:
           text: Must allow symbolic links to directories, unlike hard links.
-          weight: 1
+          weight: 2
       - R2.3:
           text: Must store the TARGET string as-is in the symlink, whether it is relative or absolute.
-          weight: 1
+          weight: 2
       - R2.4:
           text: -r or --relative must create a symbolic link with a relative path from the link location to the target, computing the relative path automatically.
-          weight: 1
+          weight: 2
 
   R3:
     title: Force, safety, and verbosity flags
     items:
       - R3.1:
           text: -f or --force must remove existing destination files before creating the link.
-          weight: 1
+          weight: 2
       - R3.2:
           text: -n or --no-dereference must treat a destination that is a symlink to a directory as a regular file, rather than following it.
-          weight: 1
+          weight: 2
       - R3.3:
           text: |
             -i or --interactive must prompt the user on stderr before removing an existing
@@ -65,29 +65,29 @@ requirements:
             input. When stdin is not a terminal (detected via os.Stdin.Fd() isatty check),
             treat as decline (do not prompt, do not remove). When -f and -i are both given,
             the last flag on the command line wins, matching GNU ln behavior.
-          weight: 1
+          weight: 2
       - R3.4:
           text: -v or --verbose must print the name of each link created to stdout.
-          weight: 1
+          weight: 2
       - R3.5:
           text: -b must create a backup of each existing destination file before removal, using the default backup suffix '~'. --backup=METHOD must accept numbered, existing, simple, and none as backup methods.
-          weight: 1
+          weight: 2
       - R3.6:
           text: -S SUFFIX or --suffix=SUFFIX must use SUFFIX instead of '~' for backup file names.
-          weight: 1
+          weight: 2
 
   R4:
     title: Differential testing
     items:
       - R4.1:
           text: Differential tests must compare stdout, stderr, exit codes, and resulting filesystem state between the Go binary and gln via pkg/testutils.
-          weight: 1
+          weight: 2
       - R4.2:
           text: "Tests must cover: hard link creation, symbolic link creation (-s), force overwrite (-f), no-dereference (-n), verbose output (-v), backup creation (-b), multiple targets into a directory, relative symlinks (-r), and error cases for hard linking directories and existing destinations."
-          weight: 1
+          weight: 2
       - R4.3:
           text: Tests must verify that created links point to the correct target and have the correct link type (hard or symbolic), matching gln behavior.
-          weight: 1
+          weight: 2
 
 non_goals:
   - cmd/ln does not implement -L or -P (logical/physical) dereference modes for following symlink chains on the target.

--- a/docs/specs/product-requirements/prd053-sort.yaml
+++ b/docs/specs/product-requirements/prd053-sort.yaml
@@ -21,73 +21,73 @@ requirements:
     items:
       - R1.1:
           text: When no flags are given, must sort all input lines lexicographically using byte values (LC_ALL=C).
-          weight: 1
+          weight: 2
       - R1.2:
           text: Must read from stdin when no file arguments are given or when a file argument is "-".
-          weight: 1
+          weight: 2
       - R1.3:
           text: Must accept multiple input files and sort their combined lines as a single stream.
-          weight: 1
+          weight: 2
       - R1.4:
           text: "-r or --reverse must reverse the sort order."
-          weight: 1
+          weight: 2
       - R1.5:
           text: "-u or --unique must output only the first of an equal run (based on the active sort key)."
-          weight: 1
+          weight: 2
       - R1.6:
           text: "-o FILE or --output=FILE must write output to FILE. FILE may be the same as an input file."
-          weight: 1
+          weight: 2
       - R1.7:
           text: "-s or --stable must preserve the input order of lines that compare equal."
-          weight: 1
+          weight: 2
 
   R2:
     title: Sort modes
     items:
       - R2.1:
           text: "-n or --numeric-sort must sort by numeric value, parsing leading whitespace and optional sign."
-          weight: 1
+          weight: 2
       - R2.2:
           text: "-h or --human-numeric-sort must sort by numeric value with SI suffixes (K, M, G, T, P, E, Z, Y)."
-          weight: 1
+          weight: 2
       - R2.3:
           text: "-M or --month-sort must sort by month name abbreviation (JAN < FEB < ... < DEC). Unknown strings sort before JAN."
-          weight: 1
+          weight: 2
       - R2.4:
           text: "-V or --version-sort must sort by version number segments (natural sort)."
-          weight: 1
+          weight: 2
 
   R3:
     title: Key fields and delimiters
     items:
       - R3.1:
           text: "-t CHAR or --field-separator=CHAR must use CHAR as the field delimiter instead of the default blank-to-non-blank transition."
-          weight: 1
+          weight: 2
       - R3.2:
           text: "-k KEYDEF or --key=KEYDEF must sort by the specified key field. KEYDEF format is F[.C][OPTS][,F[.C][OPTS]] where F is field number, C is character position, and OPTS are modifier letters (n, r, h, M, V, b, d, f, i)."
-          weight: 1
+          weight: 2
       - R3.3:
           text: Must support multiple -k options. Earlier keys take precedence; later keys break ties.
-          weight: 1
+          weight: 2
       - R3.4:
           text: "-b or --ignore-leading-blanks must ignore leading blanks when finding sort keys."
-          weight: 1
+          weight: 2
 
   R4:
     title: Exit codes and differential testing
     items:
       - R4.1:
           text: Must exit 0 when input is sorted successfully.
-          weight: 1
+          weight: 2
       - R4.2:
           text: "-c or --check must check whether input is sorted. Exit 0 if sorted, exit 1 if not. With -C or --check=quiet, suppress the diagnostic message."
-          weight: 1
+          weight: 2
       - R4.3:
           text: Must exit 2 on usage errors (invalid flags, conflicting options).
-          weight: 1
+          weight: 2
       - R4.4:
           text: "Differential tests must compare stdout output and exit codes between the Go binary and the reference binary via pkg/testutils. Tests must cover: default sort, -r, -n, -h, -M, -V, -u, -s, -k with field specs, -t delimiter, -b, -c check mode, multi-file input, and stdin."
-          weight: 1
+          weight: 2
 
 non_goals:
   - cmd/sort does not implement --parallel (threaded merge sort). Single-threaded sorting is sufficient for correctness verification.

--- a/docs/specs/product-requirements/prd054-tr.yaml
+++ b/docs/specs/product-requirements/prd054-tr.yaml
@@ -21,58 +21,58 @@ requirements:
     items:
       - R1.1:
           text: "When two SETs are given without flags, must translate each character in SET1 to the corresponding character in SET2. If SET2 is shorter than SET1, the last character of SET2 is repeated to match SET1's length."
-          weight: 1
+          weight: 2
       - R1.2:
           text: Must read from stdin and write translated output to stdout. tr does not accept file arguments.
-          weight: 1
+          weight: 2
       - R1.3:
           text: "SET specifications must support: individual characters, ranges (a-z), octal escapes (\\NNN), backslash escapes (\\n, \\t, \\\\, \\a, \\b, \\f, \\r, \\v), and repetition (CHAR*N, CHAR*)."
-          weight: 1
+          weight: 2
       - R1.4:
           text: "SET specifications must support POSIX character classes: [:alnum:], [:alpha:], [:blank:], [:cntrl:], [:digit:], [:graph:], [:lower:], [:print:], [:punct:], [:space:], [:upper:], [:xdigit:]."
-          weight: 1
+          weight: 2
 
   R2:
     title: Delete and squeeze modes
     items:
       - R2.1:
           text: "-d or --delete must delete all characters in SET1 from the input. SET2 is not used with -d alone."
-          weight: 1
+          weight: 2
       - R2.2:
           text: "-s or --squeeze-repeats must replace each run of repeated characters listed in the last SET with a single occurrence of that character."
-          weight: 1
+          weight: 2
       - R2.3:
           text: "When -d and -s are used together, must delete characters in SET1 and squeeze characters in SET2."
-          weight: 1
+          weight: 2
       - R2.4:
           text: "-c or -C or --complement must complement SET1, operating on all characters not in SET1."
-          weight: 1
+          weight: 2
 
   R3:
     title: Character class translation pairs
     items:
       - R3.1:
           text: "[:lower:] to [:upper:] must translate lowercase to uppercase. [:upper:] to [:lower:] must translate uppercase to lowercase."
-          weight: 1
+          weight: 2
       - R3.2:
           text: "When translating (not deleting), SET2 must not be empty. If SET2 is omitted, must print a usage error."
-          weight: 1
+          weight: 2
       - R3.3:
           text: "Equivalence classes [=CHAR=] must be supported in SET2 for specifying characters that sort identically."
-          weight: 1
+          weight: 2
 
   R4:
     title: Exit codes and differential testing
     items:
       - R4.1:
           text: Must exit 0 when translation or deletion completes successfully.
-          weight: 1
+          weight: 2
       - R4.2:
           text: Must exit 1 on usage errors (missing SET, invalid class, conflicting flags).
-          weight: 1
+          weight: 2
       - R4.3:
           text: "Differential tests must compare stdout output and exit codes between the Go binary and the reference binary via pkg/testutils. Tests must cover: basic translation, -d delete, -s squeeze, -c complement, -ds combined, character ranges, POSIX classes, case conversion, octal escapes, and error cases."
-          weight: 1
+          weight: 2
 
 non_goals:
   - cmd/tr does not implement multibyte character support beyond single-byte encodings. All tests use LC_ALL=C.

--- a/docs/specs/product-requirements/prd056-cp.yaml
+++ b/docs/specs/product-requirements/prd056-cp.yaml
@@ -21,64 +21,64 @@ requirements:
     items:
       - R1.1:
           text: "When given SOURCE DEST, must copy SOURCE to DEST. When given multiple SOURCE arguments and a DEST directory, must copy each SOURCE into DEST."
-          weight: 1
+          weight: 2
       - R1.2:
           text: "-i or --interactive must prompt before overwriting an existing destination file."
-          weight: 1
+          weight: 2
       - R1.3:
           text: "-f or --force must remove an existing destination file if it cannot be opened for writing, then retry the copy."
-          weight: 1
+          weight: 2
       - R1.4:
           text: "-n or --no-clobber must not overwrite an existing destination file. When combined with -i, -n takes precedence."
-          weight: 1
+          weight: 2
 
   R2:
     title: Recursive copying and symlinks
     items:
       - R2.1:
           text: "-r or -R or --recursive must copy directories recursively, preserving the directory structure."
-          weight: 1
+          weight: 2
       - R2.2:
           text: "Without -r, must refuse to copy a directory and print an error to stderr."
-          weight: 1
+          weight: 2
       - R2.3:
           text: "-L or --dereference must follow symlinks in SOURCE, copying the file they point to."
-          weight: 1
+          weight: 2
       - R2.4:
           text: "-P or --no-dereference must preserve symlinks, copying them as symlinks rather than following them. This is the default with -r."
-          weight: 1
+          weight: 2
 
   R3:
     title: Attribute preservation
     items:
       - R3.1:
           text: "-p or --preserve=mode,ownership,timestamps must preserve file mode, ownership, and modification timestamps on the copy."
-          weight: 1
+          weight: 2
       - R3.2:
           text: "-a or --archive is equivalent to -dR --preserve=all. It preserves all attributes and copies recursively without following symlinks."
-          weight: 1
+          weight: 2
       - R3.3:
           text: "--preserve=ATTR_LIST must accept a comma-separated list of attributes to preserve. Supported attributes are mode, ownership, timestamps, and links."
-          weight: 1
+          weight: 2
       - R3.4:
           text: "-v or --verbose must print the name of each file as it is copied."
-          weight: 1
+          weight: 2
 
   R4:
     title: Exit codes and differential testing
     items:
       - R4.1:
           text: Must exit 0 when all files are copied successfully.
-          weight: 1
+          weight: 2
       - R4.2:
           text: Must exit 1 when any copy operation fails (permission denied, source not found, destination is a directory without -r).
-          weight: 1
+          weight: 2
       - R4.3:
           text: "-t DIRECTORY or --target-directory=DIRECTORY must copy all SOURCE arguments into DIRECTORY."
-          weight: 1
+          weight: 2
       - R4.4:
           text: "Differential tests must compare exit codes and resulting file system state between the Go binary and the reference binary via pkg/testutils. Tests must cover: single file copy, multi-file copy into directory, -r recursive, -i interactive (via stdin), -f force, -n no-clobber, -p preserve, -a archive, -v verbose, symlink handling, and error cases."
-          weight: 1
+          weight: 2
 
 non_goals:
   - "cmd/cp does not implement --reflink (copy-on-write clones). Reflink support is filesystem-dependent and not available on all platforms."

--- a/docs/specs/product-requirements/prd057-mv.yaml
+++ b/docs/specs/product-requirements/prd057-mv.yaml
@@ -20,61 +20,61 @@ requirements:
     items:
       - R1.1:
           text: "When given SOURCE DEST, must rename SOURCE to DEST if on the same filesystem, or copy and delete if on different filesystems."
-          weight: 1
+          weight: 2
       - R1.2:
           text: "When given multiple SOURCE arguments and a DEST directory, must move each SOURCE into DEST."
-          weight: 1
+          weight: 2
       - R1.3:
           text: Must move directories without requiring a recursive flag (unlike cp).
-          weight: 1
+          weight: 2
       - R1.4:
           text: "When DEST exists and is a directory, must move SOURCE into DEST as DEST/SOURCE."
-          weight: 1
+          weight: 2
 
   R2:
     title: Overwrite control
     items:
       - R2.1:
           text: "-i or --interactive must prompt before overwriting an existing destination file."
-          weight: 1
+          weight: 2
       - R2.2:
           text: "-f or --force must not prompt before overwriting. When combined with -i, the last flag given takes precedence."
-          weight: 1
+          weight: 2
       - R2.3:
           text: "-n or --no-clobber must not overwrite an existing destination file."
-          weight: 1
+          weight: 2
       - R2.4:
           text: "When the destination cannot be overwritten due to permissions, must print an error to stderr."
-          weight: 1
+          weight: 2
 
   R3:
     title: Output control and target directory
     items:
       - R3.1:
           text: "-v or --verbose must print the name of each file as it is moved, in the format 'SOURCE -> DEST' or 'renamed SOURCE -> DEST'."
-          weight: 1
+          weight: 2
       - R3.2:
           text: "-t DIRECTORY or --target-directory=DIRECTORY must move all SOURCE arguments into DIRECTORY."
-          weight: 1
+          weight: 2
       - R3.3:
           text: "-T or --no-target-directory must treat DEST as a normal file, not a directory."
-          weight: 1
+          weight: 2
 
   R4:
     title: Exit codes and differential testing
     items:
       - R4.1:
           text: Must exit 0 when all files are moved successfully.
-          weight: 1
+          weight: 2
       - R4.2:
           text: Must exit 1 when any move operation fails (permission denied, source not found).
-          weight: 1
+          weight: 2
       - R4.3:
           text: "When moving multiple files and one fails, must continue moving remaining files and exit 1."
-          weight: 1
+          weight: 2
       - R4.4:
           text: "Differential tests must compare exit codes and resulting file system state between the Go binary and the reference binary via pkg/testutils. Tests must cover: single file rename, move into directory, multi-file move, -i interactive, -f force, -n no-clobber, -v verbose, -t target directory, directory move, and error cases."
-          weight: 1
+          weight: 2
 
 non_goals:
   - cmd/mv does not implement --backup (make backups of existing destination files).

--- a/docs/specs/product-requirements/prd058-rm.yaml
+++ b/docs/specs/product-requirements/prd058-rm.yaml
@@ -20,64 +20,64 @@ requirements:
     items:
       - R1.1:
           text: "When given one or more FILE arguments, must remove each file using unlink(2)."
-          weight: 1
+          weight: 2
       - R1.2:
           text: "Without -r, must refuse to remove a directory and print an error to stderr."
-          weight: 1
+          weight: 2
       - R1.3:
           text: "Must not remove '.' or '..' to prevent accidental directory tree destruction. Must print an error if either is specified."
-          weight: 1
+          weight: 2
       - R1.4:
           text: "When a file cannot be removed (permission denied, in use), must print an error to stderr and continue with remaining files."
-          weight: 1
+          weight: 2
 
   R2:
     title: Recursive removal and force mode
     items:
       - R2.1:
           text: "-r or -R or --recursive must remove directories and their contents recursively."
-          weight: 1
+          weight: 2
       - R2.2:
           text: "-f or --force must ignore non-existent files and never prompt. Overrides -i and -I."
-          weight: 1
+          weight: 2
       - R2.3:
           text: "When -r and -f are combined, must silently remove directory trees without prompting."
-          weight: 1
+          weight: 2
       - R2.4:
           text: "-d or --dir must remove empty directories. Without -d or -r, directory removal fails."
-          weight: 1
+          weight: 2
 
   R3:
     title: Interactive modes and verbose output
     items:
       - R3.1:
           text: "-i must prompt before every removal."
-          weight: 1
+          weight: 2
       - R3.2:
           text: "-I must prompt once before removing more than three files or when removing recursively."
-          weight: 1
+          weight: 2
       - R3.3:
           text: "-v or --verbose must print the name of each file as it is removed."
-          weight: 1
+          weight: 2
       - R3.4:
           text: "--interactive=WHEN must control prompting. WHEN is 'never' (like -f), 'once' (like -I), or 'always' (like -i)."
-          weight: 1
+          weight: 2
 
   R4:
     title: Exit codes and differential testing
     items:
       - R4.1:
           text: Must exit 0 when all files are removed successfully.
-          weight: 1
+          weight: 2
       - R4.2:
           text: Must exit 1 when any removal fails. Must continue removing remaining files.
-          weight: 1
+          weight: 2
       - R4.3:
           text: "With -f, must exit 0 even when specified files do not exist."
-          weight: 1
+          weight: 2
       - R4.4:
           text: "Differential tests must compare exit codes and resulting file system state between the Go binary and the reference binary via pkg/testutils. Tests must cover: single file removal, multi-file removal, -r recursive, -f force on non-existent, -d empty directory, -v verbose, error on directory without -r, error on permission denied, and refusing to remove '.' or '..'."
-          weight: 1
+          weight: 2
 
 non_goals:
   - cmd/rm does not implement --one-file-system (skip directories on different filesystems during recursive removal).

--- a/docs/specs/product-requirements/prd062-touch.yaml
+++ b/docs/specs/product-requirements/prd062-touch.yaml
@@ -19,64 +19,64 @@ requirements:
     items:
       - R1.1:
           text: When given one or more FILE arguments, must update the access and modification times of each file to the current time.
-          weight: 1
+          weight: 2
       - R1.2:
           text: When a named file does not exist, must create it as an empty file with default permissions.
-          weight: 1
+          weight: 2
       - R1.3:
           text: "-c or --no-create must suppress file creation. If the file does not exist, must not create it and must not report an error."
-          weight: 1
+          weight: 2
       - R1.4:
           text: Must support multiple file arguments, processing each in order.
-          weight: 1
+          weight: 2
 
   R2:
     title: Timestamp selection and explicit times
     items:
       - R2.1:
           text: "-a must change only the access time."
-          weight: 1
+          weight: 2
       - R2.2:
           text: "-m must change only the modification time."
-          weight: 1
+          weight: 2
       - R2.3:
           text: "When neither -a nor -m is given, must change both access and modification times."
-          weight: 1
+          weight: 2
       - R2.4:
           text: "-t STAMP must use the timestamp [[CC]YY]MMDDhhmm[.ss] instead of the current time."
-          weight: 1
+          weight: 2
 
   R3:
     title: Reference file and date string
     items:
       - R3.1:
           text: "-r FILE or --reference=FILE must use the timestamps of FILE instead of the current time."
-          weight: 1
+          weight: 2
       - R3.2:
           text: "-d STRING or --date=STRING must parse the date string and use it instead of the current time."
-          weight: 1
+          weight: 2
       - R3.3:
           text: "When a reference file does not exist, must print an error to stderr and exit 1."
-          weight: 1
+          weight: 2
       - R3.4:
           text: "-h or --no-dereference must affect the symbolic link itself rather than the file it points to."
-          weight: 1
+          weight: 2
 
   R4:
     title: Exit codes and differential testing
     items:
       - R4.1:
           text: Must exit 0 when all files are processed successfully.
-          weight: 1
+          weight: 2
       - R4.2:
           text: Must exit 1 when an error occurs (invalid timestamp, missing reference file, permission denied). Must continue processing remaining files after an error.
-          weight: 1
+          weight: 2
       - R4.3:
           text: "Differential tests must compare exit codes and resulting file timestamps between the Go binary and the reference binary via pkg/testutils."
-          weight: 1
+          weight: 2
       - R4.4:
           text: "Tests must cover: create new file, update existing file, -c no-create, -a access only, -m modification only, -t explicit timestamp, -d date string, -r reference file, multiple files, and error cases (invalid timestamp, missing reference file)."
-          weight: 1
+          weight: 2
 
 non_goals:
   - cmd/touch does not implement the obsolescent -t format with two-digit years outside the [[CC]YY]MMDDhhmm[.ss] specification.

--- a/docs/specs/product-requirements/prd063-timeout.yaml
+++ b/docs/specs/product-requirements/prd063-timeout.yaml
@@ -20,64 +20,64 @@ requirements:
     items:
       - R1.1:
           text: "Must run COMMAND with optional ARGS and kill it with SIGTERM if it does not exit within DURATION seconds."
-          weight: 1
+          weight: 2
       - R1.2:
           text: Must support fractional durations (e.g., timeout 0.5 command).
-          weight: 1
+          weight: 2
       - R1.3:
           text: Must support suffix multipliers s (seconds, default), m (minutes), h (hours), d (days).
-          weight: 1
+          weight: 2
       - R1.4:
           text: "When DURATION is 0, must not impose a time limit (the command runs indefinitely)."
-          weight: 1
+          weight: 2
 
   R2:
     title: Signal selection and kill-after
     items:
       - R2.1:
           text: "-s SIGNAL or --signal=SIGNAL must send the specified signal instead of SIGTERM. Must accept signal names (e.g., KILL, HUP) and numeric signal values."
-          weight: 1
+          weight: 2
       - R2.2:
           text: "-k DURATION or --kill-after=DURATION must send SIGKILL if the command is still running DURATION seconds after the initial signal."
-          weight: 1
+          weight: 2
       - R2.3:
           text: "--foreground must not create a separate process group, allowing the command to use the terminal."
-          weight: 1
+          weight: 2
       - R2.4:
           text: "--preserve-status must exit with the same status as the command, even on timeout, instead of the timeout-specific exit code 124."
-          weight: 1
+          weight: 2
 
   R3:
     title: Exit codes
     items:
       - R3.1:
           text: "When the command exits before the timeout, must exit with the command's exit status."
-          weight: 1
+          weight: 2
       - R3.2:
           text: "When the command is killed due to timeout, must exit 124 (unless --preserve-status is given)."
-          weight: 1
+          weight: 2
       - R3.3:
           text: "When the command is killed by a signal not sent by timeout, must exit 128+signum."
-          weight: 1
+          weight: 2
       - R3.4:
           text: "When the timeout command itself fails (invalid arguments, command not found), must exit 125 for internal error or 126/127 for command execution failure."
-          weight: 1
+          weight: 2
 
   R4:
     title: Differential testing
     items:
       - R4.1:
           text: "Differential tests must compare exit codes between the Go binary and the reference binary via pkg/testutils."
-          weight: 1
+          weight: 2
       - R4.2:
           text: "Tests must cover: command completes before timeout (exit with command status), command exceeds timeout (exit 124), duration 0 (no limit), -s with named and numeric signals, -k kill-after escalation, --preserve-status, and error cases (no args, invalid duration, command not found)."
-          weight: 1
+          weight: 2
       - R4.3:
           text: "Tests must use fast commands (true, false, sleep 0) and short durations to avoid slow test execution."
-          weight: 1
+          weight: 2
       - R4.4:
           text: "Tests must verify that the timed-out process is actually killed and does not remain as an orphan."
-          weight: 1
+          weight: 2
 
 non_goals:
   - cmd/timeout does not implement --verbose or any diagnostic output beyond error messages.

--- a/docs/specs/product-requirements/prd068-csplit.yaml
+++ b/docs/specs/product-requirements/prd068-csplit.yaml
@@ -21,64 +21,64 @@ requirements:
     items:
       - R1.1:
           text: "Must accept one or more PATTERN arguments. Each pattern is applied in order to split the input at the matching boundary."
-          weight: 1
+          weight: 3
       - R1.2:
           text: "/REGEXP/ must split at the next line matching REGEXP. The matching line becomes the first line of the next piece."
-          weight: 1
+          weight: 3
       - R1.3:
           text: "%REGEXP% must skip to the next line matching REGEXP without creating an output file for the skipped content."
-          weight: 1
+          weight: 3
       - R1.4:
           text: "INTEGER must split at the given line number. The specified line becomes the first line of the next piece."
-          weight: 1
+          weight: 3
 
   R2:
     title: Repeat counts and offset
     items:
       - R2.1:
           text: "{N} appended to a pattern must repeat that pattern N additional times (total N+1 applications)."
-          weight: 1
+          weight: 3
       - R2.2:
           text: "{*} appended to a pattern must repeat that pattern as many times as possible until end of input."
-          weight: 1
+          weight: 3
       - R2.3:
           text: "/REGEXP/+N and /REGEXP/-N must split N lines after or before the matching line, respectively."
-          weight: 1
+          weight: 3
       - R2.4:
           text: When a pattern does not match, must print an error to stderr. With --suppress-matched this is not an error if at least one split occurred.
-          weight: 1
+          weight: 3
 
   R3:
     title: Output control and prefix options
     items:
       - R3.1:
           text: "Must write output files named xx00, xx01, xx02, etc. by default."
-          weight: 1
+          weight: 3
       - R3.2:
           text: "-f PREFIX or --prefix=PREFIX must use PREFIX instead of 'xx' for output filenames."
-          weight: 1
+          weight: 3
       - R3.3:
           text: "-n DIGITS or --digits=DIGITS must use DIGITS-wide numeric suffixes (default 2)."
-          weight: 1
+          weight: 3
       - R3.4:
           text: "-z or --elide-empty-files must suppress creation of empty output files."
-          weight: 1
+          weight: 3
 
   R4:
     title: Exit codes and differential testing
     items:
       - R4.1:
           text: Must exit 0 when the input is split successfully.
-          weight: 1
+          weight: 3
       - R4.2:
           text: Must exit 1 when a pattern fails to match (unless suppressed) or an invalid option is given.
-          weight: 1
+          weight: 3
       - R4.3:
           text: "Differential tests must compare output file contents and exit codes between the Go binary and the reference binary via pkg/testutils."
-          weight: 1
+          weight: 3
       - R4.4:
           text: "Tests must cover: regex split, line number split, skip patterns (%), repeat counts ({N} and {*}), offset (+N/-N), -f custom prefix, -n digit width, -z elide empty, stdin input, and error cases (no match, invalid regex)."
-          weight: 1
+          weight: 3
 
 non_goals:
   - cmd/csplit does not implement --suppress-matched beyond the basic behavior.

--- a/docs/specs/product-requirements/prd070-fmt.yaml
+++ b/docs/specs/product-requirements/prd070-fmt.yaml
@@ -20,32 +20,32 @@ requirements:
     items:
       - R1.1:
           text: When invoked with no options, must reformat each paragraph of input text to fit within 75 characters (the GNU default width).
-          weight: 1
+          weight: 2
       - R1.2:
           text: Must treat blank lines as paragraph separators. Must not merge text across blank lines.
-          weight: 1
+          weight: 2
       - R1.3:
           text: Must preserve the indentation of the first line of each paragraph. Subsequent lines in the same paragraph are filled to match the second line's indentation (or the first if only one line).
-          weight: 1
+          weight: 2
       - R1.4:
           text: When given one or more FILE arguments, must read and format each file in order. When no file is given or "-" is given, must read from stdin.
-          weight: 1
+          weight: 2
 
   R2:
     title: Width control and goal width
     items:
       - R2.1:
           text: "-w WIDTH or --width=WIDTH must set the maximum line width (default 75)."
-          weight: 1
+          weight: 2
       - R2.2:
           text: "-g GOAL or --goal=GOAL must set the goal line width. Lines are filled to approximately GOAL characters. Default goal is 93% of width."
-          weight: 1
+          weight: 2
       - R2.3:
           text: Must break lines at word boundaries (spaces). Must not break in the middle of a word unless the word exceeds the maximum width.
-          weight: 1
+          weight: 2
       - R2.4:
           text: Must collapse multiple spaces between words to a single space, except after sentence-ending punctuation (. ! ?) where two spaces are preserved.
-          weight: 1
+          weight: 2
 
   R3:
     title: Split-only and uniform-spacing modes

--- a/docs/specs/product-requirements/prd071-numfmt.yaml
+++ b/docs/specs/product-requirements/prd071-numfmt.yaml
@@ -22,64 +22,64 @@ requirements:
     items:
       - R1.1:
           text: "When given --to=UNIT, must convert each input number to a human-readable string with the appropriate suffix. UNIT is one of: si (powers of 1000), iec (powers of 1024), iec-i (powers of 1024 with 'i' suffix), or none."
-          weight: 1
+          weight: 3
       - R1.2:
           text: "When given --from=UNIT, must interpret each input number as a human-readable string with suffixes and convert to a raw number. UNIT values are the same as --to."
-          weight: 1
+          weight: 3
       - R1.3:
           text: When neither --from nor --to is given, must pass numbers through unchanged.
-          weight: 1
+          weight: 3
       - R1.4:
           text: Must read numbers from stdin (one per line) when no operands are given, or process command-line operands directly.
-          weight: 1
+          weight: 3
 
   R2:
     title: Format control
     items:
       - R2.1:
           text: "--format=FORMAT must use a printf-style format string for output (e.g., '%10f', '%.2f'). Must support width, precision, and left-alignment."
-          weight: 1
+          weight: 3
       - R2.2:
           text: "--padding=N must pad the output to N characters. Positive N right-aligns; negative N left-aligns."
-          weight: 1
+          weight: 3
       - R2.3:
           text: "--round=METHOD must control rounding: up (ceiling), down (floor), from-zero (away from zero), towards-zero (truncation), or nearest (default)."
-          weight: 1
+          weight: 3
       - R2.4:
           text: "--suffix=SUFFIX must append SUFFIX to the output after the numeric value and any unit suffix."
-          weight: 1
+          weight: 3
 
   R3:
     title: Field selection and header
     items:
       - R3.1:
           text: "--field=FIELDS must convert only the specified fields (1-indexed, comma-separated ranges like cut). Other fields are passed through unchanged."
-          weight: 1
+          weight: 3
       - R3.2:
           text: "-d DELIM or --delimiter=DELIM must use DELIM as the field delimiter for --field processing."
-          weight: 1
+          weight: 3
       - R3.3:
           text: "--header[=N] must pass through the first N lines (default 1) without conversion, treating them as headers."
-          weight: 1
+          weight: 3
       - R3.4:
           text: "--to-unit=N must scale the output by dividing by N before applying --to conversion. --from-unit=N must scale the input by multiplying by N before applying --from conversion."
-          weight: 1
+          weight: 3
 
   R4:
     title: Exit codes and differential testing
     items:
       - R4.1:
           text: Must exit 0 when all conversions complete successfully.
-          weight: 1
+          weight: 3
       - R4.2:
           text: Must exit 2 when an invalid number is encountered (unless --invalid=ignore or --invalid=warn is set).
-          weight: 1
+          weight: 3
       - R4.3:
           text: "Differential tests must compare stdout and exit codes between the Go binary and the reference binary via pkg/testutils."
-          weight: 1
+          weight: 3
       - R4.4:
           text: "Tests must cover: --to si/iec/iec-i, --from si/iec, --format with width and precision, --padding, --round modes, --suffix, --field selection, --delimiter, --header, --to-unit/--from-unit, stdin and operand input, and error cases (invalid number, unknown suffix)."
-          weight: 1
+          weight: 3
 
 non_goals:
   - cmd/numfmt does not implement locale-aware digit grouping (e.g., thousands separators).

--- a/docs/specs/product-requirements/prd073-printf.yaml
+++ b/docs/specs/product-requirements/prd073-printf.yaml
@@ -21,64 +21,64 @@ requirements:
     items:
       - R1.1:
           text: "Must interpret FORMAT as a printf-style format string containing literal text and conversion specifiers. Must print the formatted result to stdout with no trailing newline unless the format includes \\n."
-          weight: 1
+          weight: 2
       - R1.2:
           text: "Must support integer conversion specifiers: %d (signed decimal), %i (signed decimal), %o (octal), %u (unsigned decimal), %x (lowercase hex), %X (uppercase hex)."
-          weight: 1
+          weight: 2
       - R1.3:
           text: "Must support floating-point conversion specifiers: %f (decimal notation), %e (scientific notation), %g (shorter of %f and %e), and their uppercase variants %F, %E, %G."
-          weight: 1
+          weight: 2
       - R1.4:
           text: "Must support string conversion specifier %s and character conversion specifier %c. %b must interpret backslash escapes in the argument string (like echo -e)."
-          weight: 1
+          weight: 2
 
   R2:
     title: Width, precision, and flags
     items:
       - R2.1:
           text: "Must support field width and precision in conversion specifiers (e.g., %10d, %.5f, %10.3f). Width specifies minimum field width; precision specifies digits after decimal for floats or maximum characters for strings."
-          weight: 1
+          weight: 2
       - R2.2:
           text: "Must support flag characters: '-' (left-align), '+' (always show sign), ' ' (space before positive numbers), '0' (zero-pad), '#' (alternate form)."
-          weight: 1
+          weight: 2
       - R2.3:
           text: "Must support '*' for width and precision, taking the value from the next argument."
-          weight: 1
+          weight: 2
       - R2.4:
           text: "Must support '%%' as a literal percent character in the format string."
-          weight: 1
+          weight: 2
 
   R3:
     title: Escape sequences and argument handling
     items:
       - R3.1:
           text: "Must interpret C-style escape sequences in FORMAT: \\\\, \\a, \\b, \\f, \\n, \\r, \\t, \\v, \\NNN (octal), \\xHH (hex), \\uHHHH (Unicode), \\UHHHHHHHH (Unicode)."
-          weight: 1
+          weight: 2
       - R3.2:
           text: "When more arguments remain than the format consumes, must reuse the format string for the remaining arguments, repeating until all arguments are consumed."
-          weight: 1
+          weight: 2
       - R3.3:
           text: "When fewer arguments are provided than the format requires, must use 0 for numeric specifiers and empty string for string specifiers."
-          weight: 1
+          weight: 2
       - R3.4:
           text: "When a numeric argument starts with a single or double quote (e.g., '\"A' or \"'A\"), must use the numeric value of the character that follows the quote."
-          weight: 1
+          weight: 2
 
   R4:
     title: Exit codes and differential testing
     items:
       - R4.1:
           text: Must exit 0 when formatting and printing complete successfully.
-          weight: 1
+          weight: 2
       - R4.2:
           text: Must exit 1 when an invalid format directive is encountered or a numeric conversion fails. Must still produce partial output before the error.
-          weight: 1
+          weight: 2
       - R4.3:
           text: "Differential tests must compare stdout and exit codes between the Go binary and the reference binary via pkg/testutils."
-          weight: 1
+          weight: 2
       - R4.4:
           text: "Tests must cover: %d/%i/%o/%u/%x/%X integer formats, %f/%e/%g float formats, %s string, %c character, %b backslash-interpreted string, width and precision, all flag characters, '*' width/precision, argument recycling, escape sequences (\\n, \\t, \\NNN, \\xHH), character value arguments (quote prefix), missing arguments, and error cases (invalid format, non-numeric argument for %d)."
-          weight: 1
+          weight: 2
 
 non_goals:
   - cmd/printf does not implement %q (shell-escaped string) which is a bash extension not in GNU coreutils printf.


### PR DESCRIPTION
## Summary

Increases requirement weights for 15 PRDs whose stitch tasks averaged 5+ minutes in run 37. The 41 tasks in the 8-15m range consumed 28% of stitch cost; higher weights will cause the measure agent to batch fewer requirements per task, reducing timeout risk.

## Changes

- **Weight 3**: prd071-numfmt (11.0m avg), prd068-csplit (10.2m avg)
- **Weight 2**: prd008-ls, prd019-seq, prd022-nl, prd037-ln, prd053-sort, prd054-tr, prd056-cp, prd057-mv, prd058-rm, prd062-touch, prd063-timeout, prd070-fmt (R1-R2 only), prd073-printf
- 15 files, 271 items updated, no requirement text changed

## Stats

- PRD words: unchanged (only weight values changed)
- Go LOC: 0 (spec-only change)

## Test plan

- [x] `mage analyze` — schema 0 errors, semantic 0 errors, broken citations 0
- [x] Spot-checked weight values in numfmt (3), fmt (R1-R2=2, R3=2, R4=3, R5=1), ls (2)

Closes #3138