### PR TITLE
GH-3148: Add shared pkg/ PRDs (hashutil, sizeparse, encutil) and wire consumers

### DIFF
--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -19,6 +19,12 @@ releases:
           status: implemented
         - id: rel00.0-uc004-testutils
           status: implemented
+        - id: rel00.0-uc005-hashutil
+          status: spec_complete
+        - id: rel00.0-uc006-sizeparse
+          status: spec_complete
+        - id: rel00.0-uc007-encutil
+          status: spec_complete
     - version: "01.1"
       name: "Batch 1.1 — cat specification and differential test"
       status: spec_complete

--- a/docs/specs/product-requirements/prd018-head.yaml
+++ b/docs/specs/product-requirements/prd018-head.yaml
@@ -88,6 +88,11 @@ non_goals:
   - cmd/head does not implement the full range of GNU multiplier suffixes (kB, MB, GB decimal variants). Only binary suffixes (K/KiB, M/MiB, G/GiB, b) are supported.
   - cmd/head does not follow files or re-read on change; it reads each input once.
 
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sizeparse
+    - github.com/petar-djukic/go-unix-utils/pkg/sys
+
 acceptance_criteria:
   - id: AC1
     criterion: "seq 1 20 | go run ./cmd/head produces lines 1 through 10, matching ghead."

--- a/docs/specs/product-requirements/prd030-md5sum.yaml
+++ b/docs/specs/product-requirements/prd030-md5sum.yaml
@@ -77,6 +77,11 @@ non_goals:
   - cmd/md5sum does not implement HMAC-MD5 or keyed variants; it computes raw MD5 digests only.
   - cmd/md5sum does not implement the --strict flag (exit non-zero for improperly formatted lines); --warn is sufficient.
 
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/hashutil
+    - github.com/petar-djukic/go-unix-utils/pkg/sys
+
 acceptance_criteria:
   - id: AC1
     criterion: "echo -n 'abc' | md5sum produces 'md5sum output matching gmd5sum', verified byte-for-byte."

--- a/docs/specs/product-requirements/prd031-sha1sum.yaml
+++ b/docs/specs/product-requirements/prd031-sha1sum.yaml
@@ -71,6 +71,11 @@ non_goals:
   - cmd/sha1sum does not implement HMAC-SHA1 or keyed variants.
   - SHA-1 is cryptographically broken; this implementation is for compatibility with GNU tools only.
 
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/hashutil
+    - github.com/petar-djukic/go-unix-utils/pkg/sys
+
 acceptance_criteria:
   - id: AC1
     criterion: "sha1sum on a known file produces the correct SHA-1 hash in GNU format, matching gsha1sum."

--- a/docs/specs/product-requirements/prd032-sha256sum.yaml
+++ b/docs/specs/product-requirements/prd032-sha256sum.yaml
@@ -71,6 +71,11 @@ non_goals:
   - cmd/sha256sum does not implement HMAC-SHA256 or keyed variants.
   - cmd/sha256sum does not implement SHA-224; it computes SHA-256 only.
 
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/hashutil
+    - github.com/petar-djukic/go-unix-utils/pkg/sys
+
 acceptance_criteria:
   - id: AC1
     criterion: "sha256sum on a known file produces the correct SHA-256 hash in GNU format, matching gsha256sum."

--- a/docs/specs/product-requirements/prd033-sha512sum.yaml
+++ b/docs/specs/product-requirements/prd033-sha512sum.yaml
@@ -71,6 +71,11 @@ non_goals:
   - cmd/sha512sum does not implement HMAC-SHA512 or keyed variants.
   - cmd/sha512sum does not implement SHA-384 or SHA-512/256 truncations.
 
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/hashutil
+    - github.com/petar-djukic/go-unix-utils/pkg/sys
+
 acceptance_criteria:
   - id: AC1
     criterion: "sha512sum on a known file produces the correct SHA-512 hash in GNU format, matching gsha512sum."

--- a/docs/specs/product-requirements/prd055-tail.yaml
+++ b/docs/specs/product-requirements/prd055-tail.yaml
@@ -83,6 +83,11 @@ non_goals:
   - "cmd/tail does not implement --retry (keep trying to open a file). This flag is only meaningful with -f."
   - cmd/tail does not implement -F (equivalent to --follow=name --retry).
 
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sizeparse
+    - github.com/petar-djukic/go-unix-utils/pkg/sys
+
 acceptance_criteria:
   - id: AC1
     criterion: "seq 1 20 | go run ./cmd/tail produces lines 11 through 20, matching gtail."

--- a/docs/specs/product-requirements/prd067-split.yaml
+++ b/docs/specs/product-requirements/prd067-split.yaml
@@ -84,6 +84,11 @@ non_goals:
   - cmd/split does not implement --verbose output mode.
   - cmd/split does not implement --elide-empty-files beyond what -n provides natively.
 
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sizeparse
+    - github.com/petar-djukic/go-unix-utils/pkg/sys
+
 acceptance_criteria:
   - id: AC1
     criterion: "seq 1 3000 | go run ./cmd/split produces xaa (lines 1-1000), xab (lines 1001-2000), xac (lines 2001-3000), matching gsplit."

--- a/docs/specs/product-requirements/prd072-od.yaml
+++ b/docs/specs/product-requirements/prd072-od.yaml
@@ -83,6 +83,11 @@ non_goals:
   - cmd/od does not implement --strings (-S) string extraction mode.
   - cmd/od does not implement --endian for byte-order control beyond native order.
 
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sizeparse
+    - github.com/petar-djukic/go-unix-utils/pkg/sys
+
 acceptance_criteria:
   - id: AC1
     criterion: "printf '\\x01\\x02\\x03\\x04' | go run ./cmd/od produces octal dump output matching god."

--- a/docs/specs/product-requirements/prd074-sha224sum.yaml
+++ b/docs/specs/product-requirements/prd074-sha224sum.yaml
@@ -71,6 +71,11 @@ non_goals:
   - cmd/sha224sum does not implement HMAC-SHA224 or keyed variants.
   - cmd/sha224sum does not implement SHA-256; it computes SHA-224 only.
 
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/hashutil
+    - github.com/petar-djukic/go-unix-utils/pkg/sys
+
 acceptance_criteria:
   - id: AC1
     criterion: "sha224sum on a known file produces the correct SHA-224 hash in GNU format, matching gsha224sum."

--- a/docs/specs/product-requirements/prd075-sha384sum.yaml
+++ b/docs/specs/product-requirements/prd075-sha384sum.yaml
@@ -71,6 +71,11 @@ non_goals:
   - cmd/sha384sum does not implement HMAC-SHA384 or keyed variants.
   - cmd/sha384sum does not implement SHA-512; it computes SHA-384 only.
 
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/hashutil
+    - github.com/petar-djukic/go-unix-utils/pkg/sys
+
 acceptance_criteria:
   - id: AC1
     criterion: "sha384sum on a known file produces the correct SHA-384 hash in GNU format, matching gsha384sum."

--- a/docs/specs/product-requirements/prd076-b2sum.yaml
+++ b/docs/specs/product-requirements/prd076-b2sum.yaml
@@ -73,6 +73,11 @@ non_goals:
   - cmd/b2sum does not implement BLAKE2s; it computes BLAKE2b only.
   - cmd/b2sum does not implement keyed hashing or BLAKE2 MAC mode.
 
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/hashutil
+    - github.com/petar-djukic/go-unix-utils/pkg/sys
+
 acceptance_criteria:
   - id: AC1
     criterion: "b2sum on a known file produces the correct BLAKE2b-512 hash in GNU format, matching gb2sum."

--- a/docs/specs/product-requirements/prd079-base32.yaml
+++ b/docs/specs/product-requirements/prd079-base32.yaml
@@ -64,6 +64,11 @@ non_goals:
   - cmd/base32 does not implement Base32hex (extended hex alphabet).
   - cmd/base32 does not implement Base64; use base64 for that.
 
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/encutil
+    - github.com/petar-djukic/go-unix-utils/pkg/sys
+
 acceptance_criteria:
   - id: AC1
     criterion: "echo hello | base32 produces Base32 encoded output matching gbase32."

--- a/docs/specs/product-requirements/prd080-base64.yaml
+++ b/docs/specs/product-requirements/prd080-base64.yaml
@@ -64,6 +64,11 @@ non_goals:
   - cmd/base64 does not implement Base64url (URL-safe alphabet).
   - cmd/base64 does not implement Base32; use base32 for that.
 
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/encutil
+    - github.com/petar-djukic/go-unix-utils/pkg/sys
+
 acceptance_criteria:
   - id: AC1
     criterion: "echo hello | base64 produces Base64 encoded output matching gbase64."

--- a/docs/specs/product-requirements/prd081-basenc.yaml
+++ b/docs/specs/product-requirements/prd081-basenc.yaml
@@ -66,6 +66,11 @@ non_goals:
   - cmd/basenc does not implement Base2 (binary) encoding.
   - cmd/basenc does not implement custom alphabet specification.
 
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/encutil
+    - github.com/petar-djukic/go-unix-utils/pkg/sys
+
 acceptance_criteria:
   - id: AC1
     criterion: "echo hello | basenc --base64 produces Base64 encoded output matching gbasenc --base64."

--- a/docs/specs/product-requirements/prd083-truncate.yaml
+++ b/docs/specs/product-requirements/prd083-truncate.yaml
@@ -56,6 +56,11 @@ requirements:
 non_goals:
   - cmd/truncate does not implement sparse file optimization.
 
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sizeparse
+    - github.com/petar-djukic/go-unix-utils/pkg/sys
+
 acceptance_criteria:
   - id: AC1
     criterion: "truncate -s 100 file creates or resizes file to 100 bytes, matching gtruncate."

--- a/docs/specs/product-requirements/prd086-hashutil.yaml
+++ b/docs/specs/product-requirements/prd086-hashutil.yaml
@@ -1,0 +1,150 @@
+id: prd086-hashutil
+title: "pkg/hashutil: Shared Hash Output and Verification Library"
+
+problem: |
+  Nine cmd/ utilities (md5sum, sha1sum, sha256sum, sha512sum, sha224sum, sha384sum,
+  b2sum, cksum, sum) share identical logic for formatting hash output in GNU text/binary
+  format, BSD tag format, and --check verification mode. In run 37, each utility
+  independently implemented ~300 lines of output formatting, checksum file parsing,
+  and --check/--warn/--quiet/--status flag handling. This duplication inflates stitch
+  task complexity and increases the risk of inconsistent behavior across utilities.
+
+  pkg/hashutil provides the shared output and verification logic. Each cmd/ utility
+  imports this package and supplies only the hash function and algorithm name; all
+  formatting, parsing, and verification behavior is delegated to pkg/hashutil.
+
+goals:
+  - G1: Provide a generic hash output formatter that produces GNU text, GNU binary, and BSD tag formats for any hash algorithm.
+  - G2: Provide a checksum file parser and verifier that handles GNU and BSD tag format lines.
+  - G3: Provide --check mode flag handling (--warn, --quiet, --status) as reusable logic.
+
+requirements:
+  R1:
+    title: Hash output formatting
+    items:
+      - R1.1:
+          text: |
+            Must provide a HashConfig struct that parameterizes the hash utility:
+
+              type HashConfig struct {
+                  Algorithm   string          // e.g. "MD5", "SHA256", "BLAKE2b"
+                  NewHash     func() hash.Hash // factory for the hash function
+                  DigestLen   int             // expected hex digest length (e.g., 32 for MD5, 64 for SHA-256)
+              }
+          weight: 1
+      - R1.2:
+          text: Must provide func FormatGNU(digest, filename string, binary bool) string that returns "HASH  FILENAME" (text mode) or "HASH *FILENAME" (binary mode).
+          weight: 1
+      - R1.3:
+          text: Must provide func FormatBSDTag(algorithm, filename, digest string) string that returns "ALGORITHM (FILENAME) = HASH".
+          weight: 1
+      - R1.4:
+          text: Must provide func ComputeDigest(r io.Reader, cfg HashConfig) (string, error) that reads all bytes from r, computes the hash, and returns the lowercase hex-encoded digest string.
+          weight: 1
+
+  R2:
+    title: Checksum verification
+    items:
+      - R2.1:
+          text: Must provide func ParseChecksumLine(line string, cfg HashConfig) (filename string, expectedDigest string, binary bool, err error) that parses a single line in GNU format ("HASH [ *]FILENAME") or BSD tag format ("ALGORITHM (FILENAME) = HASH"). Returns an error for malformed lines.
+          weight: 1
+      - R2.2:
+          text: |
+            Must provide a CheckOptions struct for --check mode behavior:
+
+              type CheckOptions struct {
+                  Warn   bool // print warning for malformed lines
+                  Quiet  bool // suppress OK lines
+                  Status bool // suppress all output, report only via exit code
+              }
+          weight: 1
+      - R2.3:
+          text: Must provide func VerifyChecksums(checksumFile string, cfg HashConfig, opts CheckOptions, stdout, stderr io.Writer) (ok bool, err error) that reads the checksum file, verifies each entry, prints results according to CheckOptions, and returns whether all checks passed.
+          weight: 4
+
+  R3:
+    title: File processing
+    items:
+      - R3.1:
+          text: Must provide func DigestFiles(files []string, cfg HashConfig, binary bool, tag bool, stdout, stderr io.Writer) int that computes and prints digests for each file (or stdin when files is empty or contains "-"), returning the exit code (0 for success, 1 if any file failed).
+          weight: 1
+      - R3.2:
+          text: Must continue processing remaining files when one file cannot be opened, printing an error to stderr for each failure.
+          weight: 1
+
+non_goals:
+  - pkg/hashutil does not implement any specific hash algorithm; callers provide hash.Hash factories.
+  - pkg/hashutil does not handle SIGPIPE; each cmd/ utility calls pkg/sys.InstallSIGPIPEHandler independently.
+  - pkg/hashutil does not implement cksum's CRC-32 or sum's BSD/System V algorithms; those utilities use hashutil only for their non-CRC --algorithm modes.
+
+package_contract:
+  exports:
+    - name: HashConfig
+      signature: "type HashConfig struct { Algorithm string; NewHash func() hash.Hash; DigestLen int }"
+    - name: CheckOptions
+      signature: "type CheckOptions struct { Warn bool; Quiet bool; Status bool }"
+    - name: FormatGNU
+      signature: "func FormatGNU(digest, filename string, binary bool) string"
+    - name: FormatBSDTag
+      signature: "func FormatBSDTag(algorithm, filename, digest string) string"
+    - name: ComputeDigest
+      signature: "func ComputeDigest(r io.Reader, cfg HashConfig) (string, error)"
+    - name: ParseChecksumLine
+      signature: "func ParseChecksumLine(line string, cfg HashConfig) (filename, expectedDigest string, binary bool, err error)"
+    - name: VerifyChecksums
+      signature: "func VerifyChecksums(checksumFile string, cfg HashConfig, opts CheckOptions, stdout, stderr io.Writer) (bool, error)"
+    - name: DigestFiles
+      signature: "func DigestFiles(files []string, cfg HashConfig, binary, tag bool, stdout, stderr io.Writer) int"
+  imports:
+    - hash
+    - io
+    - os
+    - fmt
+    - encoding/hex
+    - bufio
+    - strings
+    - regexp
+  import_constraints:
+    - "Must not import any cmd/ package."
+    - "Must not import any other pkg/ package."
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "ComputeDigest with crypto/md5 on 'hello\\n' returns the correct MD5 hex digest."
+    traces:
+      - R1.1
+      - R1.4
+  - id: AC2
+    criterion: "FormatGNU produces 'HASH  file' in text mode and 'HASH *file' in binary mode."
+    traces:
+      - R1.2
+  - id: AC3
+    criterion: "FormatBSDTag produces 'MD5 (file) = HASH' format."
+    traces:
+      - R1.3
+  - id: AC4
+    criterion: "ParseChecksumLine correctly parses both GNU and BSD tag format lines."
+    traces:
+      - R2.1
+  - id: AC5
+    criterion: "VerifyChecksums returns false and prints FAILED when a digest mismatches."
+    traces:
+      - R2.2
+      - R2.3
+  - id: AC6
+    criterion: "DigestFiles processes multiple files, printing errors for missing ones and continuing."
+    traces:
+      - R3.1
+      - R3.2
+  - id: AC7
+    criterion: "pkg/hashutil compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R3.1
+      - R3.2

--- a/docs/specs/product-requirements/prd087-sizeparse.yaml
+++ b/docs/specs/product-requirements/prd087-sizeparse.yaml
@@ -1,0 +1,123 @@
+id: prd087-sizeparse
+title: "pkg/sizeparse: Size String Parser with Unit Suffixes"
+
+problem: |
+  Eight cmd/ utilities (head, tail, split, truncate, numfmt, du, sort, od) need to parse
+  size strings with unit suffixes (K, M, G, T for powers of 1024; KB, MB, GB for powers
+  of 1000; b for 512). In run 37, each utility independently implemented suffix parsing
+  with slight variations, totaling ~50 lines per utility. This duplication risks
+  inconsistent suffix handling across utilities.
+
+  pkg/sizeparse provides a single parser that handles all GNU coreutils suffix
+  conventions. Each cmd/ utility imports this package instead of reimplementing suffix
+  multiplication.
+
+goals:
+  - G1: Parse size strings with binary (IEC) and decimal (SI) unit suffixes.
+  - G2: Support the full GNU coreutils suffix set including b, K, KiB, KB, M, MiB, MB, G, GiB, GB, T, TiB, TB, P, PiB, PB, E, EiB, EB, Z, ZiB, ZB, Y, YiB, YB.
+  - G3: Support optional sign prefixes (+, -) for relative size adjustments.
+
+requirements:
+  R1:
+    title: Size parsing
+    items:
+      - R1.1:
+          text: |
+            Must provide func Parse(s string) (int64, error) that parses a size string
+            consisting of an optional sign (+ or -), a decimal integer, and an optional
+            unit suffix. Returns the size in bytes. Returns an error for invalid input.
+          weight: 1
+      - R1.2:
+          text: |
+            Must support binary (IEC) suffixes: K or KiB (1024), M or MiB (1024^2),
+            G or GiB (1024^3), T or TiB (1024^4), P or PiB (1024^5), E or EiB (1024^6),
+            Z or ZiB (1024^7), Y or YiB (1024^8). Must also support b (512) for
+            POSIX compatibility.
+          weight: 1
+      - R1.3:
+          text: |
+            Must support decimal (SI) suffixes: KB (1000), MB (1000^2), GB (1000^3),
+            TB (1000^4), PB (1000^5), EB (1000^6), ZB (1000^7), YB (1000^8).
+          weight: 1
+      - R1.4:
+          text: Must preserve the sign in the returned value. "+100K" returns +102400, "-50M" returns -52428800. No sign prefix means positive.
+          weight: 1
+
+  R2:
+    title: Extended parsing options
+    items:
+      - R2.1:
+          text: |
+            Must provide func ParseWithOptions(s string, opts ParseOptions) (int64, error)
+            where ParseOptions allows configuring behavior:
+
+              type ParseOptions struct {
+                  AllowSign    bool // allow +/- prefix (default false for Parse)
+                  DefaultUnit  int64 // multiplier when no suffix given (default 1)
+              }
+          weight: 1
+      - R2.2:
+          text: "ParseWithOptions with DefaultUnit=1024 and input '5' returns 5120 (5 * 1024). This supports utilities like du where the default unit is blocks."
+          weight: 1
+
+  R3:
+    title: Constraints
+    items:
+      - R3.1:
+          text: Must return an error when the numeric part overflows int64.
+          weight: 1
+      - R3.2:
+          text: Must return an error when the suffix is not recognized.
+          weight: 1
+
+non_goals:
+  - pkg/sizeparse does not format sizes for output; use pkg/format.HumanSize for that.
+  - pkg/sizeparse does not handle floating-point sizes.
+
+package_contract:
+  exports:
+    - name: ParseOptions
+      signature: "type ParseOptions struct { AllowSign bool; DefaultUnit int64 }"
+    - name: Parse
+      signature: "func Parse(s string) (int64, error)"
+    - name: ParseWithOptions
+      signature: "func ParseWithOptions(s string, opts ParseOptions) (int64, error)"
+  imports:
+    - fmt
+    - strconv
+    - strings
+  import_constraints:
+    - "Must not import any cmd/ package."
+    - "Must not import any other pkg/ package."
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "Parse('100K') returns 102400."
+    traces:
+      - R1.1
+      - R1.2
+  - id: AC2
+    criterion: "Parse('5MB') returns 5000000."
+    traces:
+      - R1.1
+      - R1.3
+  - id: AC3
+    criterion: "ParseWithOptions('+50M', ParseOptions{AllowSign: true}) returns 52428800."
+    traces:
+      - R1.4
+      - R2.1
+  - id: AC4
+    criterion: "Parse('invalid') returns an error."
+    traces:
+      - R3.2
+  - id: AC5
+    criterion: "pkg/sizeparse compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R3.1
+      - R3.2

--- a/docs/specs/product-requirements/prd088-encutil.yaml
+++ b/docs/specs/product-requirements/prd088-encutil.yaml
@@ -1,0 +1,128 @@
+id: prd088-encutil
+title: "pkg/encutil: Shared Encoding and Decoding Library"
+
+problem: |
+  Three cmd/ utilities (base32, base64, basenc) share identical logic for encoding stdin
+  or file input, decoding with whitespace and garbage tolerance, and wrapping output at
+  a configurable column width. Without a shared package, each utility reimplements the
+  read-encode-wrap-write pipeline and the decode-ignore-garbage pipeline.
+
+  pkg/encutil provides the shared encoding/decoding pipeline. Each cmd/ utility imports
+  this package and supplies the encoding scheme; all I/O, wrapping, and error handling
+  is delegated to pkg/encutil.
+
+goals:
+  - G1: Provide a generic encode pipeline that reads input, encodes it, and writes wrapped output.
+  - G2: Provide a generic decode pipeline that reads encoded input, optionally ignores garbage, and writes decoded output.
+  - G3: Support configurable wrap width and encoding schemes.
+
+requirements:
+  R1:
+    title: Encoding pipeline
+    items:
+      - R1.1:
+          text: |
+            Must provide an EncoderConfig struct:
+
+              type EncoderConfig struct {
+                  Encode   func(src []byte) string  // encoding function
+                  WrapCol  int                       // wrap column (0 = no wrap, default 76)
+              }
+          weight: 1
+      - R1.2:
+          text: Must provide func Encode(r io.Reader, w io.Writer, cfg EncoderConfig) error that reads all input from r, encodes it using cfg.Encode, wraps the output at cfg.WrapCol characters per line, and writes to w.
+          weight: 1
+      - R1.3:
+          text: When WrapCol is 0, must write the entire encoded output as a single line followed by a newline.
+          weight: 1
+
+  R2:
+    title: Decoding pipeline
+    items:
+      - R2.1:
+          text: |
+            Must provide a DecoderConfig struct:
+
+              type DecoderConfig struct {
+                  Decode        func(src string) ([]byte, error) // decoding function
+                  IgnoreGarbage bool                              // ignore non-alphabet characters
+              }
+          weight: 1
+      - R2.2:
+          text: Must provide func Decode(r io.Reader, w io.Writer, cfg DecoderConfig) error that reads all encoded input from r, strips whitespace, optionally strips non-alphabet characters (when IgnoreGarbage is true), decodes, and writes the binary result to w.
+          weight: 1
+      - R2.3:
+          text: Must return an error when the input contains invalid characters and IgnoreGarbage is false.
+          weight: 1
+
+  R3:
+    title: File handling
+    items:
+      - R3.1:
+          text: Must provide func OpenInput(filename string) (io.ReadCloser, error) that opens the named file, or returns os.Stdin when filename is empty or "-".
+          weight: 1
+      - R3.2:
+          text: Must exit 1 when the input file cannot be opened, printing an error to stderr.
+          weight: 1
+
+non_goals:
+  - pkg/encutil does not implement any specific encoding scheme; callers provide encode/decode functions.
+  - pkg/encutil does not handle SIGPIPE; each cmd/ utility calls pkg/sys.InstallSIGPIPEHandler independently.
+
+package_contract:
+  exports:
+    - name: EncoderConfig
+      signature: "type EncoderConfig struct { Encode func([]byte) string; WrapCol int }"
+    - name: DecoderConfig
+      signature: "type DecoderConfig struct { Decode func(string) ([]byte, error); IgnoreGarbage bool }"
+    - name: Encode
+      signature: "func Encode(r io.Reader, w io.Writer, cfg EncoderConfig) error"
+    - name: Decode
+      signature: "func Decode(r io.Reader, w io.Writer, cfg DecoderConfig) error"
+    - name: OpenInput
+      signature: "func OpenInput(filename string) (io.ReadCloser, error)"
+  imports:
+    - io
+    - os
+    - bufio
+    - strings
+  import_constraints:
+    - "Must not import any cmd/ package."
+    - "Must not import any other pkg/ package."
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "Encode with Base64 encoder wraps at 76 characters by default."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+  - id: AC2
+    criterion: "Encode with WrapCol=0 produces single-line output."
+    traces:
+      - R1.3
+  - id: AC3
+    criterion: "Decode with Base64 decoder and IgnoreGarbage=true ignores non-alphabet characters."
+    traces:
+      - R2.1
+      - R2.2
+      - R2.3
+  - id: AC4
+    criterion: "Decode with IgnoreGarbage=false returns error on invalid input."
+    traces:
+      - R2.3
+  - id: AC5
+    criterion: "OpenInput('-') returns os.Stdin."
+    traces:
+      - R3.1
+  - id: AC6
+    criterion: "pkg/encutil compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R2.1
+      - R2.2
+      - R2.3
+      - R3.1
+      - R3.2

--- a/docs/specs/test-suites/test-rel00.0.yaml
+++ b/docs/specs/test-suites/test-rel00.0.yaml
@@ -23,6 +23,18 @@ traces:
   - prd001-testutils R3
   - prd001-testutils R4
   - prd001-testutils R5
+  - rel00.0-uc005-hashutil
+  - prd086-hashutil R1
+  - prd086-hashutil R2
+  - prd086-hashutil R3
+  - rel00.0-uc006-sizeparse
+  - prd087-sizeparse R1
+  - prd087-sizeparse R2
+  - prd087-sizeparse R3
+  - rel00.0-uc007-encutil
+  - prd088-encutil R1
+  - prd088-encutil R2
+  - prd088-encutil R3
 
 preconditions:
   - A git repository with at least one tag matching v[0-9]*.

--- a/docs/specs/use-cases/rel00.0-uc005-hashutil.yaml
+++ b/docs/specs/use-cases/rel00.0-uc005-hashutil.yaml
@@ -1,0 +1,49 @@
+id: rel00.0-uc005-hashutil
+title: "Shared hash output formatting and verification via hashutil"
+
+summary: |
+  The pkg/hashutil library provides shared logic for formatting hash digests in GNU
+  text/binary and BSD tag formats, parsing checksum files, and verifying digests with
+  --check mode. All hash cmd/ utilities (md5sum, sha1sum, sha256sum, sha512sum,
+  sha224sum, sha384sum, b2sum) import this package instead of reimplementing the
+  output and verification logic.
+
+actor: Stitch Agent
+
+trigger: |
+  The stitch agent implements a hash utility PRD and needs hash output formatting,
+  checksum file parsing, or --check verification logic.
+
+flow:
+  - id: F1
+    step: |
+      The stitch agent reads the hashutil PRD and implements the shared library with
+      HashConfig, FormatGNU, FormatBSDTag, ComputeDigest, ParseChecksumLine, and
+      VerifyChecksums functions.
+  - id: F2
+    step: |
+      The stitch agent writes unit tests for each exported function, verifying correct
+      output format, parsing, and verification behavior.
+
+touchpoints:
+  - T1: "pkg/hashutil — hash output formatting, checksum parsing, verification (prd086-hashutil R1, R2, R3)"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      Unit tests pass for ComputeDigest, FormatGNU, FormatBSDTag, ParseChecksumLine,
+      VerifyChecksums, and DigestFiles with multiple hash algorithms.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+      - AC5
+      - AC6
+      - AC7
+
+out_of_scope:
+  - Specific hash algorithm implementations (provided by Go standard library).
+  - SIGPIPE handling (each cmd/ utility handles independently).
+
+test_suite: test-rel00.0

--- a/docs/specs/use-cases/rel00.0-uc006-sizeparse.yaml
+++ b/docs/specs/use-cases/rel00.0-uc006-sizeparse.yaml
@@ -1,0 +1,45 @@
+id: rel00.0-uc006-sizeparse
+title: "Shared size string parsing with unit suffixes via sizeparse"
+
+summary: |
+  The pkg/sizeparse library provides a single parser for size strings with unit
+  suffixes (K, M, G, KB, MB, etc.) used by eight cmd/ utilities (head, tail, split,
+  truncate, numfmt, du, sort, od). Each utility imports this package instead of
+  reimplementing suffix multiplication logic.
+
+actor: Stitch Agent
+
+trigger: |
+  The stitch agent implements a utility PRD that requires parsing size strings with
+  unit suffixes.
+
+flow:
+  - id: F1
+    step: |
+      The stitch agent reads the sizeparse PRD and implements Parse and
+      ParseWithOptions functions supporting the full GNU coreutils suffix set.
+  - id: F2
+    step: |
+      The stitch agent writes unit tests covering binary (IEC) suffixes, decimal (SI)
+      suffixes, sign prefixes, default units, and error cases.
+
+touchpoints:
+  - T1: "pkg/sizeparse — size string parsing with unit suffixes (prd087-sizeparse R1, R2, R3)"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      Unit tests pass for Parse and ParseWithOptions with binary suffixes, decimal
+      suffixes, sign prefixes, default units, overflow, and invalid input.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+      - AC5
+
+out_of_scope:
+  - Size formatting for output (handled by pkg/format.HumanSize).
+  - Floating-point size parsing.
+
+test_suite: test-rel00.0

--- a/docs/specs/use-cases/rel00.0-uc007-encutil.yaml
+++ b/docs/specs/use-cases/rel00.0-uc007-encutil.yaml
@@ -1,0 +1,46 @@
+id: rel00.0-uc007-encutil
+title: "Shared encoding and decoding pipeline via encutil"
+
+summary: |
+  The pkg/encutil library provides shared logic for encoding and decoding data with
+  configurable encoding schemes, line wrapping, and garbage tolerance. The base32,
+  base64, and basenc cmd/ utilities import this package instead of reimplementing the
+  encode/decode/wrap pipeline.
+
+actor: Stitch Agent
+
+trigger: |
+  The stitch agent implements an encoding utility PRD and needs the shared encode/decode
+  pipeline.
+
+flow:
+  - id: F1
+    step: |
+      The stitch agent reads the encutil PRD and implements the shared library with
+      Encode, Decode, and OpenInput functions.
+  - id: F2
+    step: |
+      The stitch agent writes unit tests for encoding with wrap control, decoding
+      with garbage tolerance, and file input handling.
+
+touchpoints:
+  - T1: "pkg/encutil — encoding/decoding pipeline, wrap control, garbage handling (prd088-encutil R1, R2, R3)"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      Unit tests pass for Encode with wrap control, Decode with garbage tolerance,
+      and OpenInput with stdin fallback.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+      - AC5
+      - AC6
+
+out_of_scope:
+  - Specific encoding scheme implementations (provided by Go standard library).
+  - SIGPIPE handling (each cmd/ utility handles independently).
+
+test_suite: test-rel00.0


### PR DESCRIPTION
## Summary

Creates three shared pkg/ library PRDs in rel00.0 and updates 15 consuming cmd/ PRDs with package_contract imports. This eliminates ~1,200 lines of duplicated hash formatting code across utilities and establishes shared infrastructure for size parsing and encoding.

## Changes

- 3 new PRDs: prd086-hashutil, prd087-sizeparse, prd088-encutil
- 3 new use cases in rel00.0: uc005-hashutil, uc006-sizeparse, uc007-encutil
- 15 consuming PRDs updated with package_contract.imports
- test-rel00.0.yaml updated with new traces
- road-map.yaml: 3 new use cases in rel00.0

## Test plan

- [x] `mage analyze` — schema 0 errors, semantic 0 errors, broken citations 0

Closes #3148