### PR TITLE
GH-3144: Specify rel09.1 and rel10.0 — base32, base64, basenc, stat, truncate, link, sync

### DIFF
--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -414,3 +414,40 @@ releases:
           status: spec_complete
         - id: rel09.0-uc005-sum
           status: spec_complete
+    - version: "09.1"
+      name: "Batch 9.1 — encoding utilities (base32, base64, basenc)"
+      status: spec_complete
+      depends_on: ["00.0"]
+      description: |
+        Implement three encoding/decoding utilities. base32 and base64 handle RFC 4648
+        Base32 and Base64 encoding with wrap control and decode modes. basenc is a
+        generalized encoder supporting Base64, Base64URL, Base32, Base32hex, Base16, and
+        Z85 alphabets. All are verified by differential testing against GNU coreutils
+        reference binaries.
+      use_cases:
+        - id: rel09.1-uc001-base32
+          status: spec_complete
+        - id: rel09.1-uc002-base64
+          status: spec_complete
+        - id: rel09.1-uc003-basenc
+          status: spec_complete
+    - version: "10.0"
+      name: "Batch 10.0 — file metadata and operations (stat, truncate, link, sync)"
+      status: spec_complete
+      depends_on: ["00.0"]
+      description: |
+        Implement four file metadata and operation utilities. stat displays file and
+        filesystem status with printf-style format strings. truncate sets or adjusts file
+        sizes with relative operations and unit suffixes. link creates hard links via the
+        link(2) system call. sync flushes filesystem caches with per-file and filesystem
+        modes. All are verified by differential testing against GNU coreutils reference
+        binaries.
+      use_cases:
+        - id: rel10.0-uc001-stat
+          status: spec_complete
+        - id: rel10.0-uc002-truncate
+          status: spec_complete
+        - id: rel10.0-uc003-link
+          status: spec_complete
+        - id: rel10.0-uc004-sync
+          status: spec_complete

--- a/docs/specs/product-requirements/prd079-base32.yaml
+++ b/docs/specs/product-requirements/prd079-base32.yaml
@@ -1,0 +1,102 @@
+id: prd079-base32
+title: "cmd/base32: Base32 Encode and Decode"
+
+problem: |
+  macOS does not ship base32. Scripts that encode or decode Base32 data using the GNU
+  base32 format must use the Homebrew reference binary. The Go implementation must match
+  the Homebrew GNU reference binary (gbase32, installed by coreutils) byte-for-byte on
+  all flag combinations, using encoding/base32 from the Go standard library, verified
+  by differential testing via pkg/testutils.
+
+goals:
+  - G1: Encode stdin or file contents to Base32 and write to stdout.
+  - G2: Decode Base32-encoded input back to binary with --decode (-d).
+  - G3: Support line wrapping control with --wrap (-w).
+  - G4: Verify functional parity against gbase32 via differential testing.
+
+requirements:
+  R1:
+    title: Encoding
+    items:
+      - R1.1:
+          text: Must read from FILE or stdin (when no file or "-" is given) and encode the input using RFC 4648 Base32, writing the result to stdout.
+          weight: 1
+      - R1.2:
+          text: Must wrap encoded output at 76 characters per line by default.
+          weight: 1
+      - R1.3:
+          text: "-w COLS or --wrap=COLS must set the wrap column. -w 0 disables wrapping (single line output)."
+          weight: 1
+      - R1.4:
+          text: Must exit 1 when a named file cannot be opened, printing an error to stderr.
+          weight: 1
+
+  R2:
+    title: Decoding
+    items:
+      - R2.1:
+          text: "-d or --decode must decode Base32 input from FILE or stdin and write the binary result to stdout."
+          weight: 1
+      - R2.2:
+          text: Must ignore whitespace (newlines, spaces) in the input during decoding.
+          weight: 1
+      - R2.3:
+          text: "-i or --ignore-garbage must ignore non-alphabet characters in the input during decoding."
+          weight: 1
+      - R2.4:
+          text: Must exit 1 with an error to stderr when the input contains invalid Base32 characters (without --ignore-garbage).
+          weight: 1
+
+  R3:
+    title: Exit codes and SIGPIPE
+    items:
+      - R3.1:
+          text: Must exit 0 on successful encoding or decoding.
+          weight: 1
+      - R3.2:
+          text: Must exit 1 on any error (invalid input, missing file, invalid option).
+          weight: 1
+      - R3.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/base32 does not implement Base32hex (extended hex alphabet).
+  - cmd/base32 does not implement Base64; use base64 for that.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "echo hello | base32 produces Base32 encoded output matching gbase32."
+    traces:
+      - R1.1
+      - R1.2
+  - id: AC2
+    criterion: "echo NBSWY3DP | base32 -d produces 'hello', matching gbase32 -d."
+    traces:
+      - R2.1
+      - R2.2
+  - id: AC3
+    criterion: "Differential test against gbase32 passes for all required test cases."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+  - id: AC4
+    criterion: "cmd/base32 compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+      - R3.1
+      - R3.2
+      - R3.3

--- a/docs/specs/product-requirements/prd080-base64.yaml
+++ b/docs/specs/product-requirements/prd080-base64.yaml
@@ -1,0 +1,102 @@
+id: prd080-base64
+title: "cmd/base64: Base64 Encode and Decode"
+
+problem: |
+  macOS does not ship base64. Scripts that encode or decode Base64 data using the GNU
+  base64 format must use the Homebrew reference binary. The Go implementation must match
+  the Homebrew GNU reference binary (gbase64, installed by coreutils) byte-for-byte on
+  all flag combinations, using encoding/base64 from the Go standard library, verified
+  by differential testing via pkg/testutils.
+
+goals:
+  - G1: Encode stdin or file contents to Base64 and write to stdout.
+  - G2: Decode Base64-encoded input back to binary with --decode (-d).
+  - G3: Support line wrapping control with --wrap (-w).
+  - G4: Verify functional parity against gbase64 via differential testing.
+
+requirements:
+  R1:
+    title: Encoding
+    items:
+      - R1.1:
+          text: Must read from FILE or stdin (when no file or "-" is given) and encode the input using RFC 4648 Base64, writing the result to stdout.
+          weight: 1
+      - R1.2:
+          text: Must wrap encoded output at 76 characters per line by default.
+          weight: 1
+      - R1.3:
+          text: "-w COLS or --wrap=COLS must set the wrap column. -w 0 disables wrapping (single line output)."
+          weight: 1
+      - R1.4:
+          text: Must exit 1 when a named file cannot be opened, printing an error to stderr.
+          weight: 1
+
+  R2:
+    title: Decoding
+    items:
+      - R2.1:
+          text: "-d or --decode must decode Base64 input from FILE or stdin and write the binary result to stdout."
+          weight: 1
+      - R2.2:
+          text: Must ignore whitespace (newlines, spaces) in the input during decoding.
+          weight: 1
+      - R2.3:
+          text: "-i or --ignore-garbage must ignore non-alphabet characters in the input during decoding."
+          weight: 1
+      - R2.4:
+          text: Must exit 1 with an error to stderr when the input contains invalid Base64 characters (without --ignore-garbage).
+          weight: 1
+
+  R3:
+    title: Exit codes and SIGPIPE
+    items:
+      - R3.1:
+          text: Must exit 0 on successful encoding or decoding.
+          weight: 1
+      - R3.2:
+          text: Must exit 1 on any error (invalid input, missing file, invalid option).
+          weight: 1
+      - R3.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/base64 does not implement Base64url (URL-safe alphabet).
+  - cmd/base64 does not implement Base32; use base32 for that.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "echo hello | base64 produces Base64 encoded output matching gbase64."
+    traces:
+      - R1.1
+      - R1.2
+  - id: AC2
+    criterion: "echo aGVsbG8= | base64 -d produces 'hello', matching gbase64 -d."
+    traces:
+      - R2.1
+      - R2.2
+  - id: AC3
+    criterion: "Differential test against gbase64 passes for all required test cases."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+  - id: AC4
+    criterion: "cmd/base64 compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+      - R3.1
+      - R3.2
+      - R3.3

--- a/docs/specs/product-requirements/prd081-basenc.yaml
+++ b/docs/specs/product-requirements/prd081-basenc.yaml
@@ -1,0 +1,107 @@
+id: prd081-basenc
+title: "cmd/basenc: Encode and Decode with Multiple Alphabets"
+
+problem: |
+  GNU basenc is a generalized encoding utility that supports multiple encoding schemes
+  beyond base32 and base64. macOS does not ship basenc. The Go implementation must match
+  the Homebrew GNU reference binary (gbasenc, installed by coreutils) byte-for-byte on
+  all flag combinations, verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Encode or decode data using a selectable encoding scheme.
+  - G2: Support Base64, Base64URL, Base32, Base32hex, Base16, and Z85 encodings.
+  - G3: Support line wrapping and garbage ignoring like base32/base64.
+  - G4: Verify functional parity against gbasenc via differential testing.
+
+requirements:
+  R1:
+    title: Encoding schemes
+    items:
+      - R1.1:
+          text: "--base64 must encode/decode using RFC 4648 Base64 (same as base64 utility)."
+          weight: 1
+      - R1.2:
+          text: "--base64url must encode/decode using RFC 4648 Base64 with URL-safe alphabet (+ and / replaced by - and _)."
+          weight: 1
+      - R1.3:
+          text: "--base32 must encode/decode using RFC 4648 Base32 (same as base32 utility)."
+          weight: 1
+      - R1.4:
+          text: "--base32hex must encode/decode using RFC 4648 Base32 with extended hex alphabet."
+          weight: 1
+
+  R2:
+    title: Additional encodings and options
+    items:
+      - R2.1:
+          text: "--base16 must encode/decode using hexadecimal (Base16). Output is uppercase hex characters."
+          weight: 1
+      - R2.2:
+          text: "--z85 must encode/decode using ZeroMQ Z85 encoding. Input length must be a multiple of 4 bytes for encoding."
+          weight: 4
+      - R2.3:
+          text: "-d or --decode must decode the input using the selected encoding scheme."
+          weight: 1
+      - R2.4:
+          text: "-w COLS or --wrap=COLS must set the wrap column (default 76). -w 0 disables wrapping."
+          weight: 1
+
+  R3:
+    title: Input handling and error cases
+    items:
+      - R3.1:
+          text: "-i or --ignore-garbage must ignore non-alphabet characters during decoding."
+          weight: 1
+      - R3.2:
+          text: Must read from FILE or stdin (when no file or "-" is given).
+          weight: 1
+      - R3.3:
+          text: Must exit 1 when no encoding scheme is specified, when the file cannot be opened, or when decode input is invalid.
+          weight: 1
+      - R3.4:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/basenc does not implement Base2 (binary) encoding.
+  - cmd/basenc does not implement custom alphabet specification.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "echo hello | basenc --base64 produces Base64 encoded output matching gbasenc --base64."
+    traces:
+      - R1.1
+      - R2.4
+  - id: AC2
+    criterion: "echo hello | basenc --base16 produces hex output matching gbasenc --base16."
+    traces:
+      - R2.1
+  - id: AC3
+    criterion: "basenc --base64url encodes with URL-safe alphabet, matching gbasenc --base64url."
+    traces:
+      - R1.2
+  - id: AC4
+    criterion: "Differential test against gbasenc passes for all required test cases."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+  - id: AC5
+    criterion: "cmd/basenc compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+      - R3.1
+      - R3.2
+      - R3.3
+      - R3.4

--- a/docs/specs/product-requirements/prd082-stat.yaml
+++ b/docs/specs/product-requirements/prd082-stat.yaml
@@ -1,0 +1,109 @@
+id: prd082-stat
+title: "cmd/stat: Display File Status"
+
+problem: |
+  macOS ships a BSD stat that differs from GNU stat in default output format, format
+  string syntax, and flag names. GNU stat supports printf-style format strings for
+  customizable output. The Go implementation must match the Homebrew GNU reference binary
+  (gstat, installed by coreutils) byte-for-byte on all flag combinations, verified by
+  differential testing via pkg/testutils.
+
+goals:
+  - G1: Display file status information (size, permissions, timestamps, inode, etc.).
+  - G2: Support printf-style format strings for custom output via --format (-c).
+  - G3: Support filesystem status mode via --file-system (-f).
+  - G4: Verify functional parity against gstat via differential testing.
+
+requirements:
+  R1:
+    title: Default file status
+    items:
+      - R1.1:
+          text: Must display file status for each named file argument using the default multi-line format matching GNU stat output (File, Size, Blocks, IO Block, file type, Device, Inode, Links, Access mode, Uid, Gid, Access time, Modify time, Change time, Birth time).
+          weight: 4
+      - R1.2:
+          text: Must process multiple file arguments in order, printing status for each.
+          weight: 1
+      - R1.3:
+          text: "-L or --dereference must follow symlinks and report the target file's status instead of the link itself."
+          weight: 1
+      - R1.4:
+          text: Must exit 1 when any named file does not exist or cannot be accessed, printing an error to stderr, and continue processing remaining files.
+          weight: 1
+
+  R2:
+    title: Format strings
+    items:
+      - R2.1:
+          text: "-c FORMAT or --format=FORMAT must use FORMAT as a printf-style format string. Must support directives: %a (access rights octal), %A (access rights human), %b (blocks allocated), %B (block size), %d (device number decimal), %D (device number hex), %f (raw mode hex), %F (file type), %g (group ID), %G (group name), %h (hard links), %i (inode), %m (mount point), %n (file name), %N (quoted file name with symlink target), %o (optimal I/O size), %s (total size bytes), %t (major device type hex), %T (minor device type hex), %u (user ID), %U (user name), %w (birth time human), %W (birth time epoch), %x (access time human), %X (access time epoch), %y (modify time human), %Y (modify time epoch), %z (change time human), %Z (change time epoch)."
+          weight: 4
+      - R2.2:
+          text: "--printf=FORMAT must work like --format but interpret backslash escapes (\\n, \\t, etc.) and not append a trailing newline."
+          weight: 1
+      - R2.3:
+          text: "-t or --terse must produce terse output (single line of space-separated fields) matching GNU stat --terse format."
+          weight: 1
+
+  R3:
+    title: Filesystem status mode
+    items:
+      - R3.1:
+          text: "-f or --file-system must display filesystem status instead of file status. Output includes filesystem type, block size, total/free/available blocks and inodes."
+          weight: 4
+      - R3.2:
+          text: "Format directives in --file-system mode differ from file mode: %a (free blocks available to non-root), %b (total blocks), %c (total inodes), %d (free inodes), %f (free blocks), %i (filesystem ID hex), %l (max filename length), %n (file name), %s (block size optimal), %S (fundamental block size), %t (filesystem type hex), %T (filesystem type name)."
+          weight: 4
+
+  R4:
+    title: Exit codes and SIGPIPE
+    items:
+      - R4.1:
+          text: Must exit 0 when all files are processed successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any file cannot be accessed or an invalid format directive is used.
+          weight: 1
+      - R4.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/stat does not implement SELinux context display (--context).
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "stat on a regular file produces multi-line status output matching gstat."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.4
+  - id: AC2
+    criterion: "stat -c '%s %n' file produces size and name, matching gstat -c '%s %n'."
+    traces:
+      - R2.1
+  - id: AC3
+    criterion: "stat -f / produces filesystem status matching gstat -f /."
+    traces:
+      - R3.1
+      - R3.2
+  - id: AC4
+    criterion: "Differential test against gstat passes for all required test cases."
+    traces:
+      - R1.1
+      - R2.1
+      - R3.1
+  - id: AC5
+    criterion: "cmd/stat compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R3.1
+      - R3.2
+      - R4.1
+      - R4.2
+      - R4.3

--- a/docs/specs/product-requirements/prd083-truncate.yaml
+++ b/docs/specs/product-requirements/prd083-truncate.yaml
@@ -1,0 +1,92 @@
+id: prd083-truncate
+title: "cmd/truncate: Shrink or Extend File Size"
+
+problem: |
+  macOS ships a BSD truncate that differs from GNU truncate in flag syntax and relative
+  size adjustment support. The Go implementation must match the Homebrew GNU reference
+  binary (gtruncate, installed by coreutils) byte-for-byte on all flag combinations,
+  verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Set or adjust the size of files.
+  - G2: Support absolute and relative size specifications with unit suffixes.
+  - G3: Support reference file sizing.
+  - G4: Verify functional parity against gtruncate via differential testing.
+
+requirements:
+  R1:
+    title: Size specification
+    items:
+      - R1.1:
+          text: "-s SIZE or --size=SIZE must set each FILE's size to SIZE bytes. SIZE may include unit suffixes (K, M, G, T, P, E, Z, Y for powers of 1024; KB, MB, GB for powers of 1000)."
+          weight: 1
+      - R1.2:
+          text: "SIZE may be prefixed with + or - for relative adjustment (grow or shrink), < to set at most SIZE, > to set at least SIZE, / to round down to multiple, % to round up to multiple."
+          weight: 4
+      - R1.3:
+          text: Must process multiple FILE arguments, applying the same size operation to each.
+          weight: 1
+      - R1.4:
+          text: "-c or --no-create must not create files that do not exist. Without -c, missing files are created."
+          weight: 1
+
+  R2:
+    title: Reference file
+    items:
+      - R2.1:
+          text: "-r RFILE or --reference=RFILE must use the size of RFILE as the base size instead of an explicit SIZE. Can be combined with -s for relative adjustment from the reference size."
+          weight: 1
+      - R2.2:
+          text: Must exit 1 if the reference file cannot be accessed.
+          weight: 1
+
+  R3:
+    title: Exit codes and SIGPIPE
+    items:
+      - R3.1:
+          text: Must exit 0 when all files are processed successfully.
+          weight: 1
+      - R3.2:
+          text: Must exit 1 when any file cannot be opened, created, or resized, or when SIZE is invalid.
+          weight: 1
+      - R3.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/truncate does not implement sparse file optimization.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "truncate -s 100 file creates or resizes file to 100 bytes, matching gtruncate."
+    traces:
+      - R1.1
+      - R1.3
+      - R1.4
+  - id: AC2
+    criterion: "truncate -s +50 file grows file by 50 bytes, matching gtruncate."
+    traces:
+      - R1.2
+  - id: AC3
+    criterion: "truncate -r ref file sets file to ref's size, matching gtruncate."
+    traces:
+      - R2.1
+  - id: AC4
+    criterion: "Differential test against gtruncate passes for all required test cases."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R2.1
+  - id: AC5
+    criterion: "cmd/truncate compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R3.1
+      - R3.2
+      - R3.3

--- a/docs/specs/product-requirements/prd084-link.yaml
+++ b/docs/specs/product-requirements/prd084-link.yaml
@@ -1,0 +1,74 @@
+id: prd084-link
+title: "cmd/link: Create a Hard Link"
+
+problem: |
+  The link utility creates a single hard link using the link(2) system call, unlike ln
+  which supports multiple targets, symlinks, and directory handling. macOS ships link but
+  the Go implementation must match the Homebrew GNU reference binary (glink, installed
+  by coreutils) byte-for-byte, verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Create a hard link from FILE1 to FILE2 using the link(2) system call.
+  - G2: Verify functional parity against glink via differential testing.
+
+requirements:
+  R1:
+    title: Hard link creation
+    items:
+      - R1.1:
+          text: Must accept exactly two arguments FILE1 and FILE2 and create a hard link at FILE2 pointing to FILE1 using the link(2) system call.
+          weight: 1
+      - R1.2:
+          text: Must not follow symlinks, create symlinks, or handle directories specially — the raw link(2) semantics apply.
+          weight: 1
+      - R1.3:
+          text: Must exit 1 with an error to stderr if fewer or more than two arguments are given.
+          weight: 1
+      - R1.4:
+          text: Must exit 1 with an error to stderr if the link(2) call fails (e.g., FILE1 does not exist, FILE2 already exists, cross-device link).
+          weight: 1
+
+  R2:
+    title: Exit codes and SIGPIPE
+    items:
+      - R2.1:
+          text: Must exit 0 when the hard link is created successfully.
+          weight: 1
+      - R2.2:
+          text: Must exit 1 on any error.
+          weight: 1
+      - R2.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/link does not support symbolic links; use ln -s for that.
+  - cmd/link does not support multiple targets or directory handling; use ln for that.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "link file1 file2 creates a hard link at file2, matching glink behavior."
+    traces:
+      - R1.1
+      - R1.2
+  - id: AC2
+    criterion: "link with wrong number of arguments exits 1 with usage error, matching glink."
+    traces:
+      - R1.3
+  - id: AC3
+    criterion: "Differential test against glink passes for all required test cases."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+  - id: AC4
+    criterion: "cmd/link compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3

--- a/docs/specs/product-requirements/prd085-sync.yaml
+++ b/docs/specs/product-requirements/prd085-sync.yaml
@@ -1,0 +1,73 @@
+id: prd085-sync
+title: "cmd/sync: Synchronize Cached Writes to Persistent Storage"
+
+problem: |
+  macOS ships sync but the GNU version supports --data and --file-system flags for
+  selective synchronization. The Go implementation must match the Homebrew GNU reference
+  binary (gsync, installed by coreutils) byte-for-byte on all flag combinations, verified
+  by differential testing via pkg/testutils.
+
+goals:
+  - G1: Synchronize cached writes to persistent storage.
+  - G2: Support per-file and filesystem-level sync options.
+  - G3: Verify functional parity against gsync via differential testing.
+
+requirements:
+  R1:
+    title: Synchronization modes
+    items:
+      - R1.1:
+          text: When invoked with no arguments, must call sync(2) to flush all filesystem caches to persistent storage.
+          weight: 1
+      - R1.2:
+          text: When given FILE arguments, must open each file and call fsync(2) on each to flush that file's data and metadata to storage.
+          weight: 1
+      - R1.3:
+          text: "-d or --data must call fdatasync(2) instead of fsync(2) on each FILE, syncing only the file's data (not metadata). Must exit 1 if no FILE is given with -d."
+          weight: 1
+      - R1.4:
+          text: "-f or --file-system must call sync(2) for the filesystem containing each FILE rather than syncing the individual file. Must exit 1 if no FILE is given with -f."
+          weight: 1
+
+  R2:
+    title: Exit codes and SIGPIPE
+    items:
+      - R2.1:
+          text: Must exit 0 when all sync operations complete successfully.
+          weight: 1
+      - R2.2:
+          text: Must exit 1 when any file cannot be opened or sync fails.
+          weight: 1
+      - R2.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/sync does not implement filesystem-type-specific sync semantics beyond what the OS provides.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "sync with no arguments completes without error, matching gsync."
+    traces:
+      - R1.1
+  - id: AC2
+    criterion: "sync file flushes the file to storage, matching gsync file."
+    traces:
+      - R1.2
+  - id: AC3
+    criterion: "Differential test against gsync passes for all required test cases."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+  - id: AC4
+    criterion: "cmd/sync compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3

--- a/docs/specs/test-suites/test-rel-09.1.yaml
+++ b/docs/specs/test-suites/test-rel-09.1.yaml
@@ -1,0 +1,188 @@
+id: test-rel09.1
+title: "Test Suite: rel09.1 — base32, base64, basenc"
+release: rel09.1
+
+traces:
+  - rel09.1-uc001-base32
+  - rel09.1-uc002-base64
+  - rel09.1-uc003-basenc
+  - prd079-base32 R1
+  - prd079-base32 R2
+  - prd079-base32 R3
+  - prd080-base64 R1
+  - prd080-base64 R2
+  - prd080-base64 R3
+  - prd081-basenc R1
+  - prd081-basenc R2
+  - prd081-basenc R3
+
+preconditions:
+  - "Go binary for each utility is built via go build -o bin/<name> ./cmd/<name>/"
+  - "Reference binaries installed via Homebrew: gbase32, gbase64, gbasenc (coreutils package)"
+  - "Tests use LC_ALL=C for deterministic output"
+
+test_cases:
+
+  # ---- base32 ----
+
+  - name: base32_encode_stdin
+    description: "base32 encodes stdin to Base32"
+    inputs:
+      args: []
+      stdin: "hello\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd079-base32 R1.1
+      - prd079-base32 R1.2
+
+  - name: base32_decode
+    description: "base32 -d decodes Base32 input"
+    inputs:
+      args: ["-d"]
+      stdin: "NBSWY3DPEB3W64TMMQ======\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd079-base32 R2.1
+      - prd079-base32 R2.2
+
+  - name: base32_wrap_zero
+    description: "base32 -w 0 disables line wrapping"
+    inputs:
+      args: ["-w", "0"]
+      stdin: "hello world this is a longer string\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd079-base32 R1.3
+
+  # ---- base64 ----
+
+  - name: base64_encode_stdin
+    description: "base64 encodes stdin to Base64"
+    inputs:
+      args: []
+      stdin: "hello\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd080-base64 R1.1
+      - prd080-base64 R1.2
+
+  - name: base64_decode
+    description: "base64 -d decodes Base64 input"
+    inputs:
+      args: ["-d"]
+      stdin: "aGVsbG8K\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd080-base64 R2.1
+      - prd080-base64 R2.2
+
+  - name: base64_wrap_zero
+    description: "base64 -w 0 disables line wrapping"
+    inputs:
+      args: ["-w", "0"]
+      stdin: "hello world this is a longer string\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd080-base64 R1.3
+
+  # ---- basenc ----
+
+  - name: basenc_base64
+    description: "basenc --base64 encodes to Base64"
+    inputs:
+      args: ["--base64"]
+      stdin: "hello\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd081-basenc R1.1
+
+  - name: basenc_base16
+    description: "basenc --base16 encodes to hex"
+    inputs:
+      args: ["--base16"]
+      stdin: "hello\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd081-basenc R2.1
+
+  - name: basenc_base64url
+    description: "basenc --base64url encodes with URL-safe alphabet"
+    inputs:
+      args: ["--base64url"]
+      stdin: "hello\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd081-basenc R1.2
+
+  - name: basenc_base32hex
+    description: "basenc --base32hex encodes with extended hex Base32"
+    inputs:
+      args: ["--base32hex"]
+      stdin: "hello\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd081-basenc R1.4
+
+  - name: basenc_decode
+    description: "basenc --base64 -d decodes Base64 input"
+    inputs:
+      args: ["--base64", "-d"]
+      stdin: "aGVsbG8K\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd081-basenc R2.3

--- a/docs/specs/test-suites/test-rel-10.0.yaml
+++ b/docs/specs/test-suites/test-rel-10.0.yaml
@@ -1,0 +1,192 @@
+id: test-rel10.0
+title: "Test Suite: rel10.0 — stat, truncate, link, sync"
+release: rel10.0
+
+traces:
+  - rel10.0-uc001-stat
+  - rel10.0-uc002-truncate
+  - rel10.0-uc003-link
+  - rel10.0-uc004-sync
+  - prd082-stat R1
+  - prd082-stat R2
+  - prd082-stat R3
+  - prd082-stat R4
+  - prd083-truncate R1
+  - prd083-truncate R2
+  - prd083-truncate R3
+  - prd084-link R1
+  - prd084-link R2
+  - prd085-sync R1
+  - prd085-sync R2
+
+preconditions:
+  - "Go binary for each utility is built via go build -o bin/<name> ./cmd/<name>/"
+  - "Reference binaries installed via Homebrew: gstat, gtruncate, glink, gsync (coreutils package)"
+  - "Tests use LC_ALL=C for deterministic output"
+
+test_cases:
+
+  # ---- stat ----
+
+  - name: stat_default_file
+    description: "stat on a regular file produces multi-line status output"
+    inputs:
+      args: ["hello.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd082-stat R1.1
+      - prd082-stat R1.2
+
+  - name: stat_format_size_name
+    description: "stat -c '%s %n' produces size and filename"
+    inputs:
+      args: ["-c", "%s %n", "hello.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd082-stat R2.1
+
+  - name: stat_terse
+    description: "stat -t produces single-line terse output"
+    inputs:
+      args: ["-t", "hello.txt"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd082-stat R2.3
+
+  - name: stat_filesystem
+    description: "stat -f displays filesystem status"
+    inputs:
+      args: ["-f", "/"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd082-stat R3.1
+
+  # ---- truncate ----
+
+  - name: truncate_absolute_size
+    description: "truncate -s 100 sets file to 100 bytes"
+    inputs:
+      args: ["-s", "100", "testfile"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd083-truncate R1.1
+      - prd083-truncate R1.3
+
+  - name: truncate_relative_grow
+    description: "truncate -s +50 grows file by 50 bytes"
+    inputs:
+      args: ["-s", "+50", "testfile"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd083-truncate R1.2
+
+  - name: truncate_reference
+    description: "truncate -r ref file sets file to ref's size"
+    inputs:
+      args: ["-r", "ref", "testfile"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd083-truncate R2.1
+
+  # ---- link ----
+
+  - name: link_create
+    description: "link file1 file2 creates a hard link"
+    inputs:
+      args: ["file1", "file2"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd084-link R1.1
+      - prd084-link R1.2
+
+  - name: link_wrong_args
+    description: "link with one argument exits 1"
+    inputs:
+      args: ["file1"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 1
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd084-link R1.3
+
+  # ---- sync ----
+
+  - name: sync_no_args
+    description: "sync with no arguments completes without error"
+    inputs:
+      args: []
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd085-sync R1.1
+
+  - name: sync_file
+    description: "sync on a named file completes without error"
+    inputs:
+      args: ["testfile"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd085-sync R1.2

--- a/docs/specs/use-cases/rel09.1-uc001-base32.yaml
+++ b/docs/specs/use-cases/rel09.1-uc001-base32.yaml
@@ -1,0 +1,49 @@
+id: rel09.1-uc001-base32
+title: "Encode and decode Base32 data via base32"
+
+summary: |
+  The operator runs the Go base32 binary to encode or decode Base32 data. The
+  differential testing harness runs both the Go binary and the Homebrew reference
+  binary (gbase32 from coreutils) with identical inputs and confirms that their
+  outputs are identical byte-for-byte.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd079-base32.yaml) and invokes do-work to
+  produce a passing differential test for cmd/base32.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises base32 in encode mode (stdin and file), decode mode
+      (-d), and with custom wrap width (-w).
+  - id: F2
+    step: |
+      The operator tests decode with invalid input and --ignore-garbage to verify
+      error handling and garbage tolerance.
+  - id: F3
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/base32 and
+      gbase32 with the same inputs and compares stdout byte-for-byte.
+
+touchpoints:
+  - T1: "cmd/base32 — Base32 encoding/decoding, wrap control, garbage handling (prd079-base32 R1, R2, R3)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and byte-for-byte comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for encode, decode, wrap control, ignore-garbage,
+      and error cases, confirming full parity with gbase32.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+
+out_of_scope:
+  - Base32hex (extended hex alphabet) is not implemented.
+
+test_suite: test-rel-09.1

--- a/docs/specs/use-cases/rel09.1-uc002-base64.yaml
+++ b/docs/specs/use-cases/rel09.1-uc002-base64.yaml
@@ -1,0 +1,49 @@
+id: rel09.1-uc002-base64
+title: "Encode and decode Base64 data via base64"
+
+summary: |
+  The operator runs the Go base64 binary to encode or decode Base64 data. The
+  differential testing harness runs both the Go binary and the Homebrew reference
+  binary (gbase64 from coreutils) with identical inputs and confirms that their
+  outputs are identical byte-for-byte.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd080-base64.yaml) and invokes do-work to
+  produce a passing differential test for cmd/base64.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises base64 in encode mode (stdin and file), decode mode
+      (-d), and with custom wrap width (-w).
+  - id: F2
+    step: |
+      The operator tests decode with invalid input and --ignore-garbage to verify
+      error handling and garbage tolerance.
+  - id: F3
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/base64 and
+      gbase64 with the same inputs and compares stdout byte-for-byte.
+
+touchpoints:
+  - T1: "cmd/base64 — Base64 encoding/decoding, wrap control, garbage handling (prd080-base64 R1, R2, R3)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and byte-for-byte comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for encode, decode, wrap control, ignore-garbage,
+      and error cases, confirming full parity with gbase64.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+
+out_of_scope:
+  - Base64URL (URL-safe alphabet) is not implemented; use basenc for that.
+
+test_suite: test-rel-09.1

--- a/docs/specs/use-cases/rel09.1-uc003-basenc.yaml
+++ b/docs/specs/use-cases/rel09.1-uc003-basenc.yaml
@@ -1,0 +1,53 @@
+id: rel09.1-uc003-basenc
+title: "Encode and decode with multiple alphabets via basenc"
+
+summary: |
+  The operator runs the Go basenc binary to encode or decode data using a selectable
+  encoding scheme (Base64, Base64URL, Base32, Base32hex, Base16, Z85). The differential
+  testing harness runs both the Go binary and the Homebrew reference binary (gbasenc
+  from coreutils) with identical inputs and confirms that their outputs are identical
+  byte-for-byte.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd081-basenc.yaml) and invokes do-work to
+  produce a passing differential test for cmd/basenc.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises basenc with each encoding scheme (--base64, --base64url,
+      --base32, --base32hex, --base16, --z85) in encode and decode modes.
+  - id: F2
+    step: |
+      The operator tests error cases: no encoding specified, invalid decode input,
+      wrong input length for Z85.
+  - id: F3
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/basenc and
+      gbasenc with the same inputs and compares stdout byte-for-byte.
+
+touchpoints:
+  - T1: "cmd/basenc — multi-alphabet encoding/decoding, wrap control, garbage handling (prd081-basenc R1, R2, R3)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and byte-for-byte comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all encoding schemes (base64, base64url,
+      base32, base32hex, base16, z85) in encode and decode modes, confirming full
+      parity with gbasenc.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+      - AC5
+
+out_of_scope:
+  - Base2 (binary) encoding is not implemented.
+  - Custom alphabet specification is not supported.
+
+test_suite: test-rel-09.1

--- a/docs/specs/use-cases/rel10.0-uc001-stat.yaml
+++ b/docs/specs/use-cases/rel10.0-uc001-stat.yaml
@@ -1,0 +1,52 @@
+id: rel10.0-uc001-stat
+title: "Display file and filesystem status via stat"
+
+summary: |
+  The operator runs the Go stat binary to display file metadata or filesystem status.
+  The binary supports printf-style format strings for custom output. The differential
+  testing harness runs both the Go binary and the Homebrew reference binary (gstat
+  from coreutils) with identical inputs and confirms that their outputs are identical
+  byte-for-byte.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd082-stat.yaml) and invokes do-work to
+  produce a passing differential test for cmd/stat.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises stat in default mode, with format strings (-c), terse
+      mode (-t), and filesystem mode (-f).
+  - id: F2
+    step: |
+      The operator tests symlink handling (-L), multiple files, and error cases
+      (missing files).
+  - id: F3
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/stat and
+      gstat with the same inputs and compares stdout byte-for-byte.
+
+touchpoints:
+  - T1: "cmd/stat — file status display, format strings, filesystem mode (prd082-stat R1, R2, R3, R4)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and byte-for-byte comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for default output, format strings, terse mode,
+      filesystem mode, symlink dereference, and error cases, confirming full parity
+      with gstat.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+      - AC5
+
+out_of_scope:
+  - SELinux context display is not implemented.
+
+test_suite: test-rel-10.0

--- a/docs/specs/use-cases/rel10.0-uc002-truncate.yaml
+++ b/docs/specs/use-cases/rel10.0-uc002-truncate.yaml
@@ -1,0 +1,49 @@
+id: rel10.0-uc002-truncate
+title: "Shrink or extend file size via truncate"
+
+summary: |
+  The operator runs the Go truncate binary to set or adjust file sizes. The binary
+  supports absolute sizes, relative adjustments, unit suffixes, and reference files.
+  The differential testing harness runs both the Go binary and the Homebrew reference
+  binary (gtruncate from coreutils) with identical inputs and confirms behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd083-truncate.yaml) and invokes do-work to
+  produce a passing differential test for cmd/truncate.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises truncate with absolute size (-s 100), relative size
+      (-s +50, -s -10), unit suffixes (-s 1K), and reference file (-r ref).
+  - id: F2
+    step: |
+      The operator tests --no-create mode, multiple files, and error cases.
+  - id: F3
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/truncate
+      and gtruncate with the same inputs and compares resulting file sizes.
+
+touchpoints:
+  - T1: "cmd/truncate — file size control, relative adjustment, reference file (prd083-truncate R1, R2, R3)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for absolute size, relative adjustment, reference
+      file, no-create mode, and error cases, confirming full parity with gtruncate.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+      - AC5
+
+out_of_scope:
+  - Sparse file optimization is not implemented.
+
+test_suite: test-rel-10.0

--- a/docs/specs/use-cases/rel10.0-uc003-link.yaml
+++ b/docs/specs/use-cases/rel10.0-uc003-link.yaml
@@ -1,0 +1,49 @@
+id: rel10.0-uc003-link
+title: "Create a hard link via link"
+
+summary: |
+  The operator runs the Go link binary to create a hard link using the link(2) system
+  call. The differential testing harness runs both the Go binary and the Homebrew
+  reference binary (glink from coreutils) with identical inputs and confirms behavior
+  parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd084-link.yaml) and invokes do-work to
+  produce a passing differential test for cmd/link.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises link with two arguments to create a hard link, verifying
+      the resulting file has the correct inode.
+  - id: F2
+    step: |
+      The operator tests error cases: wrong argument count, non-existent source,
+      existing target, cross-device link attempt.
+  - id: F3
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/link and
+      glink with the same inputs and compares exit codes and stderr.
+
+touchpoints:
+  - T1: "cmd/link — hard link creation via link(2) (prd084-link R1, R2)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for successful link creation, argument validation,
+      and error cases, confirming full parity with glink.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+
+out_of_scope:
+  - Symbolic links are handled by ln, not link.
+
+test_suite: test-rel-10.0

--- a/docs/specs/use-cases/rel10.0-uc004-sync.yaml
+++ b/docs/specs/use-cases/rel10.0-uc004-sync.yaml
@@ -1,0 +1,49 @@
+id: rel10.0-uc004-sync
+title: "Synchronize cached writes to storage via sync"
+
+summary: |
+  The operator runs the Go sync binary to flush filesystem caches to persistent storage.
+  The binary supports per-file sync, data-only sync, and filesystem-level sync. The
+  differential testing harness runs both the Go binary and the Homebrew reference binary
+  (gsync from coreutils) with identical inputs and confirms behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd085-sync.yaml) and invokes do-work to
+  produce a passing differential test for cmd/sync.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises sync with no arguments (global sync), with file arguments
+      (per-file fsync), with -d (fdatasync), and with -f (filesystem sync).
+  - id: F2
+    step: |
+      The operator tests error cases: -d without files, -f without files, non-existent
+      file arguments.
+  - id: F3
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/sync and
+      gsync with the same inputs and compares exit codes.
+
+touchpoints:
+  - T1: "cmd/sync — global sync, per-file fsync, fdatasync, filesystem sync (prd085-sync R1, R2)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and exit code comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for global sync, per-file sync, data-only sync,
+      filesystem sync, and error cases, confirming full parity with gsync.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+
+out_of_scope:
+  - Filesystem-type-specific sync semantics beyond OS-provided behavior.
+
+test_suite: test-rel-10.0


### PR DESCRIPTION
## Summary

Specifies two releases: rel09.1 (encoding utilities: base32, base64, basenc) and rel10.0 (file metadata: stat, truncate, link, sync). This brings the total to 85 specified utilities (79% of ~108 target).

## Changes

- 7 PRDs: prd079-base32, prd080-base64, prd081-basenc, prd082-stat, prd083-truncate, prd084-link, prd085-sync
- 7 use cases: rel09.1-uc001-003, rel10.0-uc001-004
- 2 test suites: test-rel-09.1, test-rel-10.0
- road-map.yaml: added rel09.1 and rel10.0

## Stats

- 17 files, 1,426 lines added
- 85 utilities specified (79% of ~108 target)

## Test plan

- [x] `mage analyze` — schema 0 errors, semantic 0 errors, broken citations 0

Closes #3144