### PR TITLE
GH-3153: Specify rel11.1, rel12.0, rel12.1 — users, who, pinky, shred, chroot, install, tsort, pathchk, test, stty

### DIFF
--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -493,3 +493,56 @@ releases:
           status: spec_complete
         - id: rel11.0-uc004-nohup
           status: spec_complete
+    - version: "11.1"
+      name: "Batch 11.1 — user and session information (users, who, pinky)"
+      status: spec_complete
+      depends_on: ["00.0"]
+      description: |
+        Implement three user information utilities. users prints login names of logged-in
+        users. who shows detailed login session information with idle time and boot time.
+        pinky provides lightweight finger-style user lookups with GECOS field display. All
+        read the utmpx database and are verified by differential testing against GNU
+        coreutils reference binaries.
+      use_cases:
+        - id: rel11.1-uc001-users
+          status: spec_complete
+        - id: rel11.1-uc002-who
+          status: spec_complete
+        - id: rel11.1-uc003-pinky
+          status: spec_complete
+    - version: "12.0"
+      name: "Batch 12.0 — file security and installation (shred, chroot, install)"
+      status: spec_complete
+      depends_on: ["00.0"]
+      description: |
+        Implement three file security and installation utilities. shred overwrites files
+        with random data to prevent recovery. chroot changes the root directory and
+        executes commands in the new root. install copies files while setting ownership,
+        permissions, and creating directories. All are verified by differential testing
+        against GNU coreutils reference binaries.
+      use_cases:
+        - id: rel12.0-uc001-shred
+          status: spec_complete
+        - id: rel12.0-uc002-chroot
+          status: spec_complete
+        - id: rel12.0-uc003-install
+          status: spec_complete
+    - version: "12.1"
+      name: "Batch 12.1 — miscellaneous utilities (tsort, pathchk, test, stty)"
+      status: spec_complete
+      depends_on: ["00.0"]
+      description: |
+        Implement four miscellaneous utilities. tsort performs topological sorting with
+        cycle detection. pathchk validates pathnames against POSIX portability rules. test
+        evaluates conditional expressions for file tests, string comparisons, and integer
+        arithmetic. stty prints and changes terminal line settings. All are verified by
+        differential testing against GNU coreutils reference binaries.
+      use_cases:
+        - id: rel12.1-uc001-tsort
+          status: spec_complete
+        - id: rel12.1-uc002-pathchk
+          status: spec_complete
+        - id: rel12.1-uc003-test
+          status: spec_complete
+        - id: rel12.1-uc004-stty
+          status: spec_complete

--- a/docs/specs/product-requirements/prd096-users.yaml
+++ b/docs/specs/product-requirements/prd096-users.yaml
@@ -1,0 +1,65 @@
+id: prd096-users
+title: "cmd/users: Print Login Names of Currently Logged-In Users"
+
+problem: |
+  macOS ships users but the GNU version has consistent output formatting. The Go
+  implementation must match the Homebrew GNU reference binary (gusers, installed by
+  coreutils) byte-for-byte, verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Print the login names of currently logged-in users, sorted and space-separated.
+  - G2: Verify functional parity against gusers via differential testing.
+
+requirements:
+  R1:
+    title: User listing
+    items:
+      - R1.1:
+          text: Must read the utmpx database (or equivalent on the target platform) and print the login names of all currently logged-in users on a single line, space-separated, sorted alphabetically.
+          weight: 4
+      - R1.2:
+          text: When given a FILE argument, must read that file as the utmpx database instead of the system default.
+          weight: 1
+      - R1.3:
+          text: Duplicate login names (same user logged in multiple times) must appear once per session, not deduplicated.
+          weight: 1
+
+  R2:
+    title: Exit codes and SIGPIPE
+    items:
+      - R2.1:
+          text: Must exit 0 on success.
+          weight: 1
+      - R2.2:
+          text: Must exit 1 on any error.
+          weight: 1
+      - R2.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/users does not show idle time, terminal, or remote host information; use who for that.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "users prints logged-in usernames sorted and space-separated, matching gusers."
+    traces:
+      - R1.1
+      - R1.3
+  - id: AC2
+    criterion: "Differential test against gusers passes."
+    traces:
+      - R1.1
+  - id: AC3
+    criterion: "cmd/users compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R2.1
+      - R2.2
+      - R2.3
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd097-who.yaml
+++ b/docs/specs/product-requirements/prd097-who.yaml
@@ -1,0 +1,100 @@
+id: prd097-who
+title: "cmd/who: Show Who Is Logged On"
+
+problem: |
+  macOS ships a BSD who that differs from GNU who in output format, flag support, and
+  header display. The Go implementation must match the Homebrew GNU reference binary
+  (gwho, installed by coreutils) byte-for-byte on all flag combinations, verified by
+  differential testing via pkg/testutils.
+
+goals:
+  - G1: Show information about currently logged-in users.
+  - G2: Support header display, idle time, and boot time options.
+  - G3: Verify functional parity against gwho via differential testing.
+
+requirements:
+  R1:
+    title: Default user listing
+    items:
+      - R1.1:
+          text: Must read the utmpx database and print one line per logged-in user showing login name, terminal line, login time, and remote hostname (if available), matching GNU who output format.
+          weight: 4
+      - R1.2:
+          text: When given a FILE argument, must read that file as the utmpx database instead of the system default.
+          weight: 1
+      - R1.3:
+          text: "who am i (or who am I) must print only the entry for the current terminal."
+          weight: 1
+      - R1.4:
+          text: Must exit 1 when the utmpx database cannot be read.
+          weight: 1
+
+  R2:
+    title: Display options
+    items:
+      - R2.1:
+          text: "-H or --heading must print a header line above the output."
+          weight: 1
+      - R2.2:
+          text: "-u or --users must show idle time for each user. Idle time is displayed as HH:MM, '.' for active (< 1 minute), or 'old' for > 24 hours."
+          weight: 4
+      - R2.3:
+          text: "-b or --boot must show the time of the last system boot."
+          weight: 1
+      - R2.4:
+          text: "-q or --count must print login names and a count of logged-in users, one name per column."
+          weight: 1
+
+  R3:
+    title: Exit codes and SIGPIPE
+    items:
+      - R3.1:
+          text: Must exit 0 on success.
+          weight: 1
+      - R3.2:
+          text: Must exit 1 on any error.
+          weight: 1
+      - R3.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/who does not implement -r (runlevel) or -d (dead processes) on macOS.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "who prints logged-in users with terminal and time, matching gwho."
+    traces:
+      - R1.1
+  - id: AC2
+    criterion: "who -H prints a header line, matching gwho -H."
+    traces:
+      - R2.1
+  - id: AC3
+    criterion: "who -b prints boot time, matching gwho -b."
+    traces:
+      - R2.3
+  - id: AC4
+    criterion: "Differential test against gwho passes."
+    traces:
+      - R1.1
+      - R2.1
+      - R2.3
+  - id: AC5
+    criterion: "cmd/who compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+      - R3.1
+      - R3.2
+      - R3.3
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd098-pinky.yaml
+++ b/docs/specs/product-requirements/prd098-pinky.yaml
@@ -1,0 +1,87 @@
+id: prd098-pinky
+title: "cmd/pinky: Lightweight Finger Information Lookup"
+
+problem: |
+  macOS does not ship pinky. GNU pinky is a lightweight alternative to finger that shows
+  user information from the utmpx database and passwd entries. The Go implementation must
+  match the Homebrew GNU reference binary (gpinky, installed by coreutils) byte-for-byte,
+  verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Display logged-in user information in short or long format.
+  - G2: Show GECOS field information (real name, office, phone) from passwd entries.
+  - G3: Verify functional parity against gpinky via differential testing.
+
+requirements:
+  R1:
+    title: Short format (default)
+    items:
+      - R1.1:
+          text: Must display logged-in users in short format by default, showing login name, terminal, idle time, login time, and remote host, one line per user.
+          weight: 4
+      - R1.2:
+          text: When given USER arguments, must show information only for those users (from passwd and utmpx).
+          weight: 1
+      - R1.3:
+          text: "-s must force short format output (default behavior)."
+          weight: 1
+
+  R2:
+    title: Long format and field control
+    items:
+      - R2.1:
+          text: "-l must display long format output showing login name, real name (from GECOS), terminal, idle time, login time, office location, and office phone from the passwd entry."
+          weight: 4
+      - R2.2:
+          text: "-f must suppress the header line in short format."
+          weight: 1
+      - R2.3:
+          text: "-b must suppress the home directory and shell in long format. -h must suppress the project file. -p must suppress the plan file."
+          weight: 1
+
+  R3:
+    title: Exit codes and SIGPIPE
+    items:
+      - R3.1:
+          text: Must exit 0 on success.
+          weight: 1
+      - R3.2:
+          text: Must exit 1 on any error.
+          weight: 1
+      - R3.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/pinky does not read .plan or .project files from user home directories on macOS (unlike full finger).
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "pinky prints logged-in users in short format, matching gpinky."
+    traces:
+      - R1.1
+  - id: AC2
+    criterion: "pinky -l user prints long format with GECOS info, matching gpinky -l."
+    traces:
+      - R2.1
+  - id: AC3
+    criterion: "Differential test against gpinky passes."
+    traces:
+      - R1.1
+      - R2.1
+  - id: AC4
+    criterion: "cmd/pinky compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R2.1
+      - R2.2
+      - R2.3
+      - R3.1
+      - R3.2
+      - R3.3
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd099-shred.yaml
+++ b/docs/specs/product-requirements/prd099-shred.yaml
@@ -1,0 +1,100 @@
+id: prd099-shred
+title: "cmd/shred: Overwrite a File to Hide Its Contents, and Optionally Delete It"
+
+problem: |
+  macOS does not ship shred. GNU shred overwrites files with random data to make
+  recovery difficult. The Go implementation must match the Homebrew GNU reference binary
+  (gshred, installed by coreutils) byte-for-byte on all flag combinations, verified by
+  differential testing via pkg/testutils.
+
+goals:
+  - G1: Overwrite file contents with random data to prevent recovery.
+  - G2: Support configurable overwrite iterations, final zero pass, and file removal.
+  - G3: Verify functional parity against gshred via differential testing.
+
+requirements:
+  R1:
+    title: Overwrite behavior
+    items:
+      - R1.1:
+          text: Must overwrite each FILE with random data for 3 iterations by default, then optionally remove the file.
+          weight: 4
+      - R1.2:
+          text: "-n N or --iterations=N must set the number of overwrite passes to N."
+          weight: 1
+      - R1.3:
+          text: "-z or --zero must add a final overwrite pass with zeros to hide the shredding."
+          weight: 1
+      - R1.4:
+          text: "-u or --remove must truncate and remove the file after overwriting. Without -u, the file is overwritten but not deleted."
+          weight: 1
+
+  R2:
+    title: Output and size control
+    items:
+      - R2.1:
+          text: "-v or --verbose must print progress information to stderr for each overwrite pass."
+          weight: 1
+      - R2.2:
+          text: "-s N or --size=N must shred only the first N bytes. N may use unit suffixes (K, M, G)."
+          weight: 1
+      - R2.3:
+          text: Must process multiple FILE arguments, shredding each in order.
+          weight: 1
+      - R2.4:
+          text: Must exit 1 when any file cannot be opened or overwritten, printing an error to stderr, and continue processing remaining files.
+          weight: 1
+
+  R3:
+    title: Exit codes and SIGPIPE
+    items:
+      - R3.1:
+          text: Must exit 0 when all files are processed successfully.
+          weight: 1
+      - R3.2:
+          text: Must exit 1 on any error.
+          weight: 1
+      - R3.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/shred does not guarantee unrecoverability on journaled or log-structured filesystems.
+  - cmd/shred does not implement --random-source.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "shred file overwrites the file with random data for 3 passes, matching gshred."
+    traces:
+      - R1.1
+  - id: AC2
+    criterion: "shred -n 1 -z -u file overwrites once, zeros, and removes, matching gshred."
+    traces:
+      - R1.2
+      - R1.3
+      - R1.4
+  - id: AC3
+    criterion: "Differential test against gshred passes."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+  - id: AC4
+    criterion: "cmd/shred compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+      - R3.1
+      - R3.2
+      - R3.3
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys
+    - github.com/petar-djukic/go-unix-utils/pkg/sizeparse

--- a/docs/specs/product-requirements/prd100-chroot.yaml
+++ b/docs/specs/product-requirements/prd100-chroot.yaml
@@ -1,0 +1,71 @@
+id: prd100-chroot
+title: "cmd/chroot: Run a Command with a Different Root Directory"
+
+problem: |
+  macOS ships chroot but the GNU version supports --userspec and --groups flags. The Go
+  implementation must match the Homebrew GNU reference binary (gchroot, installed by
+  coreutils) byte-for-byte on all flag combinations, verified by differential testing
+  via pkg/testutils.
+
+goals:
+  - G1: Change the root directory and run a command in the new root.
+  - G2: Support user and group specification for the chrooted process.
+  - G3: Verify functional parity against gchroot via differential testing.
+
+requirements:
+  R1:
+    title: Chroot execution
+    items:
+      - R1.1:
+          text: Must call chroot(2) to change the root directory to NEWROOT, then execute COMMAND with any arguments. If no COMMAND is given, must execute ${SHELL} -i (default /bin/sh -i).
+          weight: 4
+      - R1.2:
+          text: "--userspec=USER:GROUP must set the UID and GID of the executed process. USER and GROUP may be names or numeric IDs."
+          weight: 1
+      - R1.3:
+          text: "--groups=G_LIST must set the supplementary groups of the executed process. G_LIST is a comma-separated list of group names or GIDs."
+          weight: 1
+
+  R2:
+    title: Exit codes
+    items:
+      - R2.1:
+          text: Must exit with the exit status of COMMAND when COMMAND completes.
+          weight: 1
+      - R2.2:
+          text: Must exit 125 when chroot itself fails. Must exit 126 when COMMAND is found but cannot be invoked. Must exit 127 when COMMAND is not found.
+          weight: 1
+      - R2.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/chroot does not set up the chroot filesystem; the caller must prepare NEWROOT.
+  - cmd/chroot does not implement --skip-chdir.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "chroot /tmp /bin/echo hello runs echo in a chroot, matching gchroot."
+    traces:
+      - R1.1
+  - id: AC2
+    criterion: "chroot with non-existent root exits 125, matching gchroot."
+    traces:
+      - R2.2
+  - id: AC3
+    criterion: "Differential test against gchroot passes."
+    traces:
+      - R1.1
+  - id: AC4
+    criterion: "cmd/chroot compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R2.1
+      - R2.2
+      - R2.3
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd101-install.yaml
+++ b/docs/specs/product-requirements/prd101-install.yaml
@@ -1,0 +1,103 @@
+id: prd101-install
+title: "cmd/install: Copy Files and Set Attributes"
+
+problem: |
+  macOS ships a BSD install that differs from GNU install in flag names and behavior.
+  GNU install copies files while setting ownership, permissions, and optionally creating
+  directories. The Go implementation must match the Homebrew GNU reference binary
+  (ginstall, installed by coreutils) byte-for-byte on all flag combinations, verified by
+  differential testing via pkg/testutils.
+
+goals:
+  - G1: Copy files while setting ownership and permissions.
+  - G2: Support directory creation mode.
+  - G3: Support backup and stripping options.
+  - G4: Verify functional parity against ginstall via differential testing.
+
+requirements:
+  R1:
+    title: File installation
+    items:
+      - R1.1:
+          text: Must copy SOURCE to DEST, setting permissions to 755 by default (or as specified by -m).
+          weight: 1
+      - R1.2:
+          text: "-m MODE or --mode=MODE must set the permission mode on the installed file (octal or symbolic)."
+          weight: 1
+      - R1.3:
+          text: "-o OWNER or --owner=OWNER must set the owner of the installed file."
+          weight: 1
+      - R1.4:
+          text: "-g GROUP or --group=GROUP must set the group of the installed file."
+          weight: 1
+
+  R2:
+    title: Directory creation and backup
+    items:
+      - R2.1:
+          text: "-d or --directory must create each given directory and any missing parent directories, like mkdir -p. No file copying is performed in this mode."
+          weight: 1
+      - R2.2:
+          text: "-D must create all leading destination directory components, then copy SOURCE to DEST."
+          weight: 1
+      - R2.3:
+          text: "-b or --backup must make a backup of each existing destination file. --suffix=SUFFIX sets the backup suffix (default ~)."
+          weight: 1
+      - R2.4:
+          text: "-v or --verbose must print the name of each file as it is installed."
+          weight: 1
+
+  R3:
+    title: Comparison and exit codes
+    items:
+      - R3.1:
+          text: "-C or --compare must not install if the source and destination are identical (same content and permissions). This avoids updating timestamps unnecessarily."
+          weight: 1
+      - R3.2:
+          text: Must exit 0 when all files are installed successfully. Must exit 1 on any error.
+          weight: 1
+      - R3.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/install does not implement --strip (binary stripping requires external strip tool).
+  - cmd/install does not implement SELinux context setting.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "install src dest copies src to dest with mode 755, matching ginstall."
+    traces:
+      - R1.1
+  - id: AC2
+    criterion: "install -d dir1/dir2 creates directories, matching ginstall -d."
+    traces:
+      - R2.1
+  - id: AC3
+    criterion: "install -m 644 src dest sets mode 644, matching ginstall."
+    traces:
+      - R1.2
+  - id: AC4
+    criterion: "Differential test against ginstall passes."
+    traces:
+      - R1.1
+      - R1.2
+      - R2.1
+  - id: AC5
+    criterion: "cmd/install compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+      - R3.1
+      - R3.2
+      - R3.3
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd102-tsort.yaml
+++ b/docs/specs/product-requirements/prd102-tsort.yaml
@@ -1,0 +1,75 @@
+id: prd102-tsort
+title: "cmd/tsort: Topological Sort"
+
+problem: |
+  macOS ships tsort but the GNU version has consistent error formatting. The Go
+  implementation must match the Homebrew GNU reference binary (gtsort, installed by
+  coreutils) byte-for-byte, verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Perform a topological sort on a set of partial orderings.
+  - G2: Detect and report cycles.
+  - G3: Verify functional parity against gtsort via differential testing.
+
+requirements:
+  R1:
+    title: Topological sorting
+    items:
+      - R1.1:
+          text: Must read pairs of strings from stdin (or FILE argument), where each pair "A B" means A must come before B, and produce a topological ordering on stdout, one item per line.
+          weight: 4
+      - R1.2:
+          text: When a cycle is detected, must print a cycle diagnostic to stderr and continue sorting the remaining items. Must exit 1 when any cycle is found.
+          weight: 4
+      - R1.3:
+          text: Must exit 1 when the input has an odd number of tokens (incomplete pair).
+          weight: 1
+      - R1.4:
+          text: Must read from FILE when given as argument, or stdin when no argument or "-" is given.
+          weight: 1
+
+  R2:
+    title: Exit codes and SIGPIPE
+    items:
+      - R2.1:
+          text: Must exit 0 when sorting completes with no cycles.
+          weight: 1
+      - R2.2:
+          text: Must exit 1 when any cycle is detected or input is malformed.
+          weight: 1
+      - R2.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/tsort does not implement graphical cycle visualization.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "echo 'a b b c' | tsort produces a, b, c in order, matching gtsort."
+    traces:
+      - R1.1
+      - R1.4
+  - id: AC2
+    criterion: "tsort detects a cycle and exits 1, matching gtsort."
+    traces:
+      - R1.2
+  - id: AC3
+    criterion: "Differential test against gtsort passes."
+    traces:
+      - R1.1
+      - R1.2
+  - id: AC4
+    criterion: "cmd/tsort compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd103-pathchk.yaml
+++ b/docs/specs/product-requirements/prd103-pathchk.yaml
@@ -1,0 +1,75 @@
+id: prd103-pathchk
+title: "cmd/pathchk: Check Whether File Names Are Valid or Portable"
+
+problem: |
+  macOS does not ship pathchk. GNU pathchk validates pathnames against POSIX portability
+  rules. The Go implementation must match the Homebrew GNU reference binary (gpathchk,
+  installed by coreutils) byte-for-byte, verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Check pathnames for validity and POSIX portability.
+  - G2: Support strict POSIX and extended portability checks.
+  - G3: Verify functional parity against gpathchk via differential testing.
+
+requirements:
+  R1:
+    title: Pathname checking
+    items:
+      - R1.1:
+          text: Must check each given pathname and print an error to stderr if the path is invalid on the current system (component too long, non-existent leading directory).
+          weight: 1
+      - R1.2:
+          text: "-p or --portability must check each pathname against POSIX portability rules: only portable filename characters (A-Z, a-z, 0-9, ., _, -), component length at most 14 characters, total path length at most 256 characters."
+          weight: 4
+      - R1.3:
+          text: "-P must check that the pathname does not contain a leading hyphen in any component."
+          weight: 1
+      - R1.4:
+          text: Must process multiple pathname arguments, checking each and printing errors for invalid ones.
+          weight: 1
+
+  R2:
+    title: Exit codes and SIGPIPE
+    items:
+      - R2.1:
+          text: Must exit 0 when all pathnames pass validation.
+          weight: 1
+      - R2.2:
+          text: Must exit 1 when any pathname fails validation.
+          weight: 1
+      - R2.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/pathchk does not create or modify files.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "pathchk validpath exits 0, matching gpathchk."
+    traces:
+      - R1.1
+  - id: AC2
+    criterion: "pathchk -p 'invalid/path@name' exits 1 with error, matching gpathchk -p."
+    traces:
+      - R1.2
+  - id: AC3
+    criterion: "Differential test against gpathchk passes."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+  - id: AC4
+    criterion: "cmd/pathchk compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd104-test.yaml
+++ b/docs/specs/product-requirements/prd104-test.yaml
@@ -1,0 +1,95 @@
+id: prd104-test
+title: "cmd/test: Evaluate Conditional Expressions"
+
+problem: |
+  macOS ships test (and [) but the GNU version has specific behavior for multi-argument
+  expressions and parenthesized groups. The Go implementation must match the Homebrew GNU
+  reference binary (gtest, installed by coreutils) byte-for-byte on all flag combinations,
+  verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Evaluate conditional expressions and exit with status 0 (true) or 1 (false).
+  - G2: Support file tests, string tests, and integer comparisons.
+  - G3: Support logical operators (-a, -o, !) and parenthesized groups.
+  - G4: Verify functional parity against gtest via differential testing.
+
+requirements:
+  R1:
+    title: File tests
+    items:
+      - R1.1:
+          text: "Must support file test operators: -e (exists), -f (regular file), -d (directory), -s (non-empty), -r (readable), -w (writable), -x (executable), -L or -h (symlink), -b (block special), -c (character special), -p (named pipe), -S (socket), -g (setgid), -u (setuid), -k (sticky), -G (owned by effective GID), -O (owned by effective UID), -t FD (terminal)."
+          weight: 4
+      - R1.2:
+          text: "Must support file comparison operators: FILE1 -nt FILE2 (newer than), FILE1 -ot FILE2 (older than), FILE1 -ef FILE2 (same device and inode)."
+          weight: 1
+
+  R2:
+    title: String and integer tests
+    items:
+      - R2.1:
+          text: "Must support string operators: -z STRING (zero length), -n STRING (non-zero length), STRING1 = STRING2 (equal), STRING1 != STRING2 (not equal), STRING (non-empty)."
+          weight: 1
+      - R2.2:
+          text: "Must support integer comparison operators: INT1 -eq INT2, -ne, -lt, -le, -gt, -ge."
+          weight: 1
+
+  R3:
+    title: Logical operators
+    items:
+      - R3.1:
+          text: "Must support logical operators: ! EXPR (not), EXPR1 -a EXPR2 (and), EXPR1 -o EXPR2 (or), ( EXPR ) (grouping). Parentheses must be escaped or quoted by the shell."
+          weight: 4
+      - R3.2:
+          text: Must exit 0 when the expression evaluates to true, 1 when false, and 2 on syntax errors.
+          weight: 1
+
+  R4:
+    title: Exit codes and SIGPIPE
+    items:
+      - R4.1:
+          text: Must exit 0 (true), 1 (false), or 2 (error).
+          weight: 1
+      - R4.2:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/test does not implement == (use = for string equality, matching POSIX).
+  - cmd/test does not implement regex matching (=~).
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "test -f /etc/passwd exits 0, matching gtest."
+    traces:
+      - R1.1
+  - id: AC2
+    criterion: "test 1 -eq 1 exits 0, test 1 -eq 2 exits 1, matching gtest."
+    traces:
+      - R2.2
+  - id: AC3
+    criterion: "test ! -d /nonexistent exits 0, matching gtest."
+    traces:
+      - R3.1
+  - id: AC4
+    criterion: "Differential test against gtest passes."
+    traces:
+      - R1.1
+      - R2.1
+      - R2.2
+      - R3.1
+  - id: AC5
+    criterion: "cmd/test compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R2.1
+      - R2.2
+      - R3.1
+      - R3.2
+      - R4.1
+      - R4.2
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd105-stty.yaml
+++ b/docs/specs/product-requirements/prd105-stty.yaml
@@ -1,0 +1,100 @@
+id: prd105-stty
+title: "cmd/stty: Change and Print Terminal Line Settings"
+
+problem: |
+  macOS ships a BSD stty that differs from GNU stty in output format and flag naming.
+  The Go implementation must match the Homebrew GNU reference binary (gstty, installed
+  by coreutils) byte-for-byte on all flag combinations, verified by differential testing
+  via pkg/testutils.
+
+goals:
+  - G1: Print and change terminal line settings.
+  - G2: Support all standard control characters, input/output/local/control mode flags.
+  - G3: Verify functional parity against gstty via differential testing.
+
+requirements:
+  R1:
+    title: Display terminal settings
+    items:
+      - R1.1:
+          text: When invoked with no arguments, must print a summary of current terminal settings (speed, line discipline, changed-from-default settings) matching GNU stty output format.
+          weight: 4
+      - R1.2:
+          text: "-a or --all must print all current terminal settings in a human-readable format."
+          weight: 4
+      - R1.3:
+          text: "-g or --save must print all current terminal settings in a machine-readable format (stty-readable) that can be passed back as arguments to restore settings."
+          weight: 1
+      - R1.4:
+          text: "-F DEVICE or --file=DEVICE must operate on the specified terminal device instead of stdin."
+          weight: 1
+
+  R2:
+    title: Change terminal settings
+    items:
+      - R2.1:
+          text: "Must accept setting names as arguments to enable them, and names prefixed with - to disable them (e.g., stty -echo disables echo, stty echo enables it)."
+          weight: 4
+      - R2.2:
+          text: "Must support special characters: intr, quit, erase, kill, eof, eol, eol2, swtch, start, stop, susp, rprnt, werase, lnext, discard, min, time."
+          weight: 4
+      - R2.3:
+          text: "Must support combination settings: sane (reset to reasonable defaults), cooked (same as -raw), raw (set raw mode), evenp/parity (set even parity), oddp (set odd parity)."
+          weight: 1
+      - R2.4:
+          text: "Must support speed setting: ispeed N, ospeed N, or N alone to set both input and output speed."
+          weight: 1
+
+  R3:
+    title: Exit codes and SIGPIPE
+    items:
+      - R3.1:
+          text: Must exit 0 on success.
+          weight: 1
+      - R3.2:
+          text: Must exit 1 on any error (invalid setting, cannot open device).
+          weight: 1
+      - R3.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/stty does not implement all obscure termios flags; it covers the commonly used set matching GNU stty output.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "stty with no arguments prints terminal settings summary, matching gstty."
+    traces:
+      - R1.1
+  - id: AC2
+    criterion: "stty -a prints all settings, matching gstty -a."
+    traces:
+      - R1.2
+  - id: AC3
+    criterion: "stty -g prints machine-readable settings, matching gstty -g."
+    traces:
+      - R1.3
+  - id: AC4
+    criterion: "Differential test against gstty passes."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+  - id: AC5
+    criterion: "cmd/stty compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+      - R3.1
+      - R3.2
+      - R3.3
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/test-suites/test-rel-11.1.yaml
+++ b/docs/specs/test-suites/test-rel-11.1.yaml
@@ -1,0 +1,93 @@
+id: test-rel11.1
+title: "Test Suite: rel11.1 — users, who, pinky"
+release: rel11.1
+
+traces:
+  - rel11.1-uc001-users
+  - rel11.1-uc002-who
+  - rel11.1-uc003-pinky
+  - prd096-users R1
+  - prd096-users R2
+  - prd097-who R1
+  - prd097-who R2
+  - prd097-who R3
+  - prd098-pinky R1
+  - prd098-pinky R2
+  - prd098-pinky R3
+
+preconditions:
+  - "Go binary for each utility is built via go build -o bin/<name> ./cmd/<name>/"
+  - "Reference binaries installed via Homebrew: gusers, gwho, gpinky (coreutils package)"
+  - "Tests use LC_ALL=C for deterministic output"
+
+test_cases:
+
+  - name: users_list
+    description: "users prints logged-in usernames"
+    inputs:
+      args: []
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd096-users R1.1
+
+  - name: who_default
+    description: "who prints logged-in users with terminal and time"
+    inputs:
+      args: []
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd097-who R1.1
+
+  - name: who_heading
+    description: "who -H prints header line"
+    inputs:
+      args: ["-H"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd097-who R2.1
+
+  - name: who_boot
+    description: "who -b prints boot time"
+    inputs:
+      args: ["-b"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd097-who R2.3
+
+  - name: pinky_short
+    description: "pinky prints short format user info"
+    inputs:
+      args: []
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd098-pinky R1.1

--- a/docs/specs/test-suites/test-rel-12.0.yaml
+++ b/docs/specs/test-suites/test-rel-12.0.yaml
@@ -1,0 +1,95 @@
+id: test-rel12.0
+title: "Test Suite: rel12.0 — shred, chroot, install"
+release: rel12.0
+
+traces:
+  - rel12.0-uc001-shred
+  - rel12.0-uc002-chroot
+  - rel12.0-uc003-install
+  - prd099-shred R1
+  - prd099-shred R2
+  - prd099-shred R3
+  - prd100-chroot R1
+  - prd100-chroot R2
+  - prd101-install R1
+  - prd101-install R2
+  - prd101-install R3
+
+preconditions:
+  - "Go binary for each utility is built via go build -o bin/<name> ./cmd/<name>/"
+  - "Reference binaries installed via Homebrew: gshred, gchroot, ginstall (coreutils package)"
+  - "Tests use LC_ALL=C for deterministic output"
+
+test_cases:
+
+  - name: shred_default
+    description: "shred overwrites file with 3 passes of random data"
+    inputs:
+      args: ["testfile"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd099-shred R1.1
+
+  - name: shred_zero_remove
+    description: "shred -n 1 -z -u overwrites, zeros, and removes"
+    inputs:
+      args: ["-n", "1", "-z", "-u", "testfile"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd099-shred R1.2
+      - prd099-shred R1.3
+      - prd099-shred R1.4
+
+  - name: install_copy
+    description: "install copies file with default permissions"
+    inputs:
+      args: ["src", "dest"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd101-install R1.1
+
+  - name: install_directory
+    description: "install -d creates directories"
+    inputs:
+      args: ["-d", "dir1/dir2"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd101-install R2.1
+
+  - name: install_mode
+    description: "install -m 644 sets specific permissions"
+    inputs:
+      args: ["-m", "644", "src", "dest"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd101-install R1.2

--- a/docs/specs/test-suites/test-rel-12.1.yaml
+++ b/docs/specs/test-suites/test-rel-12.1.yaml
@@ -1,0 +1,153 @@
+id: test-rel12.1
+title: "Test Suite: rel12.1 — tsort, pathchk, test, stty"
+release: rel12.1
+
+traces:
+  - rel12.1-uc001-tsort
+  - rel12.1-uc002-pathchk
+  - rel12.1-uc003-test
+  - rel12.1-uc004-stty
+  - prd102-tsort R1
+  - prd102-tsort R2
+  - prd103-pathchk R1
+  - prd103-pathchk R2
+  - prd104-test R1
+  - prd104-test R2
+  - prd104-test R3
+  - prd104-test R4
+  - prd105-stty R1
+  - prd105-stty R2
+  - prd105-stty R3
+
+preconditions:
+  - "Go binary for each utility is built via go build -o bin/<name> ./cmd/<name>/"
+  - "Reference binaries installed via Homebrew: gtsort, gpathchk, gtest, gstty (coreutils package)"
+  - "Tests use LC_ALL=C for deterministic output"
+
+test_cases:
+
+  - name: tsort_basic
+    description: "tsort produces topological ordering"
+    inputs:
+      args: []
+      stdin: "a b b c\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd102-tsort R1.1
+
+  - name: tsort_cycle
+    description: "tsort detects cycle and exits 1"
+    inputs:
+      args: []
+      stdin: "a b b a\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 1
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd102-tsort R1.2
+
+  - name: pathchk_valid
+    description: "pathchk on valid path exits 0"
+    inputs:
+      args: ["validpath"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd103-pathchk R1.1
+
+  - name: pathchk_posix_invalid
+    description: "pathchk -p on non-portable path exits 1"
+    inputs:
+      args: ["-p", "invalid@path"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 1
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd103-pathchk R1.2
+
+  - name: test_file_exists
+    description: "test -f on existing file exits 0"
+    inputs:
+      args: ["-f", "/etc/passwd"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd104-test R1.1
+
+  - name: test_integer_eq
+    description: "test 1 -eq 1 exits 0"
+    inputs:
+      args: ["1", "-eq", "1"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd104-test R2.2
+
+  - name: test_not
+    description: "test ! -d /nonexistent exits 0"
+    inputs:
+      args: ["!", "-d", "/nonexistent"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd104-test R3.1
+
+  - name: stty_default
+    description: "stty prints terminal settings summary"
+    inputs:
+      args: []
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd105-stty R1.1
+
+  - name: stty_all
+    description: "stty -a prints all settings"
+    inputs:
+      args: ["-a"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd105-stty R1.2

--- a/docs/specs/use-cases/rel11.1-uc001-users.yaml
+++ b/docs/specs/use-cases/rel11.1-uc001-users.yaml
@@ -1,0 +1,40 @@
+id: rel11.1-uc001-users
+title: "Print login names of logged-in users via users"
+
+summary: |
+  The operator runs the Go users binary. The differential testing harness runs both
+  the Go binary and the Homebrew reference binary (gusers from coreutils) with identical
+  inputs and confirms behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd096-users.yaml) and invokes do-work to produce
+  a passing differential test for cmd/users.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises users with standard flag combinations and inputs.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/users and
+      gusers with the same inputs and compares stdout, stderr, and exit codes.
+
+touchpoints:
+  - T1: "cmd/users — users prints logged-in usernames (prd096-users)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all standard flag combinations, confirming
+      full parity with gusers.
+    traces:
+      - AC1
+
+out_of_scope:
+  - Platform-specific features not available on macOS.
+
+test_suite: test-rel-11.1

--- a/docs/specs/use-cases/rel11.1-uc002-who.yaml
+++ b/docs/specs/use-cases/rel11.1-uc002-who.yaml
@@ -1,0 +1,40 @@
+id: rel11.1-uc002-who
+title: "Show who is logged on via who"
+
+summary: |
+  The operator runs the Go who binary. The differential testing harness runs both
+  the Go binary and the Homebrew reference binary (gwho from coreutils) with identical
+  inputs and confirms behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd097-who.yaml) and invokes do-work to produce
+  a passing differential test for cmd/who.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises who with standard flag combinations and inputs.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/who and
+      gwho with the same inputs and compares stdout, stderr, and exit codes.
+
+touchpoints:
+  - T1: "cmd/who — who prints user, terminal, and time info (prd097-who)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all standard flag combinations, confirming
+      full parity with gwho.
+    traces:
+      - AC1
+
+out_of_scope:
+  - Platform-specific features not available on macOS.
+
+test_suite: test-rel-11.1

--- a/docs/specs/use-cases/rel11.1-uc003-pinky.yaml
+++ b/docs/specs/use-cases/rel11.1-uc003-pinky.yaml
@@ -1,0 +1,40 @@
+id: rel11.1-uc003-pinky
+title: "Display lightweight finger information via pinky"
+
+summary: |
+  The operator runs the Go pinky binary. The differential testing harness runs both
+  the Go binary and the Homebrew reference binary (gpinky from coreutils) with identical
+  inputs and confirms behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd098-pinky.yaml) and invokes do-work to produce
+  a passing differential test for cmd/pinky.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises pinky with standard flag combinations and inputs.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/pinky and
+      gpinky with the same inputs and compares stdout, stderr, and exit codes.
+
+touchpoints:
+  - T1: "cmd/pinky — pinky prints user info in short/long format (prd098-pinky)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all standard flag combinations, confirming
+      full parity with gpinky.
+    traces:
+      - AC1
+
+out_of_scope:
+  - Platform-specific features not available on macOS.
+
+test_suite: test-rel-11.1

--- a/docs/specs/use-cases/rel12.0-uc001-shred.yaml
+++ b/docs/specs/use-cases/rel12.0-uc001-shred.yaml
@@ -1,0 +1,40 @@
+id: rel12.0-uc001-shred
+title: "Securely overwrite files via shred"
+
+summary: |
+  The operator runs the Go shred binary. The differential testing harness runs both
+  the Go binary and the Homebrew reference binary (gshred from coreutils) with identical
+  inputs and confirms behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd099-shred.yaml) and invokes do-work to produce
+  a passing differential test for cmd/shred.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises shred with standard flag combinations and inputs.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/shred and
+      gshred with the same inputs and compares stdout, stderr, and exit codes.
+
+touchpoints:
+  - T1: "cmd/shred — shred overwrites files with random data (prd099-shred)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all standard flag combinations, confirming
+      full parity with gshred.
+    traces:
+      - AC1
+
+out_of_scope:
+  - Platform-specific features not available on macOS.
+
+test_suite: test-rel-12.0

--- a/docs/specs/use-cases/rel12.0-uc002-chroot.yaml
+++ b/docs/specs/use-cases/rel12.0-uc002-chroot.yaml
@@ -1,0 +1,40 @@
+id: rel12.0-uc002-chroot
+title: "Run commands in a changed root via chroot"
+
+summary: |
+  The operator runs the Go chroot binary. The differential testing harness runs both
+  the Go binary and the Homebrew reference binary (gchroot from coreutils) with identical
+  inputs and confirms behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd100-chroot.yaml) and invokes do-work to produce
+  a passing differential test for cmd/chroot.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises chroot with standard flag combinations and inputs.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/chroot and
+      gchroot with the same inputs and compares stdout, stderr, and exit codes.
+
+touchpoints:
+  - T1: "cmd/chroot — chroot changes root and executes command (prd100-chroot)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all standard flag combinations, confirming
+      full parity with gchroot.
+    traces:
+      - AC1
+
+out_of_scope:
+  - Platform-specific features not available on macOS.
+
+test_suite: test-rel-12.0

--- a/docs/specs/use-cases/rel12.0-uc003-install.yaml
+++ b/docs/specs/use-cases/rel12.0-uc003-install.yaml
@@ -1,0 +1,40 @@
+id: rel12.0-uc003-install
+title: "Copy files and set attributes via install"
+
+summary: |
+  The operator runs the Go install binary. The differential testing harness runs both
+  the Go binary and the Homebrew reference binary (ginstall from coreutils) with identical
+  inputs and confirms behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd101-install.yaml) and invokes do-work to produce
+  a passing differential test for cmd/install.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises install with standard flag combinations and inputs.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/install and
+      ginstall with the same inputs and compares stdout, stderr, and exit codes.
+
+touchpoints:
+  - T1: "cmd/install — install copies files with permissions (prd101-install)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all standard flag combinations, confirming
+      full parity with ginstall.
+    traces:
+      - AC1
+
+out_of_scope:
+  - Platform-specific features not available on macOS.
+
+test_suite: test-rel-12.0

--- a/docs/specs/use-cases/rel12.1-uc001-tsort.yaml
+++ b/docs/specs/use-cases/rel12.1-uc001-tsort.yaml
@@ -1,0 +1,40 @@
+id: rel12.1-uc001-tsort
+title: "Perform topological sort via tsort"
+
+summary: |
+  The operator runs the Go tsort binary. The differential testing harness runs both
+  the Go binary and the Homebrew reference binary (gtsort from coreutils) with identical
+  inputs and confirms behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd102-tsort.yaml) and invokes do-work to produce
+  a passing differential test for cmd/tsort.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises tsort with standard flag combinations and inputs.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/tsort and
+      gtsort with the same inputs and compares stdout, stderr, and exit codes.
+
+touchpoints:
+  - T1: "cmd/tsort — tsort produces topological ordering (prd102-tsort)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all standard flag combinations, confirming
+      full parity with gtsort.
+    traces:
+      - AC1
+
+out_of_scope:
+  - Platform-specific features not available on macOS.
+
+test_suite: test-rel-12.1

--- a/docs/specs/use-cases/rel12.1-uc002-pathchk.yaml
+++ b/docs/specs/use-cases/rel12.1-uc002-pathchk.yaml
@@ -1,0 +1,40 @@
+id: rel12.1-uc002-pathchk
+title: "Check pathname validity via pathchk"
+
+summary: |
+  The operator runs the Go pathchk binary. The differential testing harness runs both
+  the Go binary and the Homebrew reference binary (gpathchk from coreutils) with identical
+  inputs and confirms behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd103-pathchk.yaml) and invokes do-work to produce
+  a passing differential test for cmd/pathchk.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises pathchk with standard flag combinations and inputs.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/pathchk and
+      gpathchk with the same inputs and compares stdout, stderr, and exit codes.
+
+touchpoints:
+  - T1: "cmd/pathchk — pathchk validates POSIX pathnames (prd103-pathchk)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all standard flag combinations, confirming
+      full parity with gpathchk.
+    traces:
+      - AC1
+
+out_of_scope:
+  - Platform-specific features not available on macOS.
+
+test_suite: test-rel-12.1

--- a/docs/specs/use-cases/rel12.1-uc003-test.yaml
+++ b/docs/specs/use-cases/rel12.1-uc003-test.yaml
@@ -1,0 +1,40 @@
+id: rel12.1-uc003-test
+title: "Evaluate conditional expressions via test"
+
+summary: |
+  The operator runs the Go test binary. The differential testing harness runs both
+  the Go binary and the Homebrew reference binary (gtest from coreutils) with identical
+  inputs and confirms behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd104-test.yaml) and invokes do-work to produce
+  a passing differential test for cmd/test.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises test with standard flag combinations and inputs.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/test and
+      gtest with the same inputs and compares stdout, stderr, and exit codes.
+
+touchpoints:
+  - T1: "cmd/test — test evaluates file, string, integer conditions (prd104-test)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all standard flag combinations, confirming
+      full parity with gtest.
+    traces:
+      - AC1
+
+out_of_scope:
+  - Platform-specific features not available on macOS.
+
+test_suite: test-rel-12.1

--- a/docs/specs/use-cases/rel12.1-uc004-stty.yaml
+++ b/docs/specs/use-cases/rel12.1-uc004-stty.yaml
@@ -1,0 +1,40 @@
+id: rel12.1-uc004-stty
+title: "Change terminal settings via stty"
+
+summary: |
+  The operator runs the Go stty binary. The differential testing harness runs both
+  the Go binary and the Homebrew reference binary (gstty from coreutils) with identical
+  inputs and confirms behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd105-stty.yaml) and invokes do-work to produce
+  a passing differential test for cmd/stty.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises stty with standard flag combinations and inputs.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/stty and
+      gstty with the same inputs and compares stdout, stderr, and exit codes.
+
+touchpoints:
+  - T1: "cmd/stty — stty prints and changes terminal settings (prd105-stty)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all standard flag combinations, confirming
+      full parity with gstty.
+    traces:
+      - AC1
+
+out_of_scope:
+  - Platform-specific features not available on macOS.
+
+test_suite: test-rel-12.1


### PR DESCRIPTION
## Summary

Specifies three releases with 10 utilities: rel11.1 (users, who, pinky), rel12.0 (shred, chroot, install), rel12.1 (tsort, pathchk, test, stty). 102 utilities now specified (94% of ~108 target).

## Changes

- 10 PRDs (prd096-prd105), 10 use cases, 3 test suites, road-map entries
- 24 files, 1,665 lines added

## Test plan

- [x] `mage analyze` — 0 errors

Closes #3153