### PR TITLE
GH-3140: prd072-od: increase weights and remove from rel99.0

### DIFF
--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -257,17 +257,6 @@ releases:
           status: spec_complete
         - id: rel05.4-uc004-sha512sum
           status: spec_complete
-    - version: "99.0"
-      name: "Deferred — items that could not complete in run 37"
-      status: spec_complete
-      depends_on: ["00.0"]
-      description: |
-        Deferred items from run 37 that could not complete due to stitch timeouts
-        or rate limits. prd072-od: rate-limited out of every attempt.
-        See cobbler-scaffold#1805.
-      use_cases:
-        - id: rel99.0-uc002-od
-          status: spec_complete
     - version: "06.0"
       name: "Batch 6.0 — file/directory creation and removal (mkdir, rmdir, mktemp, ln, unlink)"
       status: spec_complete
@@ -400,6 +389,6 @@ releases:
         - id: rel08.1-uc005-numfmt
           status: spec_complete
         - id: rel08.1-uc006-od
-          status: code_complete  # deferred to rel99.0, rate-limited in run 37
+          status: spec_complete
         - id: rel08.1-uc007-printf
           status: spec_complete

--- a/docs/specs/product-requirements/prd072-od.yaml
+++ b/docs/specs/product-requirements/prd072-od.yaml
@@ -20,16 +20,16 @@ requirements:
     items:
       - R1.1:
           text: "When invoked with no type options, must display input in the default format: octal 2-byte words (equivalent to -t o2), with an octal address offset in the left column."
-          weight: 1
+          weight: 2
       - R1.2:
           text: "-t TYPE or --format=TYPE must display input in the given format. TYPE consists of a format letter (a for named characters, c for C-style characters, d for signed decimal, f for floating point, o for octal, u for unsigned decimal, x for hexadecimal) optionally followed by a size in bytes."
-          weight: 1
+          weight: 2
       - R1.3:
           text: Multiple -t options may be given; each produces an additional line of output per input block.
-          weight: 1
+          weight: 2
       - R1.4:
           text: Must read from FILE arguments in order, or from stdin when no file is given or "-" is specified.
-          weight: 1
+          weight: 2
 
   R2:
     title: Address format and byte range
@@ -52,16 +52,16 @@ requirements:
     items:
       - R3.1:
           text: "-w[N] or --width[=N] must set the number of input bytes per output line (default 16). When -w is given without a value, must use 32."
-          weight: 1
+          weight: 2
       - R3.2:
           text: Must support traditional short options as aliases for type specifiers. -b is equivalent to -t o1, -c is -t c, -d is -t u2, -o is -t o2, -s is -t d2, -x is -t x2.
-          weight: 1
+          weight: 2
       - R3.3:
           text: "Duplicate bytes in multi-line output must be replaced with '*' on a line by itself to indicate repetition, matching GNU od behavior."
-          weight: 1
+          weight: 2
       - R3.4:
           text: "-v or --output-duplicates must print all input data, disabling the '*' duplicate suppression."
-          weight: 1
+          weight: 2
 
   R4:
     title: Exit codes and differential testing


### PR DESCRIPTION
## Summary

Increases requirement weights for prd072-od R1 and R3 to weight 2 (format parsing and output formatting complexity). Removes od from rel99.0 since the rate limit fix landed in cobbler-scaffold#1805. Deletes the now-empty rel99.0 release.

## Changes

- `prd072-od.yaml`: R1.1-R1.4 and R3.1-R3.4 weight 1→2
- `road-map.yaml`: removed rel99.0 (empty), reset rel08.1 od to spec_complete

## Test plan

- [x] `mage analyze` — 0 errors, 0 broken citations

Closes #3140