### PR TITLE
GH-3146: Specify rel10.1 and rel11.0 — chmod, chgrp, chown, mkfifo, mknod, nice, nohup

### DIFF
--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -457,3 +457,39 @@ releases:
           status: spec_complete
         - id: rel10.0-uc004-sync
           status: spec_complete
+    - version: "10.1"
+      name: "Batch 10.1 — permission and ownership (chmod, chgrp, chown)"
+      status: spec_complete
+      depends_on: ["00.0"]
+      description: |
+        Implement three permission and ownership utilities. chmod changes file mode bits
+        with octal and symbolic mode specifications. chgrp changes group ownership. chown
+        changes file owner and group with OWNER[:GROUP] syntax. All support recursive
+        traversal and symlink handling options. All are verified by differential testing
+        against GNU coreutils reference binaries.
+      use_cases:
+        - id: rel10.1-uc001-chmod
+          status: spec_complete
+        - id: rel10.1-uc002-chgrp
+          status: spec_complete
+        - id: rel10.1-uc003-chown
+          status: spec_complete
+    - version: "11.0"
+      name: "Batch 11.0 — special files and process control (mkfifo, mknod, nice, nohup)"
+      status: spec_complete
+      depends_on: ["00.0"]
+      description: |
+        Implement four special file and process control utilities. mkfifo creates named
+        pipes. mknod creates block special, character special, or FIFO files. nice runs
+        commands with adjusted scheduling priority. nohup runs commands immune to SIGHUP
+        with automatic output redirection. All are verified by differential testing against
+        GNU coreutils reference binaries.
+      use_cases:
+        - id: rel11.0-uc001-mkfifo
+          status: spec_complete
+        - id: rel11.0-uc002-mknod
+          status: spec_complete
+        - id: rel11.0-uc003-nice
+          status: spec_complete
+        - id: rel11.0-uc004-nohup
+          status: spec_complete

--- a/docs/specs/product-requirements/prd089-chmod.yaml
+++ b/docs/specs/product-requirements/prd089-chmod.yaml
@@ -1,0 +1,115 @@
+id: prd089-chmod
+title: "cmd/chmod: Change File Mode Bits"
+
+problem: |
+  macOS ships a BSD chmod that differs from GNU chmod in recursive behavior, verbose
+  output, and symbolic mode parsing edge cases. The Go implementation must match the
+  Homebrew GNU reference binary (gchmod, installed by coreutils) byte-for-byte on all
+  flag combinations, verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Change file permission bits using octal or symbolic mode specifications.
+  - G2: Support recursive mode changes with -R.
+  - G3: Support verbose, changes-only, and silent output modes.
+  - G4: Verify functional parity against gchmod via differential testing.
+
+requirements:
+  R1:
+    title: Mode specification
+    items:
+      - R1.1:
+          text: Must accept an octal mode (e.g., 755, 0644) and set the file's permission bits to that value.
+          weight: 1
+      - R1.2:
+          text: "Must accept symbolic mode specifications: [ugoa][+-=][rwxXst] with comma-separated clauses (e.g., u+x, go-w, a=rw). Must support multiple comma-separated clauses (e.g., u=rwx,go=rx)."
+          weight: 4
+      - R1.3:
+          text: Must process multiple FILE arguments, applying the mode change to each.
+          weight: 1
+      - R1.4:
+          text: Must exit 1 when any file cannot be accessed, printing an error to stderr, and continue processing remaining files.
+          weight: 1
+
+  R2:
+    title: Recursive and output control
+    items:
+      - R2.1:
+          text: "-R or --recursive must change modes recursively for directories and their contents."
+          weight: 4
+      - R2.2:
+          text: "-v or --verbose must print a diagnostic for every file processed."
+          weight: 1
+      - R2.3:
+          text: "-c or --changes must print a diagnostic only for files whose mode actually changed."
+          weight: 1
+      - R2.4:
+          text: "-f or --silent or --quiet must suppress most error messages."
+          weight: 1
+
+  R3:
+    title: Special mode bits and reference
+    items:
+      - R3.1:
+          text: "Must support setuid (u+s), setgid (g+s), and sticky bit (o+t) in symbolic mode."
+          weight: 1
+      - R3.2:
+          text: "--reference=RFILE must set each FILE's mode to match RFILE's mode."
+          weight: 1
+
+  R4:
+    title: Exit codes and SIGPIPE
+    items:
+      - R4.1:
+          text: Must exit 0 when all files are processed successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any file cannot be accessed or the mode specification is invalid.
+          weight: 1
+      - R4.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/chmod does not implement SELinux context changes.
+  - cmd/chmod does not implement --preserve-root (not applicable on macOS).
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "chmod 755 file sets permissions to rwxr-xr-x, matching gchmod."
+    traces:
+      - R1.1
+      - R1.3
+  - id: AC2
+    criterion: "chmod u+x,go-w file applies symbolic mode correctly, matching gchmod."
+    traces:
+      - R1.2
+  - id: AC3
+    criterion: "chmod -R 644 dir recursively changes all files, matching gchmod -R."
+    traces:
+      - R2.1
+  - id: AC4
+    criterion: "Differential test against gchmod passes for all required test cases."
+    traces:
+      - R1.1
+      - R1.2
+      - R2.1
+  - id: AC5
+    criterion: "cmd/chmod compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+      - R3.1
+      - R3.2
+      - R4.1
+      - R4.2
+      - R4.3
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd090-chgrp.yaml
+++ b/docs/specs/product-requirements/prd090-chgrp.yaml
@@ -1,0 +1,93 @@
+id: prd090-chgrp
+title: "cmd/chgrp: Change Group Ownership"
+
+problem: |
+  macOS ships a BSD chgrp that differs from GNU chgrp in recursive traversal flags
+  and symlink handling options. The Go implementation must match the Homebrew GNU
+  reference binary (gchgrp, installed by coreutils) byte-for-byte on all flag
+  combinations, verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Change the group ownership of files.
+  - G2: Support recursive ownership changes with -R and symlink traversal control.
+  - G3: Verify functional parity against gchgrp via differential testing.
+
+requirements:
+  R1:
+    title: Group ownership change
+    items:
+      - R1.1:
+          text: Must accept a GROUP argument (name or numeric GID) and one or more FILE arguments, changing each file's group to GROUP.
+          weight: 1
+      - R1.2:
+          text: "--reference=RFILE must set each FILE's group to match RFILE's group."
+          weight: 1
+      - R1.3:
+          text: Must process multiple FILE arguments, applying the group change to each.
+          weight: 1
+      - R1.4:
+          text: Must exit 1 when any file cannot be accessed or the group is invalid, printing an error to stderr, and continue processing remaining files.
+          weight: 1
+
+  R2:
+    title: Recursive and symlink handling
+    items:
+      - R2.1:
+          text: "-R or --recursive must change group ownership recursively for directories and their contents."
+          weight: 4
+      - R2.2:
+          text: "-h or --no-dereference must change the symlink itself rather than the target. Without -h, must change the target."
+          weight: 1
+      - R2.3:
+          text: "-H must follow symlinks given on the command line but not in recursive traversal. -L must follow all symlinks. -P must never follow symlinks (default with -R)."
+          weight: 4
+
+  R3:
+    title: Output control and exit codes
+    items:
+      - R3.1:
+          text: "-v or --verbose must print a diagnostic for every file processed. -c or --changes must print only when changes are made. -f or --silent must suppress most errors."
+          weight: 1
+      - R3.2:
+          text: Must exit 0 when all files are processed successfully. Must exit 1 on any error.
+          weight: 1
+      - R3.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/chgrp does not implement --preserve-root.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "chgrp staff file changes group to staff, matching gchgrp."
+    traces:
+      - R1.1
+      - R1.3
+  - id: AC2
+    criterion: "chgrp -R staff dir recursively changes group, matching gchgrp -R."
+    traces:
+      - R2.1
+  - id: AC3
+    criterion: "Differential test against gchgrp passes for all required test cases."
+    traces:
+      - R1.1
+      - R1.2
+      - R2.1
+  - id: AC4
+    criterion: "cmd/chgrp compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R3.1
+      - R3.2
+      - R3.3
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd091-chown.yaml
+++ b/docs/specs/product-requirements/prd091-chown.yaml
@@ -1,0 +1,98 @@
+id: prd091-chown
+title: "cmd/chown: Change File Owner and Group"
+
+problem: |
+  macOS ships a BSD chown that differs from GNU chown in recursive traversal flags,
+  symlink handling, and OWNER:GROUP parsing. The Go implementation must match the
+  Homebrew GNU reference binary (gchown, installed by coreutils) byte-for-byte on all
+  flag combinations, verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Change the owner and/or group of files using OWNER, OWNER:GROUP, OWNER:, :GROUP, or numeric UID:GID syntax.
+  - G2: Support recursive ownership changes with -R and symlink traversal control.
+  - G3: Verify functional parity against gchown via differential testing.
+
+requirements:
+  R1:
+    title: Ownership specification
+    items:
+      - R1.1:
+          text: "Must accept OWNER[:GROUP] syntax: OWNER changes only owner, OWNER:GROUP changes both, OWNER: changes owner and sets group to OWNER's login group, :GROUP changes only group."
+          weight: 4
+      - R1.2:
+          text: OWNER and GROUP may be names or numeric IDs. Must resolve names to IDs via the system user/group database.
+          weight: 1
+      - R1.3:
+          text: "--reference=RFILE must set each FILE's owner and group to match RFILE's."
+          weight: 1
+      - R1.4:
+          text: Must exit 1 when any file cannot be accessed or the owner/group is invalid, printing an error to stderr, and continue processing remaining files.
+          weight: 1
+
+  R2:
+    title: Recursive and symlink handling
+    items:
+      - R2.1:
+          text: "-R or --recursive must change ownership recursively for directories and their contents."
+          weight: 4
+      - R2.2:
+          text: "-h or --no-dereference must change the symlink itself rather than the target."
+          weight: 1
+      - R2.3:
+          text: "-H must follow symlinks on the command line only. -L must follow all symlinks. -P must never follow symlinks (default with -R)."
+          weight: 4
+
+  R3:
+    title: Output control and exit codes
+    items:
+      - R3.1:
+          text: "-v or --verbose must print a diagnostic for every file processed. -c or --changes must print only when changes are made. -f or --silent must suppress most errors."
+          weight: 1
+      - R3.2:
+          text: Must exit 0 when all files are processed successfully. Must exit 1 on any error.
+          weight: 1
+      - R3.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/chown does not implement --preserve-root.
+  - cmd/chown does not implement --from=CURRENT_OWNER:CURRENT_GROUP conditional change.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "chown user:staff file changes owner and group, matching gchown."
+    traces:
+      - R1.1
+      - R1.2
+  - id: AC2
+    criterion: "chown -R user dir recursively changes owner, matching gchown -R."
+    traces:
+      - R2.1
+  - id: AC3
+    criterion: "chown :staff file changes only group, matching gchown."
+    traces:
+      - R1.1
+  - id: AC4
+    criterion: "Differential test against gchown passes for all required test cases."
+    traces:
+      - R1.1
+      - R1.2
+      - R2.1
+  - id: AC5
+    criterion: "cmd/chown compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R3.1
+      - R3.2
+      - R3.3
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd092-mkfifo.yaml
+++ b/docs/specs/product-requirements/prd092-mkfifo.yaml
@@ -1,0 +1,78 @@
+id: prd092-mkfifo
+title: "cmd/mkfifo: Make FIFOs (Named Pipes)"
+
+problem: |
+  macOS ships mkfifo but the GNU version supports --mode (-m) for setting permissions
+  at creation. The Go implementation must match the Homebrew GNU reference binary
+  (gmkfifo, installed by coreutils) byte-for-byte on all flag combinations, verified
+  by differential testing via pkg/testutils.
+
+goals:
+  - G1: Create one or more named pipes (FIFOs).
+  - G2: Support permission mode specification at creation.
+  - G3: Verify functional parity against gmkfifo via differential testing.
+
+requirements:
+  R1:
+    title: FIFO creation
+    items:
+      - R1.1:
+          text: Must create a FIFO (named pipe) at each specified path using the mkfifo(2) system call.
+          weight: 1
+      - R1.2:
+          text: Must process multiple NAME arguments, creating a FIFO for each.
+          weight: 1
+      - R1.3:
+          text: "-m MODE or --mode=MODE must set the FIFO's permission bits to MODE (octal or symbolic). Default is 0666 modified by umask."
+          weight: 1
+      - R1.4:
+          text: Must exit 1 when any FIFO cannot be created (e.g., path already exists), printing an error to stderr, and continue processing remaining arguments.
+          weight: 1
+
+  R2:
+    title: Exit codes and SIGPIPE
+    items:
+      - R2.1:
+          text: Must exit 0 when all FIFOs are created successfully.
+          weight: 1
+      - R2.2:
+          text: Must exit 1 when any creation fails.
+          weight: 1
+      - R2.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/mkfifo does not implement SELinux context setting.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "mkfifo pipe1 creates a FIFO at pipe1, matching gmkfifo."
+    traces:
+      - R1.1
+      - R1.2
+  - id: AC2
+    criterion: "mkfifo -m 600 pipe1 creates a FIFO with mode 600, matching gmkfifo."
+    traces:
+      - R1.3
+  - id: AC3
+    criterion: "Differential test against gmkfifo passes for all required test cases."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+  - id: AC4
+    criterion: "cmd/mkfifo compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd093-mknod.yaml
+++ b/docs/specs/product-requirements/prd093-mknod.yaml
@@ -1,0 +1,72 @@
+id: prd093-mknod
+title: "cmd/mknod: Make Block or Character Special Files"
+
+problem: |
+  macOS ships mknod but the GNU version supports --mode (-m) for setting permissions.
+  The Go implementation must match the Homebrew GNU reference binary (gmknod, installed
+  by coreutils) byte-for-byte on all flag combinations, verified by differential
+  testing via pkg/testutils.
+
+goals:
+  - G1: Create block special, character special, or FIFO special files.
+  - G2: Support permission mode specification at creation.
+  - G3: Verify functional parity against gmknod via differential testing.
+
+requirements:
+  R1:
+    title: Special file creation
+    items:
+      - R1.1:
+          text: "Must accept NAME TYPE [MAJOR MINOR] arguments. TYPE is b (block special), c or u (character special), or p (FIFO). Block and character types require MAJOR and MINOR device numbers."
+          weight: 4
+      - R1.2:
+          text: "-m MODE or --mode=MODE must set the file's permission bits to MODE (octal or symbolic). Default is 0666 modified by umask for FIFOs, 0660 for device files."
+          weight: 1
+      - R1.3:
+          text: Must exit 1 with an error when arguments are invalid (wrong count, non-numeric device numbers, FIFO with device numbers given).
+          weight: 1
+
+  R2:
+    title: Exit codes and SIGPIPE
+    items:
+      - R2.1:
+          text: Must exit 0 when the special file is created successfully.
+          weight: 1
+      - R2.2:
+          text: Must exit 1 when creation fails or arguments are invalid.
+          weight: 1
+      - R2.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/mknod does not implement SELinux context setting.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "mknod pipe1 p creates a FIFO, matching gmknod."
+    traces:
+      - R1.1
+  - id: AC2
+    criterion: "mknod -m 644 pipe1 p creates a FIFO with mode 644, matching gmknod."
+    traces:
+      - R1.2
+  - id: AC3
+    criterion: "Differential test against gmknod passes for all required test cases."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+  - id: AC4
+    criterion: "cmd/mknod compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R2.1
+      - R2.2
+      - R2.3
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd094-nice.yaml
+++ b/docs/specs/product-requirements/prd094-nice.yaml
@@ -1,0 +1,77 @@
+id: prd094-nice
+title: "cmd/nice: Run a Program with Modified Scheduling Priority"
+
+problem: |
+  macOS ships nice but the GNU version supports the --adjustment (-n) flag syntax.
+  The Go implementation must match the Homebrew GNU reference binary (gnice, installed
+  by coreutils) byte-for-byte on all flag combinations, verified by differential
+  testing via pkg/testutils.
+
+goals:
+  - G1: Run a command with an adjusted scheduling priority (nice value).
+  - G2: Print the current nice value when invoked without a command.
+  - G3: Verify functional parity against gnice via differential testing.
+
+requirements:
+  R1:
+    title: Priority adjustment
+    items:
+      - R1.1:
+          text: Must run COMMAND with its scheduling priority adjusted by the given increment. Default increment is 10 (lower priority).
+          weight: 1
+      - R1.2:
+          text: "-n ADJUST or --adjustment=ADJUST must set the priority increment. ADJUST may be negative (requires privileges) or positive."
+          weight: 1
+      - R1.3:
+          text: When invoked with no COMMAND, must print the current nice value to stdout and exit 0.
+          weight: 1
+      - R1.4:
+          text: Must pass all remaining arguments after COMMAND as arguments to the executed command.
+          weight: 1
+
+  R2:
+    title: Exit codes
+    items:
+      - R2.1:
+          text: Must exit with the exit status of COMMAND when COMMAND completes.
+          weight: 1
+      - R2.2:
+          text: Must exit 125 when the adjustment is invalid or nice(2) fails. Must exit 126 when COMMAND is found but cannot be invoked. Must exit 127 when COMMAND is not found.
+          weight: 1
+      - R2.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/nice does not implement real-time scheduling priorities.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "nice echo hello runs echo with default +10 priority, matching gnice."
+    traces:
+      - R1.1
+      - R1.4
+  - id: AC2
+    criterion: "nice -n 5 echo hello adjusts priority by 5, matching gnice."
+    traces:
+      - R1.2
+  - id: AC3
+    criterion: "Differential test against gnice passes for all required test cases."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+  - id: AC4
+    criterion: "cmd/nice compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd095-nohup.yaml
+++ b/docs/specs/product-requirements/prd095-nohup.yaml
@@ -1,0 +1,77 @@
+id: prd095-nohup
+title: "cmd/nohup: Run a Command Immune to Hangups"
+
+problem: |
+  macOS ships nohup but the GNU version has specific behavior for stdout/stderr
+  redirection to nohup.out. The Go implementation must match the Homebrew GNU reference
+  binary (gnohup, installed by coreutils) byte-for-byte on all flag combinations,
+  verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Run a command immune to SIGHUP, with stdout/stderr redirection when not a terminal.
+  - G2: Verify functional parity against gnohup via differential testing.
+
+requirements:
+  R1:
+    title: SIGHUP immunity and output redirection
+    items:
+      - R1.1:
+          text: Must ignore SIGHUP (signal.Ignore(syscall.SIGHUP)) before executing COMMAND.
+          weight: 1
+      - R1.2:
+          text: If stdout is a terminal, must redirect stdout to nohup.out in the current directory. If that fails, must redirect to $HOME/nohup.out. Must print a message to stderr indicating where output is redirected.
+          weight: 4
+      - R1.3:
+          text: If stderr is a terminal and stdout has been redirected, must redirect stderr to stdout (i.e., both go to nohup.out).
+          weight: 1
+      - R1.4:
+          text: Must pass all remaining arguments after COMMAND as arguments to the executed command.
+          weight: 1
+
+  R2:
+    title: Exit codes
+    items:
+      - R2.1:
+          text: Must exit with the exit status of COMMAND when COMMAND completes.
+          weight: 1
+      - R2.2:
+          text: Must exit 125 when nohup itself fails. Must exit 126 when COMMAND is found but cannot be invoked. Must exit 127 when COMMAND is not found.
+          weight: 1
+      - R2.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/nohup does not implement --help or --version beyond usage on error.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "nohup echo hello redirects output to nohup.out when stdout is a terminal, matching gnohup."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.4
+  - id: AC2
+    criterion: "nohup missing-cmd exits 127, matching gnohup."
+    traces:
+      - R2.2
+  - id: AC3
+    criterion: "Differential test against gnohup passes for all required test cases."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+  - id: AC4
+    criterion: "cmd/nohup compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/test-suites/test-rel-10.1.yaml
+++ b/docs/specs/test-suites/test-rel-10.1.yaml
@@ -1,0 +1,161 @@
+id: test-rel10.1
+title: "Test Suite: rel10.1 — chmod, chgrp, chown"
+release: rel10.1
+
+traces:
+  - rel10.1-uc001-chmod
+  - rel10.1-uc002-chgrp
+  - rel10.1-uc003-chown
+  - prd089-chmod R1
+  - prd089-chmod R2
+  - prd089-chmod R3
+  - prd089-chmod R4
+  - prd090-chgrp R1
+  - prd090-chgrp R2
+  - prd090-chgrp R3
+  - prd091-chown R1
+  - prd091-chown R2
+  - prd091-chown R3
+
+preconditions:
+  - "Go binary for each utility is built via go build -o bin/<name> ./cmd/<name>/"
+  - "Reference binaries installed via Homebrew: gchmod, gchgrp, gchown (coreutils package)"
+  - "Tests use LC_ALL=C for deterministic output"
+  - "Tests run with sufficient permissions for ownership changes (may require root for chown)"
+
+test_cases:
+
+  # ---- chmod ----
+
+  - name: chmod_octal
+    description: "chmod 755 sets permissions to rwxr-xr-x"
+    inputs:
+      args: ["755", "testfile"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd089-chmod R1.1
+      - prd089-chmod R1.3
+
+  - name: chmod_symbolic
+    description: "chmod u+x,go-w applies symbolic mode"
+    inputs:
+      args: ["u+x,go-w", "testfile"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd089-chmod R1.2
+
+  - name: chmod_recursive
+    description: "chmod -R 644 changes permissions recursively"
+    inputs:
+      args: ["-R", "644", "testdir"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd089-chmod R2.1
+
+  - name: chmod_verbose
+    description: "chmod -v 644 prints diagnostic for each file"
+    inputs:
+      args: ["-v", "644", "testfile"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd089-chmod R2.2
+
+  # ---- chgrp ----
+
+  - name: chgrp_basic
+    description: "chgrp staff file changes group"
+    inputs:
+      args: ["staff", "testfile"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd090-chgrp R1.1
+      - prd090-chgrp R1.3
+
+  - name: chgrp_recursive
+    description: "chgrp -R staff dir changes group recursively"
+    inputs:
+      args: ["-R", "staff", "testdir"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd090-chgrp R2.1
+
+  # ---- chown ----
+
+  - name: chown_owner_group
+    description: "chown user:staff file changes owner and group"
+    inputs:
+      args: ["user:staff", "testfile"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd091-chown R1.1
+      - prd091-chown R1.2
+
+  - name: chown_group_only
+    description: "chown :staff file changes only group"
+    inputs:
+      args: [":staff", "testfile"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd091-chown R1.1
+
+  - name: chown_recursive
+    description: "chown -R user dir changes owner recursively"
+    inputs:
+      args: ["-R", "user", "testdir"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd091-chown R2.1

--- a/docs/specs/test-suites/test-rel-11.0.yaml
+++ b/docs/specs/test-suites/test-rel-11.0.yaml
@@ -1,0 +1,160 @@
+id: test-rel11.0
+title: "Test Suite: rel11.0 — mkfifo, mknod, nice, nohup"
+release: rel11.0
+
+traces:
+  - rel11.0-uc001-mkfifo
+  - rel11.0-uc002-mknod
+  - rel11.0-uc003-nice
+  - rel11.0-uc004-nohup
+  - prd092-mkfifo R1
+  - prd092-mkfifo R2
+  - prd093-mknod R1
+  - prd093-mknod R2
+  - prd094-nice R1
+  - prd094-nice R2
+  - prd095-nohup R1
+  - prd095-nohup R2
+
+preconditions:
+  - "Go binary for each utility is built via go build -o bin/<name> ./cmd/<name>/"
+  - "Reference binaries installed via Homebrew: gmkfifo, gmknod, gnice, gnohup (coreutils package)"
+  - "Tests use LC_ALL=C for deterministic output"
+
+test_cases:
+
+  # ---- mkfifo ----
+
+  - name: mkfifo_basic
+    description: "mkfifo creates a named pipe"
+    inputs:
+      args: ["testpipe"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd092-mkfifo R1.1
+
+  - name: mkfifo_mode
+    description: "mkfifo -m 600 creates a FIFO with restricted permissions"
+    inputs:
+      args: ["-m", "600", "testpipe"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd092-mkfifo R1.3
+
+  # ---- mknod ----
+
+  - name: mknod_fifo
+    description: "mknod pipe1 p creates a FIFO"
+    inputs:
+      args: ["pipe1", "p"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd093-mknod R1.1
+
+  - name: mknod_mode
+    description: "mknod -m 644 pipe1 p creates a FIFO with mode 644"
+    inputs:
+      args: ["-m", "644", "pipe1", "p"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd093-mknod R1.2
+
+  # ---- nice ----
+
+  - name: nice_default
+    description: "nice echo hello runs with default +10 adjustment"
+    inputs:
+      args: ["echo", "hello"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd094-nice R1.1
+      - prd094-nice R1.4
+
+  - name: nice_custom
+    description: "nice -n 5 echo hello adjusts by 5"
+    inputs:
+      args: ["-n", "5", "echo", "hello"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd094-nice R1.2
+
+  - name: nice_no_command
+    description: "nice with no command prints current nice value"
+    inputs:
+      args: []
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd094-nice R1.3
+
+  # ---- nohup ----
+
+  - name: nohup_basic
+    description: "nohup echo hello runs immune to SIGHUP"
+    inputs:
+      args: ["echo", "hello"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd095-nohup R1.1
+      - prd095-nohup R1.4
+
+  - name: nohup_missing_command
+    description: "nohup nonexistent exits 127"
+    inputs:
+      args: ["nonexistent_command_xyz"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 127
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd095-nohup R2.2

--- a/docs/specs/use-cases/rel10.1-uc001-chmod.yaml
+++ b/docs/specs/use-cases/rel10.1-uc001-chmod.yaml
@@ -1,0 +1,50 @@
+id: rel10.1-uc001-chmod
+title: "Change file permission bits via chmod"
+
+summary: |
+  The operator runs the Go chmod binary to change file permission bits using octal or
+  symbolic mode specifications. The differential testing harness runs both the Go binary
+  and the Homebrew reference binary (gchmod from coreutils) with identical inputs and
+  confirms behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd089-chmod.yaml) and invokes do-work to produce
+  a passing differential test for cmd/chmod.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises chmod with octal modes (755, 644), symbolic modes (u+x,
+      go-w, a=rw), recursive mode (-R), and output control (-v, -c).
+  - id: F2
+    step: |
+      The operator tests setuid/setgid/sticky bits, --reference mode, and error cases.
+  - id: F3
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/chmod and
+      gchmod with the same inputs and compares exit codes and stderr.
+
+touchpoints:
+  - T1: "cmd/chmod — mode parsing, recursive traversal, output control (prd089-chmod R1, R2, R3, R4)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for octal modes, symbolic modes, recursive changes,
+      setuid/setgid/sticky, reference mode, and error cases, confirming full parity
+      with gchmod.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+      - AC5
+
+out_of_scope:
+  - SELinux context changes.
+
+test_suite: test-rel-10.1

--- a/docs/specs/use-cases/rel10.1-uc002-chgrp.yaml
+++ b/docs/specs/use-cases/rel10.1-uc002-chgrp.yaml
@@ -1,0 +1,47 @@
+id: rel10.1-uc002-chgrp
+title: "Change group ownership via chgrp"
+
+summary: |
+  The operator runs the Go chgrp binary to change file group ownership. The differential
+  testing harness runs both the Go binary and the Homebrew reference binary (gchgrp from
+  coreutils) with identical inputs and confirms behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd090-chgrp.yaml) and invokes do-work to produce
+  a passing differential test for cmd/chgrp.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises chgrp with group names and GIDs, recursive mode (-R),
+      symlink handling (-h, -H, -L, -P), and output control (-v, -c).
+  - id: F2
+    step: |
+      The operator tests --reference mode, multiple files, and error cases.
+  - id: F3
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/chgrp and
+      gchgrp with the same inputs and compares exit codes and stderr.
+
+touchpoints:
+  - T1: "cmd/chgrp — group ownership change, recursive traversal, symlink handling (prd090-chgrp R1, R2, R3)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for group name/GID, recursive changes, symlink
+      handling, reference mode, and error cases, confirming full parity with gchgrp.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+
+out_of_scope:
+  - --preserve-root is not implemented.
+
+test_suite: test-rel-10.1

--- a/docs/specs/use-cases/rel10.1-uc003-chown.yaml
+++ b/docs/specs/use-cases/rel10.1-uc003-chown.yaml
@@ -1,0 +1,50 @@
+id: rel10.1-uc003-chown
+title: "Change file owner and group via chown"
+
+summary: |
+  The operator runs the Go chown binary to change file owner and/or group using
+  OWNER[:GROUP] syntax. The differential testing harness runs both the Go binary and the
+  Homebrew reference binary (gchown from coreutils) with identical inputs and confirms
+  behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd091-chown.yaml) and invokes do-work to produce
+  a passing differential test for cmd/chown.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises chown with OWNER, OWNER:GROUP, OWNER:, :GROUP syntax,
+      recursive mode (-R), symlink handling (-h, -H, -L, -P), and output control.
+  - id: F2
+    step: |
+      The operator tests --reference mode, numeric UIDs/GIDs, and error cases.
+  - id: F3
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/chown and
+      gchown with the same inputs and compares exit codes and stderr.
+
+touchpoints:
+  - T1: "cmd/chown — ownership parsing, recursive traversal, symlink handling (prd091-chown R1, R2, R3)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all OWNER:GROUP syntax variants, recursive
+      changes, symlink handling, reference mode, and error cases, confirming full
+      parity with gchown.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+      - AC5
+
+out_of_scope:
+  - --preserve-root and --from conditional changes are not implemented.
+
+test_suite: test-rel-10.1

--- a/docs/specs/use-cases/rel11.0-uc001-mkfifo.yaml
+++ b/docs/specs/use-cases/rel11.0-uc001-mkfifo.yaml
@@ -1,0 +1,44 @@
+id: rel11.0-uc001-mkfifo
+title: "Create named pipes via mkfifo"
+
+summary: |
+  The operator runs the Go mkfifo binary to create named pipes (FIFOs). The differential
+  testing harness runs both the Go binary and the Homebrew reference binary (gmkfifo from
+  coreutils) with identical inputs and confirms behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd092-mkfifo.yaml) and invokes do-work to produce
+  a passing differential test for cmd/mkfifo.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises mkfifo with one or more names, with -m mode specification,
+      and tests error cases (existing path).
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/mkfifo and
+      gmkfifo with the same inputs and compares exit codes and stderr.
+
+touchpoints:
+  - T1: "cmd/mkfifo — FIFO creation, mode specification (prd092-mkfifo R1, R2)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for basic creation, mode specification, multiple
+      names, and error cases, confirming full parity with gmkfifo.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+
+out_of_scope:
+  - SELinux context setting.
+
+test_suite: test-rel-11.0

--- a/docs/specs/use-cases/rel11.0-uc002-mknod.yaml
+++ b/docs/specs/use-cases/rel11.0-uc002-mknod.yaml
@@ -1,0 +1,46 @@
+id: rel11.0-uc002-mknod
+title: "Create special files via mknod"
+
+summary: |
+  The operator runs the Go mknod binary to create block special, character special, or
+  FIFO special files. The differential testing harness runs both the Go binary and the
+  Homebrew reference binary (gmknod from coreutils) with identical inputs and confirms
+  behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd093-mknod.yaml) and invokes do-work to produce
+  a passing differential test for cmd/mknod.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises mknod with FIFO type (p), block type (b) with device
+      numbers, character type (c) with device numbers, and -m mode specification.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/mknod and
+      gmknod with the same inputs and compares exit codes and stderr.
+
+touchpoints:
+  - T1: "cmd/mknod — special file creation, device numbers, mode specification (prd093-mknod R1, R2)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for FIFO creation, device file creation with
+      major/minor numbers, mode specification, and error cases, confirming full
+      parity with gmknod.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+
+out_of_scope:
+  - SELinux context setting.
+
+test_suite: test-rel-11.0

--- a/docs/specs/use-cases/rel11.0-uc003-nice.yaml
+++ b/docs/specs/use-cases/rel11.0-uc003-nice.yaml
@@ -1,0 +1,45 @@
+id: rel11.0-uc003-nice
+title: "Run commands with modified priority via nice"
+
+summary: |
+  The operator runs the Go nice binary to execute a command with an adjusted scheduling
+  priority. The differential testing harness runs both the Go binary and the Homebrew
+  reference binary (gnice from coreutils) with identical inputs and confirms behavior
+  parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd094-nice.yaml) and invokes do-work to produce
+  a passing differential test for cmd/nice.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises nice with default adjustment, custom adjustment (-n),
+      no-command mode (print current nice value), and error cases.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/nice and
+      gnice with the same inputs and compares stdout and exit codes.
+
+touchpoints:
+  - T1: "cmd/nice — priority adjustment, command execution (prd094-nice R1, R2)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for default adjustment, custom adjustment, current
+      nice value display, and error cases, confirming full parity with gnice.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+
+out_of_scope:
+  - Real-time scheduling priorities.
+
+test_suite: test-rel-11.0

--- a/docs/specs/use-cases/rel11.0-uc004-nohup.yaml
+++ b/docs/specs/use-cases/rel11.0-uc004-nohup.yaml
@@ -1,0 +1,49 @@
+id: rel11.0-uc004-nohup
+title: "Run commands immune to hangups via nohup"
+
+summary: |
+  The operator runs the Go nohup binary to execute a command immune to SIGHUP with
+  automatic stdout/stderr redirection to nohup.out. The differential testing harness
+  runs both the Go binary and the Homebrew reference binary (gnohup from coreutils)
+  with identical inputs and confirms behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd095-nohup.yaml) and invokes do-work to produce
+  a passing differential test for cmd/nohup.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises nohup with a simple command, verifying SIGHUP immunity,
+      nohup.out creation, and stderr redirection.
+  - id: F2
+    step: |
+      The operator tests error cases: missing command (exit 127), non-executable
+      command (exit 126).
+  - id: F3
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/nohup and
+      gnohup with the same inputs and compares exit codes and stderr messages.
+
+touchpoints:
+  - T1: "cmd/nohup — SIGHUP immunity, output redirection, command execution (prd095-nohup R1, R2)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for basic nohup execution, nohup.out creation,
+      stderr redirection, and error cases, confirming full parity with gnohup.
+    traces:
+      - AC1
+      - AC2
+      - AC3
+      - AC4
+
+out_of_scope:
+  - --help and --version beyond usage on error.
+
+test_suite: test-rel-11.0


### PR DESCRIPTION
## Summary

Specifies two releases: rel10.1 (permission/ownership: chmod, chgrp, chown) and rel11.0 (special files/process control: mkfifo, mknod, nice, nohup). 92 utilities now specified (85% of ~108 target).

## Changes

- 7 PRDs: prd089-chmod, prd090-chgrp, prd091-chown, prd092-mkfifo, prd093-mknod, prd094-nice, prd095-nohup
- 7 use cases, 2 test suites, road-map entries

## Test plan

- [x] `mage analyze` — 0 errors

Closes #3146