### PR TITLE
GH-1405: Specify rel09.0 — sha224sum, sha384sum, b2sum, cksum, sum

### DIFF
--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -392,3 +392,25 @@ releases:
           status: spec_complete
         - id: rel08.1-uc007-printf
           status: spec_complete
+    - version: "09.0"
+      name: "Batch 9.0 — hash and checksum utilities (sha224sum, sha384sum, b2sum, cksum, sum)"
+      status: spec_complete
+      depends_on: ["00.0"]
+      description: |
+        Implement five checksum and hash utilities. sha224sum and sha384sum complete the
+        SHA-2 family alongside the existing sha256sum and sha512sum. b2sum adds BLAKE2b
+        support with variable-length digests. cksum computes POSIX CRC-32 checksums with
+        optional algorithm selection for modern hashes. sum computes BSD or System V
+        checksums. All are verified by differential testing against GNU coreutils reference
+        binaries.
+      use_cases:
+        - id: rel09.0-uc001-sha224sum
+          status: spec_complete
+        - id: rel09.0-uc002-sha384sum
+          status: spec_complete
+        - id: rel09.0-uc003-b2sum
+          status: spec_complete
+        - id: rel09.0-uc004-cksum
+          status: spec_complete
+        - id: rel09.0-uc005-sum
+          status: spec_complete

--- a/docs/specs/product-requirements/prd074-sha224sum.yaml
+++ b/docs/specs/product-requirements/prd074-sha224sum.yaml
@@ -1,0 +1,121 @@
+id: prd074-sha224sum
+title: "cmd/sha224sum: Compute and Check SHA-224 Message Digests"
+
+problem: |
+  macOS ships shasum -a 224 rather than sha224sum; the invocation differs from GNU
+  sha224sum. Scripts that generate or verify SHA-224 checksums using the GNU format
+  must use the Homebrew reference binary. The Go implementation must match the Homebrew
+  GNU reference binary (gsha224sum, installed by coreutils) byte-for-byte on all flag
+  combinations, using crypto/sha256 (sha256.New224) from the Go standard library,
+  verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Compute SHA-224 digests for one or more files or stdin and print them in GNU format, matching gsha224sum behavior.
+  - G2: Support --check (-c) to verify a checksum file and report mismatches.
+  - G3: Support --binary (-b), --text (-t), and --tag output format flags.
+
+requirements:
+  R1:
+    title: Digest computation
+    items:
+      - R1.1:
+          text: Must compute the SHA-224 digest of each named file and write one line per file in the format "HASH  FILENAME" (text mode) or "HASH *FILENAME" (binary mode). The default is text mode.
+          weight: 1
+      - R1.2:
+          text: Must read from stdin and print "HASH  -" when no file arguments are given or when "-" is provided as a filename.
+          weight: 1
+      - R1.3:
+          text: --tag must use BSD-style output format "SHA224 (FILENAME) = HASH".
+          weight: 1
+      - R1.4:
+          text: Must exit 1 when any named file cannot be opened, printing an error to stderr, and continue processing remaining files.
+          weight: 1
+
+  R2:
+    title: Checksum verification (--check, -c)
+    items:
+      - R2.1:
+          text: "--check FILE must read FILE, parse each line (GNU or BSD tag format), recompute the SHA-224 digest, and compare to the stored hash."
+          weight: 1
+      - R2.2:
+          text: 'Must print "FILENAME: OK" or "FILENAME: FAILED" for each entry. Must exit 1 if any check fails.'
+          weight: 1
+      - R2.3:
+          text: --warn prints a warning for each malformed line. --quiet suppresses OK lines. --status suppresses all output.
+          weight: 1
+
+  R3:
+    title: Binary and text mode flags
+    items:
+      - R3.1:
+          text: -b marks input as binary; output uses "HASH *FILENAME". -t (default) uses "HASH  FILENAME".
+          weight: 1
+      - R3.2:
+          text: --tag produces BSD tag format regardless of -b/-t.
+          weight: 1
+
+  R4:
+    title: Exit codes and SIGPIPE
+    items:
+      - R4.1:
+          text: Must exit 0 when all files are processed and all verified digests match.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any file cannot be opened, any digest fails, or the checksum file is unreadable.
+          weight: 1
+      - R4.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/sha224sum does not implement HMAC-SHA224 or keyed variants.
+  - cmd/sha224sum does not implement SHA-256; it computes SHA-224 only.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "sha224sum on a known file produces the correct SHA-224 hash in GNU format, matching gsha224sum."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+  - id: AC2
+    criterion: "sha224sum --check on a valid checksum file exits 0 and prints 'FILENAME: OK' for each entry."
+    traces:
+      - R1.4
+      - R2.1
+      - R2.2
+      - R4.1
+      - R4.2
+      - R4.3
+  - id: AC3
+    criterion: "sha224sum --check on a file with a mismatch exits 1 and prints 'FILENAME: FAILED'."
+    traces:
+      - R1.4
+      - R2.1
+      - R2.2
+      - R4.1
+      - R4.2
+      - R4.3
+  - id: AC4
+    criterion: "Differential test against gsha224sum passes for all required test cases."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+  - id: AC5
+    criterion: "cmd/sha224sum compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R3.1
+      - R3.2
+      - R4.1
+      - R4.2
+      - R4.3

--- a/docs/specs/product-requirements/prd075-sha384sum.yaml
+++ b/docs/specs/product-requirements/prd075-sha384sum.yaml
@@ -1,0 +1,121 @@
+id: prd075-sha384sum
+title: "cmd/sha384sum: Compute and Check SHA-384 Message Digests"
+
+problem: |
+  macOS ships shasum -a 384 rather than sha384sum; the invocation differs from GNU
+  sha384sum. Scripts that generate or verify SHA-384 checksums using the GNU format
+  must use the Homebrew reference binary. The Go implementation must match the Homebrew
+  GNU reference binary (gsha384sum, installed by coreutils) byte-for-byte on all flag
+  combinations, using crypto/sha512 (sha512.New384) from the Go standard library,
+  verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Compute SHA-384 digests for one or more files or stdin and print them in GNU format, matching gsha384sum behavior.
+  - G2: Support --check (-c) to verify a checksum file and report mismatches.
+  - G3: Support --binary (-b), --text (-t), and --tag output format flags.
+
+requirements:
+  R1:
+    title: Digest computation
+    items:
+      - R1.1:
+          text: Must compute the SHA-384 digest of each named file and write one line per file in the format "HASH  FILENAME" (text mode) or "HASH *FILENAME" (binary mode). The default is text mode.
+          weight: 1
+      - R1.2:
+          text: Must read from stdin and print "HASH  -" when no file arguments are given or when "-" is provided as a filename.
+          weight: 1
+      - R1.3:
+          text: --tag must use BSD-style output format "SHA384 (FILENAME) = HASH".
+          weight: 1
+      - R1.4:
+          text: Must exit 1 when any named file cannot be opened, printing an error to stderr, and continue processing remaining files.
+          weight: 1
+
+  R2:
+    title: Checksum verification (--check, -c)
+    items:
+      - R2.1:
+          text: "--check FILE must read FILE, parse each line (GNU or BSD tag format), recompute the SHA-384 digest, and compare to the stored hash."
+          weight: 1
+      - R2.2:
+          text: 'Must print "FILENAME: OK" or "FILENAME: FAILED" for each entry. Must exit 1 if any check fails.'
+          weight: 1
+      - R2.3:
+          text: --warn prints a warning for each malformed line. --quiet suppresses OK lines. --status suppresses all output.
+          weight: 1
+
+  R3:
+    title: Binary and text mode flags
+    items:
+      - R3.1:
+          text: -b marks input as binary; output uses "HASH *FILENAME". -t (default) uses "HASH  FILENAME".
+          weight: 1
+      - R3.2:
+          text: --tag produces BSD tag format regardless of -b/-t.
+          weight: 1
+
+  R4:
+    title: Exit codes and SIGPIPE
+    items:
+      - R4.1:
+          text: Must exit 0 when all files are processed and all verified digests match.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any file cannot be opened, any digest fails, or the checksum file is unreadable.
+          weight: 1
+      - R4.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/sha384sum does not implement HMAC-SHA384 or keyed variants.
+  - cmd/sha384sum does not implement SHA-512; it computes SHA-384 only.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "sha384sum on a known file produces the correct SHA-384 hash in GNU format, matching gsha384sum."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+  - id: AC2
+    criterion: "sha384sum --check on a valid checksum file exits 0 and prints 'FILENAME: OK' for each entry."
+    traces:
+      - R1.4
+      - R2.1
+      - R2.2
+      - R4.1
+      - R4.2
+      - R4.3
+  - id: AC3
+    criterion: "sha384sum --check on a file with a mismatch exits 1 and prints 'FILENAME: FAILED'."
+    traces:
+      - R1.4
+      - R2.1
+      - R2.2
+      - R4.1
+      - R4.2
+      - R4.3
+  - id: AC4
+    criterion: "Differential test against gsha384sum passes for all required test cases."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+  - id: AC5
+    criterion: "cmd/sha384sum compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R3.1
+      - R3.2
+      - R4.1
+      - R4.2
+      - R4.3

--- a/docs/specs/product-requirements/prd076-b2sum.yaml
+++ b/docs/specs/product-requirements/prd076-b2sum.yaml
@@ -1,0 +1,128 @@
+id: prd076-b2sum
+title: "cmd/b2sum: Compute and Check BLAKE2 Message Digests"
+
+problem: |
+  macOS does not ship b2sum. Scripts that generate or verify BLAKE2 checksums using
+  the GNU b2sum format must use the Homebrew reference binary. The Go implementation
+  must match the Homebrew GNU reference binary (gb2sum, installed by coreutils)
+  byte-for-byte on all flag combinations, using golang.org/x/crypto/blake2b, verified
+  by differential testing via pkg/testutils.
+
+goals:
+  - G1: Compute BLAKE2b digests for one or more files or stdin and print them in GNU format, matching gb2sum behavior.
+  - G2: Support --check (-c) to verify a checksum file and report mismatches.
+  - G3: Support --binary (-b), --text (-t), --tag output format, and --length for variable digest length.
+
+requirements:
+  R1:
+    title: Digest computation
+    items:
+      - R1.1:
+          text: Must compute the BLAKE2b-512 digest of each named file and write one line per file in the format "HASH  FILENAME" (text mode) or "HASH *FILENAME" (binary mode). The default is text mode.
+          weight: 1
+      - R1.2:
+          text: Must read from stdin and print "HASH  -" when no file arguments are given or when "-" is provided as a filename.
+          weight: 1
+      - R1.3:
+          text: --tag must use BSD-style output format "BLAKE2b (FILENAME) = HASH". When --length is specified, the tag name must include the bit length (e.g., "BLAKE2b-256").
+          weight: 1
+      - R1.4:
+          text: Must exit 1 when any named file cannot be opened, printing an error to stderr, and continue processing remaining files.
+          weight: 1
+
+  R2:
+    title: Checksum verification (--check, -c)
+    items:
+      - R2.1:
+          text: "--check FILE must read FILE, parse each line (GNU or BSD tag format), recompute the BLAKE2b digest, and compare to the stored hash."
+          weight: 1
+      - R2.2:
+          text: 'Must print "FILENAME: OK" or "FILENAME: FAILED" for each entry. Must exit 1 if any check fails.'
+          weight: 1
+      - R2.3:
+          text: --warn prints a warning for each malformed line. --quiet suppresses OK lines. --status suppresses all output.
+          weight: 1
+
+  R3:
+    title: Output format and digest length
+    items:
+      - R3.1:
+          text: -b marks input as binary; output uses "HASH *FILENAME". -t (default) uses "HASH  FILENAME".
+          weight: 1
+      - R3.2:
+          text: --tag produces BSD tag format regardless of -b/-t.
+          weight: 1
+      - R3.3:
+          text: "--length=N sets the digest length in bits. N must be a positive multiple of 8 and at most 512. Default is 512. Must exit 1 with an error message if N is invalid."
+          weight: 4
+
+  R4:
+    title: Exit codes and SIGPIPE
+    items:
+      - R4.1:
+          text: Must exit 0 when all files are processed and all verified digests match.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any file cannot be opened, any digest fails, or the checksum file is unreadable.
+          weight: 1
+      - R4.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/b2sum does not implement BLAKE2s; it computes BLAKE2b only.
+  - cmd/b2sum does not implement keyed hashing or BLAKE2 MAC mode.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "b2sum on a known file produces the correct BLAKE2b-512 hash in GNU format, matching gb2sum."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+  - id: AC2
+    criterion: "b2sum --check on a valid checksum file exits 0 and prints 'FILENAME: OK' for each entry."
+    traces:
+      - R1.4
+      - R2.1
+      - R2.2
+      - R4.1
+      - R4.2
+      - R4.3
+  - id: AC3
+    criterion: "b2sum --check on a file with a mismatch exits 1 and prints 'FILENAME: FAILED'."
+    traces:
+      - R1.4
+      - R2.1
+      - R2.2
+      - R4.1
+      - R4.2
+      - R4.3
+  - id: AC4
+    criterion: "b2sum --length=256 produces a 64-character hex digest, matching gb2sum --length=256."
+    traces:
+      - R3.3
+  - id: AC5
+    criterion: "Differential test against gb2sum passes for all required test cases."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+  - id: AC6
+    criterion: "cmd/b2sum compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R3.1
+      - R3.2
+      - R3.3
+      - R4.1
+      - R4.2
+      - R4.3

--- a/docs/specs/product-requirements/prd077-cksum.yaml
+++ b/docs/specs/product-requirements/prd077-cksum.yaml
@@ -1,0 +1,97 @@
+id: prd077-cksum
+title: "cmd/cksum: Print CRC Checksum and Byte Count"
+
+problem: |
+  macOS ships a BSD cksum that differs from GNU cksum in algorithm selection and output
+  format options. GNU cksum supports CRC-32 (POSIX default), as well as modern hash
+  algorithms via --algorithm. The Go implementation must match the Homebrew GNU reference
+  binary (gcksum, installed by coreutils) byte-for-byte on all flag combinations,
+  verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Compute CRC-32 checksums and byte counts for files or stdin in POSIX format.
+  - G2: Support --algorithm flag for alternate digest algorithms (sm3, blake2b, sha1, sha224, sha256, sha384, sha512).
+  - G3: Support --untagged and --raw output format control.
+  - G4: Verify functional parity against gcksum via differential testing.
+
+requirements:
+  R1:
+    title: Default CRC checksum
+    items:
+      - R1.1:
+          text: Must compute the POSIX CRC-32 checksum of each named file and print one line per file in the format "CHECKSUM BYTES FILENAME".
+          weight: 4
+      - R1.2:
+          text: Must read from stdin when no file arguments are given. Stdin output omits the filename.
+          weight: 1
+      - R1.3:
+          text: Must process multiple files in argument order, printing one line per file.
+          weight: 1
+      - R1.4:
+          text: Must exit 1 when any named file cannot be opened, printing an error to stderr, and continue processing remaining files.
+          weight: 1
+
+  R2:
+    title: Algorithm selection and output format
+    items:
+      - R2.1:
+          text: "--algorithm=ALG selects the digest algorithm. Supported values: crc (default), sm3, blake2b, sha1, sha224, sha256, sha384, sha512. Non-CRC algorithms produce tagged output by default (e.g., 'SHA256 (file) = HASH')."
+          weight: 4
+      - R2.2:
+          text: "--untagged produces traditional GNU hash output ('HASH  FILENAME') instead of tagged BSD format when used with non-CRC algorithms."
+          weight: 1
+      - R2.3:
+          text: "--raw outputs the raw binary digest instead of hex-encoded text. Only valid with non-CRC algorithms."
+          weight: 1
+
+  R3:
+    title: Exit codes and SIGPIPE
+    items:
+      - R3.1:
+          text: Must exit 0 when all files are processed successfully.
+          weight: 1
+      - R3.2:
+          text: Must exit 1 when any file cannot be opened or an invalid algorithm is specified.
+          weight: 1
+      - R3.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/cksum does not implement --check mode for CRC verification (GNU cksum supports --check only for non-CRC algorithms).
+  - cmd/cksum does not implement --base64 encoding.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "cksum on a known file produces the correct CRC checksum and byte count, matching gcksum."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+  - id: AC2
+    criterion: "cksum --algorithm=sha256 on a file produces tagged SHA-256 output, matching gcksum --algorithm=sha256."
+    traces:
+      - R2.1
+      - R2.2
+  - id: AC3
+    criterion: "Differential test against gcksum passes for all required test cases."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+  - id: AC4
+    criterion: "cmd/cksum compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R3.1
+      - R3.2
+      - R3.3

--- a/docs/specs/product-requirements/prd078-sum.yaml
+++ b/docs/specs/product-requirements/prd078-sum.yaml
@@ -1,0 +1,92 @@
+id: prd078-sum
+title: "cmd/sum: Checksum and Count Blocks in a File"
+
+problem: |
+  macOS ships a BSD sum that differs from GNU sum in default algorithm and output format.
+  GNU sum supports two algorithms: BSD (default, -r) and System V (-s). The Go
+  implementation must match the Homebrew GNU reference binary (gsum, installed by
+  coreutils) byte-for-byte on all flag combinations, verified by differential testing
+  via pkg/testutils.
+
+goals:
+  - G1: Compute a checksum and block count for files or stdin.
+  - G2: Support BSD (-r, default) and System V (-s) checksum algorithms.
+  - G3: Verify functional parity against gsum via differential testing.
+
+requirements:
+  R1:
+    title: Default checksum computation
+    items:
+      - R1.1:
+          text: Must compute the BSD checksum (16-bit rotating checksum) of each named file by default and print "CHECKSUM BLOCKS FILENAME". Block size is 1024 bytes.
+          weight: 4
+      - R1.2:
+          text: Must read from stdin when no file arguments are given. Stdin output omits the filename.
+          weight: 1
+      - R1.3:
+          text: Must process multiple files in argument order, printing one line per file.
+          weight: 1
+      - R1.4:
+          text: Must exit 1 when any named file cannot be opened, printing an error to stderr, and continue processing remaining files.
+          weight: 1
+
+  R2:
+    title: Algorithm selection
+    items:
+      - R2.1:
+          text: -r selects the BSD checksum algorithm (default). The checksum is a 16-bit rotating checksum, block size 1024 bytes.
+          weight: 1
+      - R2.2:
+          text: -s selects the System V checksum algorithm. The checksum is a 16-bit sum of all bytes, block size 512 bytes. Output format is "CHECKSUM BLOCKS FILENAME".
+          weight: 4
+
+  R3:
+    title: Exit codes and SIGPIPE
+    items:
+      - R3.1:
+          text: Must exit 0 when all files are processed successfully.
+          weight: 1
+      - R3.2:
+          text: Must exit 1 when any file cannot be opened.
+          weight: 1
+      - R3.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/sum does not implement any modern hash algorithms; use sha256sum or cksum --algorithm for that.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "sum on a known file produces the correct BSD checksum and block count, matching gsum."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+  - id: AC2
+    criterion: "sum -s on a file produces the System V checksum and block count, matching gsum -s."
+    traces:
+      - R2.1
+      - R2.2
+  - id: AC3
+    criterion: "Differential test against gsum passes for all required test cases."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+  - id: AC4
+    criterion: "cmd/sum compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R3.1
+      - R3.2
+      - R3.3

--- a/docs/specs/test-suites/test-rel-09.0.yaml
+++ b/docs/specs/test-suites/test-rel-09.0.yaml
@@ -1,0 +1,307 @@
+id: test-rel09.0
+title: "Test Suite: rel09.0 — sha224sum, sha384sum, b2sum, cksum, sum"
+release: rel09.0
+
+traces:
+  - rel09.0-uc001-sha224sum
+  - rel09.0-uc002-sha384sum
+  - rel09.0-uc003-b2sum
+  - rel09.0-uc004-cksum
+  - rel09.0-uc005-sum
+  - prd074-sha224sum R1
+  - prd074-sha224sum R2
+  - prd074-sha224sum R3
+  - prd074-sha224sum R4
+  - prd075-sha384sum R1
+  - prd075-sha384sum R2
+  - prd075-sha384sum R3
+  - prd075-sha384sum R4
+  - prd076-b2sum R1
+  - prd076-b2sum R2
+  - prd076-b2sum R3
+  - prd076-b2sum R4
+  - prd077-cksum R1
+  - prd077-cksum R2
+  - prd077-cksum R3
+  - prd078-sum R1
+  - prd078-sum R2
+  - prd078-sum R3
+
+preconditions:
+  - "Go binary for each utility is built via go build -o bin/<name> ./cmd/<name>/"
+  - "Reference binaries installed via Homebrew: gsha224sum, gsha384sum, gb2sum, gcksum, gsum (coreutils package)"
+  - "Tests use LC_ALL=C for deterministic output"
+
+test_cases:
+
+  # ---- sha224sum ----
+
+  - name: sha224sum_compute_stdin
+    description: "sha224sum on stdin produces SHA-224 hash in GNU text format"
+    inputs:
+      args: []
+      stdin: "hello\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd074-sha224sum R1.1
+      - prd074-sha224sum R1.2
+
+  - name: sha224sum_compute_file
+    description: "sha224sum on a named file produces correct hash and filename"
+    inputs:
+      args: ["hello.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd074-sha224sum R1.1
+
+  - name: sha224sum_check_valid
+    description: "sha224sum --check with correct checksums exits 0 and prints OK"
+    inputs:
+      args: ["--check", "sums.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd074-sha224sum R2.1
+      - prd074-sha224sum R2.2
+
+  - name: sha224sum_tag_format
+    description: "sha224sum --tag produces BSD-style tagged output"
+    inputs:
+      args: ["--tag"]
+      stdin: "hello\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd074-sha224sum R1.3
+
+  # ---- sha384sum ----
+
+  - name: sha384sum_compute_stdin
+    description: "sha384sum on stdin produces SHA-384 hash in GNU text format"
+    inputs:
+      args: []
+      stdin: "hello\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd075-sha384sum R1.1
+      - prd075-sha384sum R1.2
+
+  - name: sha384sum_compute_file
+    description: "sha384sum on a named file produces correct hash and filename"
+    inputs:
+      args: ["hello.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd075-sha384sum R1.1
+
+  - name: sha384sum_check_valid
+    description: "sha384sum --check with correct checksums exits 0 and prints OK"
+    inputs:
+      args: ["--check", "sums.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd075-sha384sum R2.1
+      - prd075-sha384sum R2.2
+
+  - name: sha384sum_tag_format
+    description: "sha384sum --tag produces BSD-style tagged output"
+    inputs:
+      args: ["--tag"]
+      stdin: "hello\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd075-sha384sum R1.3
+
+  # ---- b2sum ----
+
+  - name: b2sum_compute_stdin
+    description: "b2sum on stdin produces BLAKE2b-512 hash in GNU text format"
+    inputs:
+      args: []
+      stdin: "hello\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd076-b2sum R1.1
+      - prd076-b2sum R1.2
+
+  - name: b2sum_compute_file
+    description: "b2sum on a named file produces correct hash and filename"
+    inputs:
+      args: ["hello.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd076-b2sum R1.1
+
+  - name: b2sum_length_256
+    description: "b2sum --length=256 produces a shorter hex digest"
+    inputs:
+      args: ["--length=256"]
+      stdin: "hello\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd076-b2sum R3.3
+
+  - name: b2sum_check_valid
+    description: "b2sum --check with correct checksums exits 0 and prints OK"
+    inputs:
+      args: ["--check", "sums.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd076-b2sum R2.1
+      - prd076-b2sum R2.2
+
+  # ---- cksum ----
+
+  - name: cksum_default_crc
+    description: "cksum on stdin produces CRC checksum and byte count"
+    inputs:
+      args: []
+      stdin: "hello\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd077-cksum R1.1
+      - prd077-cksum R1.2
+
+  - name: cksum_file
+    description: "cksum on a named file produces checksum, byte count, and filename"
+    inputs:
+      args: ["hello.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd077-cksum R1.1
+      - prd077-cksum R1.3
+
+  - name: cksum_algorithm_sha256
+    description: "cksum --algorithm=sha256 produces tagged SHA-256 output"
+    inputs:
+      args: ["--algorithm=sha256"]
+      stdin: "hello\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd077-cksum R2.1
+
+  # ---- sum ----
+
+  - name: sum_default_bsd
+    description: "sum on stdin produces BSD checksum and block count"
+    inputs:
+      args: []
+      stdin: "hello\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd078-sum R1.1
+      - prd078-sum R1.2
+
+  - name: sum_file
+    description: "sum on a named file produces checksum, block count, and filename"
+    inputs:
+      args: ["hello.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd078-sum R1.1
+      - prd078-sum R1.3
+
+  - name: sum_sysv
+    description: "sum -s produces System V checksum with 512-byte block count"
+    inputs:
+      args: ["-s"]
+      stdin: "hello\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd078-sum R2.2

--- a/docs/specs/use-cases/rel09.0-uc001-sha224sum.yaml
+++ b/docs/specs/use-cases/rel09.0-uc001-sha224sum.yaml
@@ -1,0 +1,53 @@
+id: rel09.0-uc001-sha224sum
+title: "Compute and verify SHA-224 digests via sha224sum"
+
+summary: |
+  The operator runs the Go sha224sum binary on one or more files or stdin. The binary
+  computes SHA-224 digests and prints them in GNU format, or verifies a checksum file.
+  The differential testing harness then runs both the Go binary and the Homebrew
+  reference binary (gsha224sum from coreutils) with identical inputs and confirms that
+  their outputs are identical byte-for-byte.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd074-sha224sum.yaml) and invokes do-work to
+  produce a passing differential test for cmd/sha224sum.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises sha224sum in digest mode (file and stdin), check mode
+      (--check), and tag mode (--tag). --check changes the processing model from digest
+      computation to verification against stored hashes.
+  - id: F2
+    step: |
+      The operator tests --check with both matching and mismatching digests to verify
+      OK/FAILED output and correct exit codes.
+  - id: F3
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/sha224sum and
+      gsha224sum with the same inputs and compares stdout byte-for-byte. Requires F1
+      (binary must be built).
+
+touchpoints:
+  - T1: "cmd/sha224sum — SHA-224 digest computation, GNU format output, check mode, binary/tag flags (prd074-sha224sum R1, R2, R3, R4)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and byte-for-byte comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for file digest, stdin digest, --check valid,
+      --check mismatch, and --tag BSD format, confirming full parity with gsha224sum.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+      - AC5
+
+out_of_scope:
+  - SHA-256 digests are not implemented by this utility.
+
+test_suite: test-rel09.0

--- a/docs/specs/use-cases/rel09.0-uc002-sha384sum.yaml
+++ b/docs/specs/use-cases/rel09.0-uc002-sha384sum.yaml
@@ -1,0 +1,53 @@
+id: rel09.0-uc002-sha384sum
+title: "Compute and verify SHA-384 digests via sha384sum"
+
+summary: |
+  The operator runs the Go sha384sum binary on one or more files or stdin. The binary
+  computes SHA-384 digests and prints them in GNU format, or verifies a checksum file.
+  The differential testing harness then runs both the Go binary and the Homebrew
+  reference binary (gsha384sum from coreutils) with identical inputs and confirms that
+  their outputs are identical byte-for-byte.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd075-sha384sum.yaml) and invokes do-work to
+  produce a passing differential test for cmd/sha384sum.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises sha384sum in digest mode (file and stdin), check mode
+      (--check), and tag mode (--tag). --check changes the processing model from digest
+      computation to verification against stored hashes.
+  - id: F2
+    step: |
+      The operator tests --check with both matching and mismatching digests to verify
+      OK/FAILED output and correct exit codes.
+  - id: F3
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/sha384sum and
+      gsha384sum with the same inputs and compares stdout byte-for-byte. Requires F1
+      (binary must be built).
+
+touchpoints:
+  - T1: "cmd/sha384sum — SHA-384 digest computation, GNU format output, check mode, binary/tag flags (prd075-sha384sum R1, R2, R3, R4)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and byte-for-byte comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for file digest, stdin digest, --check valid,
+      --check mismatch, and --tag BSD format, confirming full parity with gsha384sum.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+      - AC5
+
+out_of_scope:
+  - SHA-512 digests are not implemented by this utility.
+
+test_suite: test-rel09.0

--- a/docs/specs/use-cases/rel09.0-uc003-b2sum.yaml
+++ b/docs/specs/use-cases/rel09.0-uc003-b2sum.yaml
@@ -1,0 +1,55 @@
+id: rel09.0-uc003-b2sum
+title: "Compute and verify BLAKE2 digests via b2sum"
+
+summary: |
+  The operator runs the Go b2sum binary on one or more files or stdin. The binary
+  computes BLAKE2b digests and prints them in GNU format, or verifies a checksum file.
+  The differential testing harness then runs both the Go binary and the Homebrew
+  reference binary (gb2sum from coreutils) with identical inputs and confirms that
+  their outputs are identical byte-for-byte.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd076-b2sum.yaml) and invokes do-work to
+  produce a passing differential test for cmd/b2sum.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises b2sum in digest mode (file and stdin), check mode
+      (--check), tag mode (--tag), and variable-length mode (--length=256).
+  - id: F2
+    step: |
+      The operator tests --check with both matching and mismatching digests to verify
+      OK/FAILED output and correct exit codes.
+  - id: F3
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/b2sum and
+      gb2sum with the same inputs and compares stdout byte-for-byte. Requires F1
+      (binary must be built).
+
+touchpoints:
+  - T1: "cmd/b2sum — BLAKE2b digest computation, GNU format output, check mode, binary/tag/length flags (prd076-b2sum R1, R2, R3, R4)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and byte-for-byte comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for file digest, stdin digest, --check valid,
+      --check mismatch, --tag BSD format, and --length=256 variable-length mode,
+      confirming full parity with gb2sum.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+      - AC5
+      - AC6
+
+out_of_scope:
+  - BLAKE2s algorithm is not implemented.
+  - Keyed hashing and BLAKE2 MAC mode are not implemented.
+
+test_suite: test-rel09.0

--- a/docs/specs/use-cases/rel09.0-uc004-cksum.yaml
+++ b/docs/specs/use-cases/rel09.0-uc004-cksum.yaml
@@ -1,0 +1,53 @@
+id: rel09.0-uc004-cksum
+title: "Compute CRC checksums and byte counts via cksum"
+
+summary: |
+  The operator runs the Go cksum binary on one or more files or stdin. The binary
+  computes CRC-32 checksums (POSIX default) or alternate digest algorithms via
+  --algorithm. The differential testing harness then runs both the Go binary and the
+  Homebrew reference binary (gcksum from coreutils) with identical inputs and confirms
+  that their outputs are identical byte-for-byte.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd077-cksum.yaml) and invokes do-work to
+  produce a passing differential test for cmd/cksum.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises cksum in default CRC mode (file and stdin), and with
+      --algorithm=sha256 to verify tagged hash output.
+  - id: F2
+    step: |
+      The operator tests --untagged and --raw output format options with non-CRC
+      algorithms.
+  - id: F3
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/cksum and
+      gcksum with the same inputs and compares stdout byte-for-byte. Requires F1
+      (binary must be built).
+
+touchpoints:
+  - T1: "cmd/cksum — CRC-32 checksum, algorithm selection, output format control (prd077-cksum R1, R2, R3)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and byte-for-byte comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for default CRC mode, --algorithm=sha256 tagged
+      output, --untagged format, stdin input, multi-file input, and error cases,
+      confirming full parity with gcksum.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+
+out_of_scope:
+  - --check mode for CRC verification is not implemented.
+  - --base64 encoding is not implemented.
+
+test_suite: test-rel09.0

--- a/docs/specs/use-cases/rel09.0-uc005-sum.yaml
+++ b/docs/specs/use-cases/rel09.0-uc005-sum.yaml
@@ -1,0 +1,51 @@
+id: rel09.0-uc005-sum
+title: "Compute checksums and block counts via sum"
+
+summary: |
+  The operator runs the Go sum binary on one or more files or stdin. The binary computes
+  BSD or System V checksums and prints the checksum and block count. The differential
+  testing harness then runs both the Go binary and the Homebrew reference binary (gsum
+  from coreutils) with identical inputs and confirms that their outputs are identical
+  byte-for-byte.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd078-sum.yaml) and invokes do-work to
+  produce a passing differential test for cmd/sum.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises sum in default BSD mode (file and stdin) and System V
+      mode (-s).
+  - id: F2
+    step: |
+      The operator tests multi-file input and error cases (missing files) to verify
+      correct output and exit codes.
+  - id: F3
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/sum and
+      gsum with the same inputs and compares stdout byte-for-byte. Requires F1
+      (binary must be built).
+
+touchpoints:
+  - T1: "cmd/sum — BSD and System V checksum algorithms, block count output (prd078-sum R1, R2, R3)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and byte-for-byte comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for BSD mode, System V mode (-s), stdin input,
+      multi-file input, and error cases, confirming full parity with gsum.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+
+out_of_scope:
+  - Modern hash algorithms are not implemented; use sha256sum or cksum for that.
+
+test_suite: test-rel09.0


### PR DESCRIPTION
## Summary

Specifies release 09.0 with 5 hash and checksum utilities: sha224sum, sha384sum, b2sum, cksum, sum. This completes the SHA-2 family and adds BLAKE2b, CRC-32, and BSD/System V checksum support.

## Changes

- 5 PRDs: prd074-sha224sum, prd075-sha384sum, prd076-b2sum, prd077-cksum, prd078-sum
- 5 use cases: rel09.0-uc001 through rel09.0-uc005
- 1 test suite: test-rel-09.0 with 20 test cases
- road-map.yaml: added rel09.0 with 5 use cases

## Stats

- 12 files, 1,153 lines added
- 78 utilities specified (73% of ~108 target)

## Test plan

- [x] `mage analyze` — schema 0 errors, semantic 0 errors, broken citations 0

Closes #1405