### PR TITLE
GH-3155: Complete utility catalog — rel13.0, rel13.1, rel14.0

### DIFF
--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -546,3 +546,54 @@ releases:
           status: spec_complete
         - id: rel12.1-uc004-stty
           status: spec_complete
+    - version: "13.0"
+      name: "Batch 13.0 — directory listing and filesystem (df, dir, vdir, dircolors)"
+      status: spec_complete
+      depends_on: ["00.0"]
+      description: |
+        Implement four directory listing and filesystem utilities. df reports filesystem
+        disk space usage with human-readable and SI format options. dir lists directory
+        contents in multi-column format (equivalent to ls -C -b). vdir lists directory
+        contents in long format (equivalent to ls -l -b). dircolors outputs shell commands
+        to set LS_COLORS for colorized ls output. All are verified by differential testing
+        against GNU coreutils reference binaries.
+      use_cases:
+        - id: rel13.0-uc001-df
+          status: spec_complete
+        - id: rel13.0-uc002-dir
+          status: spec_complete
+        - id: rel13.0-uc003-vdir
+          status: spec_complete
+        - id: rel13.0-uc004-dircolors
+          status: spec_complete
+    - version: "13.1"
+      name: "Batch 13.1 — text formatting (pr, ptx)"
+      status: spec_complete
+      depends_on: ["00.0"]
+      description: |
+        Implement two text formatting utilities. pr paginates text files for printing with
+        headers, page numbers, and multi-column layout. ptx produces a permuted
+        (keyword-in-context) index from text input. Both are verified by differential
+        testing against GNU coreutils reference binaries.
+      use_cases:
+        - id: rel13.1-uc001-pr
+          status: spec_complete
+        - id: rel13.1-uc002-ptx
+          status: spec_complete
+    - version: "14.0"
+      name: "Batch 14.0 — moreutils (chronic, pee, vidir)"
+      status: spec_complete
+      depends_on: ["00.0"]
+      description: |
+        Implement three moreutils utilities. chronic runs commands and suppresses output
+        unless the command fails, useful for cron jobs. pee tees stdin to multiple pipe
+        commands simultaneously. vidir enables batch renaming and deletion of files by
+        editing a directory listing in a text editor. All are verified by differential
+        testing against Homebrew moreutils reference binaries.
+      use_cases:
+        - id: rel14.0-uc001-chronic
+          status: spec_complete
+        - id: rel14.0-uc002-pee
+          status: spec_complete
+        - id: rel14.0-uc003-vidir
+          status: spec_complete

--- a/docs/specs/product-requirements/prd106-df.yaml
+++ b/docs/specs/product-requirements/prd106-df.yaml
@@ -1,0 +1,216 @@
+id: prd106-df
+title: "cmd/df: Report Filesystem Disk Space Usage"
+
+problem: |
+  df reports filesystem disk space usage, but macOS BSD df and GNU df differ in default
+  block size (512-byte vs 1024-byte blocks), column headers, output alignment, and flag
+  availability (--output absent in BSD df, -T absent in BSD df). Scripts that parse df
+  output break when moving between platforms. The Go implementation must match the Homebrew
+  GNU reference binary (gdf, installed by coreutils) byte-for-byte on all in-scope flag
+  combinations, verified by differential testing via pkg/testutils.
+
+  df requires pkg/sys for filesystem metadata (statvfs for block counts, device resolution)
+  and for SIGPIPE handling. These shared components are specified in prd002-sys.
+
+goals:
+  - G1: Report filesystem disk space usage for mounted filesystems, showing total, used, available, use percentage, and mount point.
+  - G2: Support human-readable output (-h for binary, -H for SI units).
+  - G3: Support filesystem type display (-T) and type-based filtering (-t, -x).
+  - G4: Support inode reporting (-i) and customizable column selection (--output).
+
+requirements:
+  R1:
+    title: Default output formatting
+    items:
+      - R1.1:
+          text: |
+            When invoked with no arguments, must list all mounted filesystems excluding
+            pseudo-filesystems (those with 0 total blocks), displaying one line per filesystem.
+            Default columns are: Filesystem, 1K-blocks, Used, Available, Use%, Mounted on.
+            Sizes are reported in 1024-byte block units.
+          weight: 4
+      - R1.2:
+          text: |
+            Must print a header line as the first line of output. Column headers must match
+            GNU df exactly: "Filesystem", "1K-blocks", "Used", "Available", "Use%",
+            "Mounted on". Numeric columns (1K-blocks, Used, Available, Use%) are right-aligned.
+            Filesystem and Mounted on are left-aligned.
+          weight: 4
+      - R1.3:
+          text: |
+            Use% is calculated as ceiling((total - available) * 100 / total) when total > 0.
+            When total is 0, Use% is displayed as a dash "-". The percentage is followed by
+            "%" with no space. Values are right-aligned in a column wide enough for "100%".
+          weight: 4
+      - R1.4:
+          text: |
+            When one or more FILE arguments are given, must report the filesystem containing
+            each FILE rather than all filesystems. If a FILE does not exist, must print a
+            diagnostic to stderr and continue processing remaining arguments.
+          weight: 1
+      - R1.5:
+          text: |
+            Column widths must be computed as per-column maxima of entry lengths across all
+            rows including the header, matching GNU df alignment. Fields are separated by
+            at least one space.
+          weight: 4
+
+  R2:
+    title: Human-readable and SI output
+    items:
+      - R2.1:
+          text: |
+            -h or --human-readable must display sizes using binary units (1024-based: K, M, G,
+            T, P, E) via pkg/format.HumanSize(bytes int64, opts HumanSizeOpts) string with
+            opts.Binary = true. The column header changes from "1K-blocks" to "Size". -h
+            applies to the Size, Used, and Available columns.
+          weight: 1
+      - R2.2:
+          text: |
+            -H or --si must display sizes using SI units (1000-based: kB, MB, GB, TB, PB, EB)
+            via pkg/format.HumanSize(bytes int64, opts HumanSizeOpts) string with opts.Binary =
+            false. The column header changes from "1K-blocks" to "Size". -H applies to the
+            Size, Used, and Available columns.
+          weight: 1
+      - R2.3:
+          text: -h and -H are mutually exclusive. The last one on the command line takes precedence.
+          weight: 1
+
+  R3:
+    title: Filesystem type, inode display, and column selection
+    items:
+      - R3.1:
+          text: |
+            -T or --print-type must insert a "Type" column after the Filesystem column,
+            showing the filesystem type (e.g., apfs, ext4, tmpfs) for each entry.
+          weight: 1
+      - R3.2:
+          text: |
+            -i or --inodes must display inode information instead of block usage. Columns
+            become: Filesystem, Inodes, IUsed, IFree, IUse%, Mounted on. IUse% is calculated
+            the same way as Use% but using inode counts instead of block counts.
+          weight: 1
+      - R3.3:
+          text: |
+            -a or --all must include pseudo-filesystems (those with 0 total blocks) in the
+            output. Without -a, filesystems with 0 total blocks are excluded.
+          weight: 1
+      - R3.4:
+          text: |
+            -l or --local must restrict output to local filesystems only, excluding network
+            filesystems (NFS, SMB, CIFS, etc.).
+          weight: 1
+      - R3.5:
+          text: |
+            -t TYPE or --type=TYPE must include only filesystems of the specified type.
+            Multiple -t flags may be given to include multiple types. When -t is given,
+            only filesystems matching at least one specified type are shown.
+          weight: 1
+      - R3.6:
+          text: |
+            -x TYPE or --exclude-type=TYPE must exclude filesystems of the specified type.
+            Multiple -x flags may be given. When both -t and -x are given, -t inclusion
+            is applied first, then -x exclusion.
+          weight: 1
+      - R3.7:
+          text: |
+            --output or --output=FIELD_LIST must select which columns to display. When
+            --output is given without a field list, all available fields are shown. When
+            a comma-separated field list is given, only those fields appear in the specified
+            order. Available fields: source, fstype, itotal, iused, iavail, ipcent, size,
+            used, avail, pcent, file, target. --output is incompatible with -i, -T, and -h;
+            if combined, must print an error and exit 1.
+          weight: 4
+
+  R4:
+    title: Exit codes and signal handling
+    items:
+      - R4.1:
+          text: Must exit 0 when all filesystems are reported successfully.
+          weight: 1
+      - R4.2:
+          text: Must exit 1 when any error occurs (inaccessible FILE argument, invalid option). Must print a diagnostic to stderr for each error.
+          weight: 1
+      - R4.3:
+          text: Must install a SIGPIPE handler at startup by calling pkg/sys.InstallSIGPIPEHandler() so that piping df output to head or other truncating consumers does not produce a broken-pipe error message.
+          weight: 1
+
+non_goals:
+  - --sync (invoke sync before getting usage info) is out of scope.
+  - --no-sync is accepted but has no effect (it is the default).
+  - --total (produce a grand total line) is out of scope.
+  - -P (POSIX output format) is out of scope; default output matches GNU df.
+  - --block-size=SIZE with arbitrary unit suffixes is out of scope; only -h, -H, and default 1K blocks are supported.
+  - -k is accepted but has no visible effect (1K is the default).
+  - Reporting on individual block devices or disk partitions beyond what the OS mounts is out of scope.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "Default mode comparison -- gdf and go run ./cmd/df produce identical output for mounted filesystems when run on the same machine. Differential tests must compare column headers, alignment, and Use% values."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.5
+  - id: AC2
+    criterion: "Human-readable sizes -- gdf -h and go run ./cmd/df -h produce identical size strings for all columns."
+    traces:
+      - R2.1
+      - R2.3
+  - id: AC3
+    criterion: "SI units -- gdf -H and go run ./cmd/df -H produce identical size strings for all columns."
+    traces:
+      - R2.2
+      - R2.3
+  - id: AC4
+    criterion: "Filesystem type display -- gdf -T and go run ./cmd/df -T produce identical output including the Type column."
+    traces:
+      - R3.1
+  - id: AC5
+    criterion: "Inode display -- gdf -i and go run ./cmd/df -i produce identical inode columns and IUse% values."
+    traces:
+      - R3.2
+  - id: AC6
+    criterion: "Type filtering -- gdf -t apfs and go run ./cmd/df -t apfs produce identical filtered output. gdf -x devfs and the Go binary with -x devfs exclude the same filesystems."
+    traces:
+      - R3.5
+      - R3.6
+  - id: AC7
+    criterion: "Output column selection -- gdf --output=source,size,used,avail,pcent,target and the Go binary produce identical column-selected output."
+    traces:
+      - R3.7
+  - id: AC8
+    criterion: "FILE argument -- gdf / and go run ./cmd/df / produce identical output for the root filesystem."
+    traces:
+      - R1.4
+  - id: AC9
+    criterion: "Exit codes -- the Go binary exits 1 when given a non-existent file argument and prints a diagnostic to stderr, matching gdf behavior."
+    traces:
+      - R4.1
+      - R4.2
+      - R4.3
+  - id: AC10
+    criterion: "cmd/df compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R1.5
+      - R2.1
+      - R2.2
+      - R2.3
+      - R3.1
+      - R3.2
+      - R3.3
+      - R3.4
+      - R3.5
+      - R3.6
+      - R3.7
+      - R4.1
+      - R4.2
+      - R4.3
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd107-dir.yaml
+++ b/docs/specs/product-requirements/prd107-dir.yaml
@@ -1,0 +1,113 @@
+id: prd107-dir
+title: "cmd/dir: List Directory Contents"
+
+problem: |
+  dir is a GNU coreutils utility equivalent to "ls -C -b". It lists directory contents in
+  multi-column format with non-printable characters escaped using C-style backslash sequences.
+  macOS does not ship a dir command; the Go implementation must match the Homebrew GNU
+  reference binary (gdir, installed by coreutils) byte-for-byte on all flag combinations,
+  verified by differential testing via pkg/testutils.
+
+  dir shares the bulk of its logic with cmd/ls (prd008-ls). The implementation must invoke
+  the same listing engine with hardcoded defaults for multi-column layout (-C) and C-style
+  escaping (-b). dir requires pkg/sys for SIGPIPE handling and terminal width queries.
+
+goals:
+  - G1: List directory contents in multi-column format with C-style escaping of non-printable characters, matching GNU dir (ls -C -b) output.
+  - G2: Accept the same arguments as ls, with the only difference being the default format and quoting style.
+
+requirements:
+  R1:
+    title: Default behavior and output format
+    items:
+      - R1.1:
+          text: |
+            Must list directory contents in multi-column format by default, regardless of
+            whether stdout is a TTY. This matches GNU dir behavior where -C is the default
+            format. When stdout is a TTY, terminal width is obtained by calling
+            pkg/sys.TerminalWidth() (int, error). When stdout is not a TTY, must use a
+            default width of 80 columns.
+          weight: 1
+      - R1.2:
+          text: |
+            Must escape non-printable characters in filenames using C-style backslash
+            sequences by default. This matches the -b (--escape) behavior of ls. Backslash,
+            newline, tab, and other control characters are printed as \\, \n, \t, and \NNN
+            (octal) respectively. Spaces in filenames are printed as \  (backslash space).
+          weight: 1
+      - R1.3:
+          text: |
+            Must sort entries in the C locale order (LC_COLLATE=C) by default, matching
+            ls default sort behavior. Entries whose names start with "." are excluded unless
+            -a or -A is given.
+          weight: 1
+      - R1.4:
+          text: When no directory arguments are given, must default to the current directory (".").
+          weight: 1
+      - R1.5:
+          text: Must accept all flags that ls accepts. dir is identical to ls except for the default format (-C) and default quoting style (-b). All other behavior is inherited from ls.
+          weight: 1
+
+  R2:
+    title: Exit codes and signal handling
+    items:
+      - R2.1:
+          text: Must exit 0 when all listed paths are accessed and output is written successfully.
+          weight: 1
+      - R2.2:
+          text: Must exit 1 when a minor problem occurs (permission denied, file not found). Must print a diagnostic to stderr and continue processing remaining entries.
+          weight: 1
+      - R2.3:
+          text: Must exit 2 when a serious problem occurs such as an invalid command-line option, matching GNU dir (and ls) exit-code contract.
+          weight: 1
+      - R2.4:
+          text: Must install a SIGPIPE handler at startup by calling pkg/sys.InstallSIGPIPEHandler() so that piping dir output to head or other truncating consumers does not produce a broken-pipe error message.
+          weight: 1
+
+non_goals:
+  - dir does not add any flags beyond what ls provides; it is strictly ls with different defaults.
+  - Color output (--color) is not enabled by default in dir; it must be explicitly requested.
+  - Long format (-l) is not the default; -C is the default.
+  - Recursive listing (-R) is supported but not default behavior.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "Default mode comparison -- gdir and go run ./cmd/dir on a test directory produce identical multi-column output with escaped filenames. Differential tests must set LC_ALL=C."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R1.5
+  - id: AC2
+    criterion: "Non-TTY output -- gdir piped to cat and go run ./cmd/dir piped to cat produce identical 80-column multi-column output."
+    traces:
+      - R1.1
+      - R1.2
+  - id: AC3
+    criterion: "Escaping -- filenames containing spaces, backslashes, newlines, and control characters are escaped identically by gdir and the Go binary."
+    traces:
+      - R1.2
+  - id: AC4
+    criterion: "Exit codes -- the Go binary exits 1 when given a non-existent path and exits 2 for an invalid option, matching gdir behavior."
+    traces:
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+  - id: AC5
+    criterion: "cmd/dir compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R1.5
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd108-vdir.yaml
+++ b/docs/specs/product-requirements/prd108-vdir.yaml
@@ -1,0 +1,118 @@
+id: prd108-vdir
+title: "cmd/vdir: List Directory Contents Verbosely"
+
+problem: |
+  vdir is a GNU coreutils utility equivalent to "ls -l -b". It lists directory contents in
+  long format with non-printable characters escaped using C-style backslash sequences.
+  macOS does not ship a vdir command; the Go implementation must match the Homebrew GNU
+  reference binary (gvdir, installed by coreutils) byte-for-byte on all flag combinations,
+  verified by differential testing via pkg/testutils.
+
+  vdir shares the bulk of its logic with cmd/ls (prd008-ls). The implementation must invoke
+  the same listing engine with hardcoded defaults for long format (-l) and C-style escaping
+  (-b). vdir requires pkg/sys for SIGPIPE handling and extended file metadata.
+
+goals:
+  - G1: List directory contents in long format with C-style escaping of non-printable characters, matching GNU vdir (ls -l -b) output.
+  - G2: Accept the same arguments as ls, with the only difference being the default format and quoting style.
+
+requirements:
+  R1:
+    title: Default behavior and output format
+    items:
+      - R1.1:
+          text: |
+            Must list directory contents in long format (-l) by default, regardless of
+            whether stdout is a TTY. This matches GNU vdir behavior where -l is the default
+            format. Long format fields are: permissions (10 chars), nlink, owner, group, size,
+            mtime, name — matching the layout specified in prd008-ls R1.6 through R1.10.
+          weight: 1
+      - R1.2:
+          text: |
+            Must escape non-printable characters in filenames using C-style backslash
+            sequences by default. This matches the -b (--escape) behavior of ls. Backslash,
+            newline, tab, and other control characters are printed as \\, \n, \t, and \NNN
+            (octal) respectively. Spaces in filenames are printed as \  (backslash space).
+          weight: 1
+      - R1.3:
+          text: |
+            Must print a "total N" block count line before the directory listing, where
+            N = sum(fi.Blocks for all listed entries) / 2. This matches the long-format
+            total line behavior specified in prd008-ls R1.10.
+          weight: 1
+      - R1.4:
+          text: |
+            Must sort entries in the C locale order (LC_COLLATE=C) by default. Entries whose
+            names start with "." are excluded unless -a or -A is given.
+          weight: 1
+      - R1.5:
+          text: When no directory arguments are given, must default to the current directory (".").
+          weight: 1
+      - R1.6:
+          text: Must accept all flags that ls accepts. vdir is identical to ls except for the default format (-l) and default quoting style (-b). All other behavior is inherited from ls.
+          weight: 1
+
+  R2:
+    title: Exit codes and signal handling
+    items:
+      - R2.1:
+          text: Must exit 0 when all listed paths are accessed and output is written successfully.
+          weight: 1
+      - R2.2:
+          text: Must exit 1 when a minor problem occurs (permission denied, file not found). Must print a diagnostic to stderr and continue processing remaining entries.
+          weight: 1
+      - R2.3:
+          text: Must exit 2 when a serious problem occurs such as an invalid command-line option, matching GNU vdir (and ls) exit-code contract.
+          weight: 1
+      - R2.4:
+          text: Must install a SIGPIPE handler at startup by calling pkg/sys.InstallSIGPIPEHandler() so that piping vdir output to head or other truncating consumers does not produce a broken-pipe error message.
+          weight: 1
+
+non_goals:
+  - vdir does not add any flags beyond what ls provides; it is strictly ls with different defaults.
+  - Color output (--color) is not enabled by default in vdir; it must be explicitly requested.
+  - Multi-column format (-C) is not the default; -l is the default.
+  - Recursive listing (-R) is supported but not default behavior.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "Default mode comparison -- gvdir and go run ./cmd/vdir on a test directory produce identical long-format output with escaped filenames. Differential tests must set LC_ALL=C."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R1.5
+      - R1.6
+  - id: AC2
+    criterion: "Total line -- gvdir and go run ./cmd/vdir produce identical 'total N' block count lines."
+    traces:
+      - R1.3
+  - id: AC3
+    criterion: "Escaping -- filenames containing spaces, backslashes, newlines, and control characters are escaped identically by gvdir and the Go binary."
+    traces:
+      - R1.2
+  - id: AC4
+    criterion: "Exit codes -- the Go binary exits 1 when given a non-existent path and exits 2 for an invalid option, matching gvdir behavior."
+    traces:
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+  - id: AC5
+    criterion: "cmd/vdir compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R1.5
+      - R1.6
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd109-dircolors.yaml
+++ b/docs/specs/product-requirements/prd109-dircolors.yaml
@@ -1,0 +1,183 @@
+id: prd109-dircolors
+title: "cmd/dircolors: Color Setup for ls"
+
+problem: |
+  dircolors outputs shell commands to set the LS_COLORS environment variable, which controls
+  file-type colorization in ls. macOS does not ship dircolors; the Go implementation must
+  match the Homebrew GNU reference binary (gdircolors, installed by coreutils) byte-for-byte
+  on all flag combinations, verified by differential testing via pkg/testutils.
+
+  dircolors reads a color configuration database (either a file argument or built-in defaults)
+  and translates it into a shell-evaluable assignment of LS_COLORS. The database format maps
+  file types and extensions to ANSI color codes. dircolors requires pkg/sys for SIGPIPE
+  handling.
+
+goals:
+  - G1: Output shell commands to set LS_COLORS from a color database, matching GNU dircolors output.
+  - G2: Support Bourne shell (-b/--sh/--bourne-shell) and C shell (-c/--csh/--c-shell) output formats.
+  - G3: Support printing the built-in default database (-p/--print-database).
+  - G4: Parse the GNU dircolors database format including TERM entries, file type keywords, and extension mappings.
+
+requirements:
+  R1:
+    title: Shell output format
+    items:
+      - R1.1:
+          text: |
+            When invoked with -b, --sh, or --bourne-shell, must output Bourne shell commands
+            to set and export LS_COLORS. The output format is:
+            LS_COLORS='<value>';
+            export LS_COLORS
+            where <value> is the colon-separated list of type=code pairs derived from the
+            database.
+          weight: 1
+      - R1.2:
+          text: |
+            When invoked with -c, --csh, or --c-shell, must output C shell commands to set
+            LS_COLORS. The output format is:
+            setenv LS_COLORS '<value>'
+            where <value> is the colon-separated list of type=code pairs.
+          weight: 1
+      - R1.3:
+          text: |
+            When neither -b nor -c is given, must auto-detect the shell from the SHELL
+            environment variable. If SHELL ends with "csh" (e.g., /bin/tcsh, /bin/csh), use
+            C shell format. Otherwise use Bourne shell format. This matches GNU dircolors
+            auto-detection behavior.
+          weight: 1
+      - R1.4:
+          text: |
+            -b and -c are mutually exclusive. The last one on the command line takes
+            precedence.
+          weight: 1
+
+  R2:
+    title: Database parsing
+    items:
+      - R2.1:
+          text: |
+            Must parse the GNU dircolors database format. Lines beginning with # are comments.
+            Blank lines are ignored. Each non-comment line has the form "KEYWORD value" where
+            KEYWORD is a file type name (e.g., DIR, LINK, EXEC, FIFO, SOCK, BLK, CHR, ORPHAN,
+            SETUID, SETGID, STICKY, OTHER_WRITABLE, STICKY_OTHER_WRITABLE, CAPABILITY,
+            MULTIHARDLINK) or a TERM entry, or a file extension (e.g., .tar, .gz, .jpg).
+          weight: 4
+      - R2.2:
+          text: |
+            TERM lines specify terminal types for which the color database applies. If the
+            current TERM environment variable does not match any TERM line in the database,
+            must output an empty LS_COLORS value. When no TERM lines are present in the
+            database, the database applies to all terminals.
+          weight: 1
+      - R2.3:
+          text: |
+            File type keywords map to two-letter LS_COLORS codes: DIR=di, LINK=ln, EXEC=ex,
+            FIFO=pi, SOCK=so, BLK=bd, CHR=cd, ORPHAN=or, SETUID=su, SETGID=sg, STICKY=st,
+            OTHER_WRITABLE=ow, STICKY_OTHER_WRITABLE=tw, CAPABILITY=ca, MULTIHARDLINK=mh,
+            NORMAL=no, FILE=fi, RESET=rs, MISSING=mi, LEFT=lc, RIGHT=rc, END=ec.
+            Extension entries (lines starting with . or *.) map to the full extension
+            pattern in LS_COLORS (e.g., "*.tar=01;31").
+          weight: 4
+      - R2.4:
+          text: |
+            When a filename argument is given, must read and parse that file as the color
+            database. When no filename is given (and -p is not given), must use the built-in
+            default database. The built-in defaults must match the output of
+            gdircolors --print-database.
+          weight: 4
+      - R2.5:
+          text: |
+            When "-" is given as the filename argument, must read the database from stdin.
+          weight: 1
+
+  R3:
+    title: Print database, exit codes, and signal handling
+    items:
+      - R3.1:
+          text: |
+            -p or --print-database must print the built-in default color database to stdout
+            in the dircolors database format (comments, TERM lines, keywords, extensions).
+            The output must match gdircolors --print-database byte-for-byte.
+          weight: 1
+      - R3.2:
+          text: |
+            -p is incompatible with a filename argument. If both are given, must print an
+            error to stderr and exit 1.
+          weight: 1
+      - R3.3:
+          text: Must exit 0 on success.
+          weight: 1
+      - R3.4:
+          text: |
+            Must exit 1 on error (invalid database syntax, file not found, incompatible
+            options). Must print a diagnostic to stderr for each error including the
+            filename and line number of the offending line in the database.
+          weight: 1
+      - R3.5:
+          text: Must install a SIGPIPE handler at startup by calling pkg/sys.InstallSIGPIPEHandler() so that piping dircolors output to head or other truncating consumers does not produce a broken-pipe error message.
+          weight: 1
+
+non_goals:
+  - Custom color themes beyond the built-in GNU defaults are out of scope; dircolors reads whatever database is provided but ships only the GNU default.
+  - Interactive editing of the color database is out of scope.
+  - Validation of ANSI color code syntax within database values is out of scope; values are passed through verbatim.
+  - COLORTERM environment variable handling is out of scope.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "Bourne shell output -- gdircolors --sh and go run ./cmd/dircolors --sh produce identical LS_COLORS assignment output."
+    traces:
+      - R1.1
+      - R1.3
+      - R2.4
+  - id: AC2
+    criterion: "C shell output -- gdircolors --csh and go run ./cmd/dircolors --csh produce identical setenv output."
+    traces:
+      - R1.2
+      - R1.3
+      - R2.4
+  - id: AC3
+    criterion: "Print database -- gdircolors -p and go run ./cmd/dircolors -p produce identical default database output."
+    traces:
+      - R3.1
+      - R3.2
+  - id: AC4
+    criterion: "Custom database -- gdircolors --sh FILE and go run ./cmd/dircolors --sh FILE produce identical output when given the same custom database file."
+    traces:
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+  - id: AC5
+    criterion: "Shell auto-detection -- with SHELL=/bin/bash, gdircolors and go run ./cmd/dircolors produce Bourne shell format. With SHELL=/bin/tcsh, both produce C shell format."
+    traces:
+      - R1.3
+      - R1.4
+  - id: AC6
+    criterion: "Exit codes -- the Go binary exits 1 when given both -p and a filename argument, and exits 1 for an invalid database file, matching gdircolors behavior."
+    traces:
+      - R3.2
+      - R3.3
+      - R3.4
+      - R3.5
+  - id: AC7
+    criterion: "cmd/dircolors compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+      - R2.5
+      - R3.1
+      - R3.2
+      - R3.3
+      - R3.4
+      - R3.5
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd110-pr.yaml
+++ b/docs/specs/product-requirements/prd110-pr.yaml
@@ -1,0 +1,91 @@
+id: prd110-pr
+title: "cmd/pr: Paginate or Columnate Files for Printing"
+
+problem: |
+  macOS ships a BSD pr that differs from GNU pr in header format, column handling, and
+  flag syntax. The Go implementation must match the Homebrew GNU reference binary (gpr,
+  installed by coreutils) byte-for-byte, verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Paginate text files with headers, footers, and page numbers.
+  - G2: Support multi-column layout and line numbering.
+  - G3: Verify functional parity against gpr via differential testing.
+
+requirements:
+  R1:
+    title: Page layout
+    items:
+      - R1.1:
+          text: Must format input into pages of 66 lines by default (header 5 lines, body 56 lines, footer 5 lines). Each page header shows the date, filename, and page number.
+          weight: 4
+      - R1.2:
+          text: "-l N or --length=N must set the page length to N lines. -h HEADER or --header=HEADER must replace the filename in the header."
+          weight: 1
+      - R1.3:
+          text: "-t or --omit-header must suppress the 5-line header and 5-line footer. -T or --omit-pagination must suppress header/footer and do not pad page bottom."
+          weight: 1
+      - R1.4:
+          text: Must read from FILE arguments or stdin when no file or "-" is given.
+          weight: 1
+
+  R2:
+    title: Columns and formatting
+    items:
+      - R2.1:
+          text: "-COLUMN or --columns=COLUMN must produce multi-column output. Columns are filled down by default. -a or --across fills across instead."
+          weight: 4
+      - R2.2:
+          text: "-n[CHAR[WIDTH]] or --number-lines[=CHAR[WIDTH]] must number output lines. CHAR is the separator (default tab), WIDTH is the number field width (default 5)."
+          weight: 1
+      - R2.3:
+          text: "-o MARGIN or --indent=MARGIN must indent each line by MARGIN spaces. -w WIDTH or --width=WIDTH must set the page width (default 72)."
+          weight: 1
+      - R2.4:
+          text: "-d or --double-space must double-space the output. -s CHAR or --separator=CHAR must use CHAR as the column separator (default tab)."
+          weight: 1
+
+  R3:
+    title: Exit codes and SIGPIPE
+    items:
+      - R3.1:
+          text: Must exit 0 on success. Must exit 1 on any error.
+          weight: 1
+      - R3.2:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/pr does not implement -m (merge files side by side) in this release.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "pr on a text file produces paginated output with header, matching gpr."
+    traces:
+      - R1.1
+      - R1.4
+  - id: AC2
+    criterion: "pr -2 produces two-column output, matching gpr -2."
+    traces:
+      - R2.1
+  - id: AC3
+    criterion: "Differential test against gpr passes."
+    traces:
+      - R1.1
+      - R2.1
+  - id: AC4
+    criterion: "cmd/pr compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+      - R3.1
+      - R3.2
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd111-ptx.yaml
+++ b/docs/specs/product-requirements/prd111-ptx.yaml
@@ -1,0 +1,86 @@
+id: prd111-ptx
+title: "cmd/ptx: Produce a Permuted Index"
+
+problem: |
+  macOS does not ship ptx. GNU ptx produces a permuted (keyword-in-context) index of
+  text input. The Go implementation must match the Homebrew GNU reference binary (gptx,
+  installed by coreutils) byte-for-byte, verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Produce a permuted (KWIC) index from text input.
+  - G2: Support output width, gap size, and reference control.
+  - G3: Verify functional parity against gptx via differential testing.
+
+requirements:
+  R1:
+    title: Index generation
+    items:
+      - R1.1:
+          text: Must read input lines and produce a permuted index where each significant word appears as a keyword in context, with the surrounding text shown on either side.
+          weight: 4
+      - R1.2:
+          text: "-w N or --width=N must set the output line width (default 72). -g N or --gap-size=N must set the minimum gap between columns (default 3)."
+          weight: 1
+      - R1.3:
+          text: "-f or --ignore-case must fold lowercase to uppercase for sorting purposes."
+          weight: 1
+      - R1.4:
+          text: Must read from FILE or stdin when no file or "-" is given.
+          weight: 1
+
+  R2:
+    title: Reference and word control
+    items:
+      - R2.1:
+          text: "-A or --auto-reference must produce automatically generated references based on file name and line number."
+          weight: 1
+      - R2.2:
+          text: "-r or --references must treat the first field of each line as a reference and exclude it from the index."
+          weight: 1
+      - R2.3:
+          text: "-W REGEXP or --word-regexp=REGEXP must use REGEXP to define what constitutes a word."
+          weight: 4
+
+  R3:
+    title: Exit codes and SIGPIPE
+    items:
+      - R3.1:
+          text: Must exit 0 on success. Must exit 1 on any error.
+          weight: 1
+      - R3.2:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/ptx does not implement TeX/roff output format in this release.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "ptx on a text file produces a permuted index, matching gptx."
+    traces:
+      - R1.1
+      - R1.4
+  - id: AC2
+    criterion: "ptx -f folds case for sorting, matching gptx -f."
+    traces:
+      - R1.3
+  - id: AC3
+    criterion: "Differential test against gptx passes."
+    traces:
+      - R1.1
+  - id: AC4
+    criterion: "cmd/ptx compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+      - R2.3
+      - R3.1
+      - R3.2
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd112-chronic.yaml
+++ b/docs/specs/product-requirements/prd112-chronic.yaml
@@ -1,0 +1,71 @@
+id: prd112-chronic
+title: "cmd/chronic: Run a Command Quietly Unless It Fails"
+
+problem: |
+  chronic (from moreutils) runs a command and suppresses its output unless the command
+  fails. This is useful in cron jobs where output triggers email only on errors. The Go
+  implementation must match the Homebrew reference binary (chronic, installed by
+  moreutils) byte-for-byte, verified by differential testing via pkg/testutils.
+
+goals:
+  - G1: Run a command, capturing stdout and stderr, and display them only if the command fails.
+  - G2: Verify functional parity against the reference chronic binary via differential testing.
+
+requirements:
+  R1:
+    title: Command execution and output suppression
+    items:
+      - R1.1:
+          text: Must execute COMMAND with any arguments, capturing stdout and stderr. If COMMAND exits 0, suppress all output. If COMMAND exits non-zero, write the captured stdout to stdout and captured stderr to stderr.
+          weight: 4
+      - R1.2:
+          text: "-e or --stderr must also trigger output display when the command writes to stderr, even if it exits 0."
+          weight: 1
+      - R1.3:
+          text: "-v or --verbose must print the command being run to stderr before execution."
+          weight: 1
+
+  R2:
+    title: Exit codes and SIGPIPE
+    items:
+      - R2.1:
+          text: Must exit with the exit status of COMMAND.
+          weight: 1
+      - R2.2:
+          text: Must exit 100 when COMMAND cannot be found or executed.
+          weight: 1
+      - R2.3:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/chronic does not implement timeout or resource limits on the executed command.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "chronic echo hello produces no output (exit 0 suppresses), matching reference."
+    traces:
+      - R1.1
+  - id: AC2
+    criterion: "chronic false produces no stdout but the exit code is 1, matching reference."
+    traces:
+      - R1.1
+      - R2.1
+  - id: AC3
+    criterion: "Differential test against reference chronic passes."
+    traces:
+      - R1.1
+      - R1.2
+  - id: AC4
+    criterion: "cmd/chronic compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R2.1
+      - R2.2
+      - R2.3
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd113-pee.yaml
+++ b/docs/specs/product-requirements/prd113-pee.yaml
@@ -1,0 +1,62 @@
+id: prd113-pee
+title: "cmd/pee: Tee Standard Input to Pipes"
+
+problem: |
+  pee (from moreutils) reads stdin and writes it to multiple commands simultaneously,
+  like tee but for pipe commands instead of files. The Go implementation must match the
+  Homebrew reference binary (pee, installed by moreutils) byte-for-byte, verified by
+  differential testing via pkg/testutils.
+
+goals:
+  - G1: Read stdin and pipe it to multiple commands simultaneously.
+  - G2: Verify functional parity against the reference pee binary via differential testing.
+
+requirements:
+  R1:
+    title: Pipe teeing
+    items:
+      - R1.1:
+          text: Must accept one or more COMMAND arguments. Must read stdin and write the input to the stdin of each COMMAND in parallel. Each COMMAND is executed via the shell (sh -c COMMAND).
+          weight: 4
+      - R1.2:
+          text: Must wait for all commands to complete before exiting.
+          weight: 1
+      - R1.3:
+          text: Stdout of each COMMAND goes to stdout, interleaved.
+          weight: 1
+
+  R2:
+    title: Exit codes and SIGPIPE
+    items:
+      - R2.1:
+          text: Must exit 0 when all commands exit 0. Must exit 1 when any command exits non-zero.
+          weight: 1
+      - R2.2:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/pee does not implement output ordering or serialization of command outputs.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "echo hello | pee 'cat' 'wc -c' writes hello and byte count, matching reference."
+    traces:
+      - R1.1
+      - R1.3
+  - id: AC2
+    criterion: "Differential test against reference pee passes."
+    traces:
+      - R1.1
+  - id: AC3
+    criterion: "cmd/pee compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R2.1
+      - R2.2
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd114-vidir.yaml
+++ b/docs/specs/product-requirements/prd114-vidir.yaml
@@ -1,0 +1,67 @@
+id: prd114-vidir
+title: "cmd/vidir: Edit a Directory in a Text Editor"
+
+problem: |
+  vidir (from moreutils) allows batch renaming and deletion of files by editing a
+  directory listing in a text editor. The Go implementation must match the Homebrew
+  reference binary (vidir, installed by moreutils) in behavior, verified by differential
+  testing via pkg/testutils.
+
+goals:
+  - G1: List files in a directory, open the listing in an editor, and apply renames/deletions.
+  - G2: Verify functional parity against the reference vidir binary via differential testing.
+
+requirements:
+  R1:
+    title: Directory editing
+    items:
+      - R1.1:
+          text: Must list files from the specified directory (or current directory if none given), or from stdin if piped, with each line formatted as "NUMBER\tFILENAME". Must open this listing in the editor specified by $EDITOR (default vi).
+          weight: 4
+      - R1.2:
+          text: After the editor exits, must compare the edited listing with the original. Deleted lines cause the corresponding file to be removed. Changed filenames cause the file to be renamed.
+          weight: 4
+      - R1.3:
+          text: Must process renames before deletions to avoid conflicts. Must create parent directories for renames that move files to new paths.
+          weight: 1
+      - R1.4:
+          text: "-v or --verbose must print each action (rename, delete) to stderr."
+          weight: 1
+
+  R2:
+    title: Exit codes and SIGPIPE
+    items:
+      - R2.1:
+          text: Must exit 0 on success. Must exit 1 when the editor exits non-zero or a rename/delete fails.
+          weight: 1
+      - R2.2:
+          text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
+          weight: 1
+
+non_goals:
+  - cmd/vidir does not implement recursive directory editing.
+  - cmd/vidir does not support undo.
+
+acceptance_criteria:
+  - id: AC1
+    criterion: "vidir lists files with tab-separated numbers and names, matching reference."
+    traces:
+      - R1.1
+  - id: AC2
+    criterion: "vidir applies renames and deletions from edited listing, matching reference."
+    traces:
+      - R1.2
+      - R1.3
+  - id: AC3
+    criterion: "cmd/vidir compiles with no warnings under golangci-lint."
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R2.1
+      - R2.2
+
+package_contract:
+  imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/test-suites/test-rel-13.0.yaml
+++ b/docs/specs/test-suites/test-rel-13.0.yaml
@@ -1,0 +1,109 @@
+id: test-rel13.0
+title: "Test Suite: rel13.0 — df, dir, vdir, dircolors"
+release: rel13.0
+
+traces:
+  - rel13.0-uc001-df
+  - rel13.0-uc002-dir
+  - rel13.0-uc003-vdir
+  - rel13.0-uc004-dircolors
+  - prd106-df R1
+  - prd106-df R2
+  - prd106-df R3
+  - prd107-dir R1
+  - prd107-dir R2
+  - prd108-vdir R1
+  - prd108-vdir R2
+  - prd109-dircolors R1
+  - prd109-dircolors R2
+
+preconditions:
+  - "Go binary for each utility is built via go build -o bin/<name> ./cmd/<name>/"
+  - "Reference binaries installed via Homebrew: gdf, gdir, gvdir, gdircolors (coreutils package)"
+  - "Tests use LC_ALL=C for deterministic output"
+
+test_cases:
+
+  - name: df_default
+    description: "df shows filesystem usage"
+    inputs:
+      args: []
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd106-df R1.1
+
+  - name: df_human
+    description: "df -h shows human-readable sizes"
+    inputs:
+      args: ["-h"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd106-df R2.1
+
+  - name: dir_default
+    description: "dir lists files in columns"
+    inputs:
+      args: ["."]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd107-dir R1.1
+
+  - name: vdir_default
+    description: "vdir lists files in long format"
+    inputs:
+      args: ["."]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd108-vdir R1.1
+
+  - name: dircolors_bourne
+    description: "dircolors -b outputs Bourne shell LS_COLORS assignment"
+    inputs:
+      args: ["-b"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd109-dircolors R1.1
+
+  - name: dircolors_print_database
+    description: "dircolors -p prints default color database"
+    inputs:
+      args: ["-p"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd109-dircolors R1.3

--- a/docs/specs/test-suites/test-rel-13.1.yaml
+++ b/docs/specs/test-suites/test-rel-13.1.yaml
@@ -1,0 +1,64 @@
+id: test-rel13.1
+title: "Test Suite: rel13.1 — pr, ptx"
+release: rel13.1
+
+traces:
+  - rel13.1-uc001-pr
+  - rel13.1-uc002-ptx
+  - prd110-pr R1
+  - prd110-pr R2
+  - prd110-pr R3
+  - prd111-ptx R1
+  - prd111-ptx R2
+  - prd111-ptx R3
+
+preconditions:
+  - "Go binary for each utility is built via go build -o bin/<name> ./cmd/<name>/"
+  - "Reference binaries installed via Homebrew: gpr, gptx (coreutils package)"
+  - "Tests use LC_ALL=C for deterministic output"
+
+test_cases:
+
+  - name: pr_default
+    description: "pr paginates input with header"
+    inputs:
+      args: []
+      stdin: "line1\nline2\nline3\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd110-pr R1.1
+      - prd110-pr R1.4
+
+  - name: pr_two_columns
+    description: "pr -2 produces two-column output"
+    inputs:
+      args: ["-2"]
+      stdin: "a\nb\nc\nd\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd110-pr R2.1
+
+  - name: ptx_basic
+    description: "ptx produces permuted index"
+    inputs:
+      args: []
+      stdin: "hello world\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd111-ptx R1.1
+      - prd111-ptx R1.4

--- a/docs/specs/test-suites/test-rel-14.0.yaml
+++ b/docs/specs/test-suites/test-rel-14.0.yaml
@@ -1,0 +1,79 @@
+id: test-rel14.0
+title: "Test Suite: rel14.0 — chronic, pee, vidir"
+release: rel14.0
+
+traces:
+  - rel14.0-uc001-chronic
+  - rel14.0-uc002-pee
+  - rel14.0-uc003-vidir
+  - prd112-chronic R1
+  - prd112-chronic R2
+  - prd113-pee R1
+  - prd113-pee R2
+  - prd114-vidir R1
+  - prd114-vidir R2
+
+preconditions:
+  - "Go binary for each utility is built via go build -o bin/<name> ./cmd/<name>/"
+  - "Reference binaries installed via Homebrew: chronic, pee, vidir (moreutils package)"
+  - "Tests use LC_ALL=C for deterministic output"
+
+test_cases:
+
+  - name: chronic_success_suppressed
+    description: "chronic suppresses output on success"
+    inputs:
+      args: ["echo", "hello"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd112-chronic R1.1
+
+  - name: chronic_failure_shown
+    description: "chronic shows output on failure"
+    inputs:
+      args: ["false"]
+      stdin: null
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 1
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd112-chronic R1.1
+      - prd112-chronic R2.1
+
+  - name: pee_two_commands
+    description: "pee pipes stdin to two commands"
+    inputs:
+      args: ["cat", "wc -c"]
+      stdin: "hello\n"
+      env: ["LC_ALL=C"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd113-pee R1.1
+      - prd113-pee R1.3
+
+  - name: vidir_list_format
+    description: "vidir lists files with tab-separated numbers"
+    inputs:
+      args: ["."]
+      stdin: null
+      env: ["LC_ALL=C", "EDITOR=cat"]
+    normalization: none
+    expected:
+      exit_code: 0
+      stdout: ""
+      stderr: ""
+    traces:
+      - prd114-vidir R1.1

--- a/docs/specs/use-cases/rel13.0-uc001-df.yaml
+++ b/docs/specs/use-cases/rel13.0-uc001-df.yaml
@@ -1,0 +1,40 @@
+id: rel13.0-uc001-df
+title: "Report filesystem disk space usage via df"
+
+summary: |
+  The operator runs the Go df binary. The differential testing harness runs both
+  the Go binary and the reference binary (gdf) with identical inputs and confirms
+  behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd106-df.yaml) and invokes do-work to produce
+  a passing differential test for cmd/df.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises df with standard flag combinations and inputs.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/df and
+      gdf with the same inputs and compares stdout, stderr, and exit codes.
+
+touchpoints:
+  - T1: "cmd/df — df reports filesystem usage (prd106-df)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all standard flag combinations, confirming
+      full parity with gdf.
+    traces:
+      - AC1
+
+out_of_scope:
+  - Platform-specific features not available on macOS.
+
+test_suite: test-rel-13.0

--- a/docs/specs/use-cases/rel13.0-uc002-dir.yaml
+++ b/docs/specs/use-cases/rel13.0-uc002-dir.yaml
@@ -1,0 +1,40 @@
+id: rel13.0-uc002-dir
+title: "List directory contents in columns via dir"
+
+summary: |
+  The operator runs the Go dir binary. The differential testing harness runs both
+  the Go binary and the reference binary (gdir) with identical inputs and confirms
+  behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd107-dir.yaml) and invokes do-work to produce
+  a passing differential test for cmd/dir.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises dir with standard flag combinations and inputs.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/dir and
+      gdir with the same inputs and compares stdout, stderr, and exit codes.
+
+touchpoints:
+  - T1: "cmd/dir — dir lists directory contents (prd107-dir)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all standard flag combinations, confirming
+      full parity with gdir.
+    traces:
+      - AC1
+
+out_of_scope:
+  - Platform-specific features not available on macOS.
+
+test_suite: test-rel-13.0

--- a/docs/specs/use-cases/rel13.0-uc003-vdir.yaml
+++ b/docs/specs/use-cases/rel13.0-uc003-vdir.yaml
@@ -1,0 +1,40 @@
+id: rel13.0-uc003-vdir
+title: "List directory contents verbosely via vdir"
+
+summary: |
+  The operator runs the Go vdir binary. The differential testing harness runs both
+  the Go binary and the reference binary (gvdir) with identical inputs and confirms
+  behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd108-vdir.yaml) and invokes do-work to produce
+  a passing differential test for cmd/vdir.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises vdir with standard flag combinations and inputs.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/vdir and
+      gvdir with the same inputs and compares stdout, stderr, and exit codes.
+
+touchpoints:
+  - T1: "cmd/vdir — vdir lists directory contents verbosely (prd108-vdir)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all standard flag combinations, confirming
+      full parity with gvdir.
+    traces:
+      - AC1
+
+out_of_scope:
+  - Platform-specific features not available on macOS.
+
+test_suite: test-rel-13.0

--- a/docs/specs/use-cases/rel13.0-uc004-dircolors.yaml
+++ b/docs/specs/use-cases/rel13.0-uc004-dircolors.yaml
@@ -1,0 +1,40 @@
+id: rel13.0-uc004-dircolors
+title: "Set up ls color output via dircolors"
+
+summary: |
+  The operator runs the Go dircolors binary. The differential testing harness runs both
+  the Go binary and the reference binary (gdircolors) with identical inputs and confirms
+  behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd109-dircolors.yaml) and invokes do-work to produce
+  a passing differential test for cmd/dircolors.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises dircolors with standard flag combinations and inputs.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/dircolors and
+      gdircolors with the same inputs and compares stdout, stderr, and exit codes.
+
+touchpoints:
+  - T1: "cmd/dircolors — dircolors outputs LS_COLORS shell commands (prd109-dircolors)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all standard flag combinations, confirming
+      full parity with gdircolors.
+    traces:
+      - AC1
+
+out_of_scope:
+  - Platform-specific features not available on macOS.
+
+test_suite: test-rel-13.0

--- a/docs/specs/use-cases/rel13.1-uc001-pr.yaml
+++ b/docs/specs/use-cases/rel13.1-uc001-pr.yaml
@@ -1,0 +1,40 @@
+id: rel13.1-uc001-pr
+title: "Paginate files for printing via pr"
+
+summary: |
+  The operator runs the Go pr binary. The differential testing harness runs both
+  the Go binary and the reference binary (gpr) with identical inputs and confirms
+  behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd110-pr.yaml) and invokes do-work to produce
+  a passing differential test for cmd/pr.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises pr with standard flag combinations and inputs.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/pr and
+      gpr with the same inputs and compares stdout, stderr, and exit codes.
+
+touchpoints:
+  - T1: "cmd/pr — pr paginates text with headers (prd110-pr)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all standard flag combinations, confirming
+      full parity with gpr.
+    traces:
+      - AC1
+
+out_of_scope:
+  - Platform-specific features not available on macOS.
+
+test_suite: test-rel-13.1

--- a/docs/specs/use-cases/rel13.1-uc002-ptx.yaml
+++ b/docs/specs/use-cases/rel13.1-uc002-ptx.yaml
@@ -1,0 +1,40 @@
+id: rel13.1-uc002-ptx
+title: "Produce a permuted index via ptx"
+
+summary: |
+  The operator runs the Go ptx binary. The differential testing harness runs both
+  the Go binary and the reference binary (gptx) with identical inputs and confirms
+  behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd111-ptx.yaml) and invokes do-work to produce
+  a passing differential test for cmd/ptx.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises ptx with standard flag combinations and inputs.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/ptx and
+      gptx with the same inputs and compares stdout, stderr, and exit codes.
+
+touchpoints:
+  - T1: "cmd/ptx — ptx produces KWIC index (prd111-ptx)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all standard flag combinations, confirming
+      full parity with gptx.
+    traces:
+      - AC1
+
+out_of_scope:
+  - Platform-specific features not available on macOS.
+
+test_suite: test-rel-13.1

--- a/docs/specs/use-cases/rel14.0-uc001-chronic.yaml
+++ b/docs/specs/use-cases/rel14.0-uc001-chronic.yaml
@@ -1,0 +1,40 @@
+id: rel14.0-uc001-chronic
+title: "Run commands quietly unless they fail via chronic"
+
+summary: |
+  The operator runs the Go chronic binary. The differential testing harness runs both
+  the Go binary and the reference binary (chronic) with identical inputs and confirms
+  behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd112-chronic.yaml) and invokes do-work to produce
+  a passing differential test for cmd/chronic.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises chronic with standard flag combinations and inputs.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/chronic and
+      chronic with the same inputs and compares stdout, stderr, and exit codes.
+
+touchpoints:
+  - T1: "cmd/chronic — chronic suppresses output on success (prd112-chronic)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all standard flag combinations, confirming
+      full parity with chronic.
+    traces:
+      - AC1
+
+out_of_scope:
+  - Platform-specific features not available on macOS.
+
+test_suite: test-rel-14.0

--- a/docs/specs/use-cases/rel14.0-uc002-pee.yaml
+++ b/docs/specs/use-cases/rel14.0-uc002-pee.yaml
@@ -1,0 +1,40 @@
+id: rel14.0-uc002-pee
+title: "Tee stdin to pipes via pee"
+
+summary: |
+  The operator runs the Go pee binary. The differential testing harness runs both
+  the Go binary and the reference binary (pee) with identical inputs and confirms
+  behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd113-pee.yaml) and invokes do-work to produce
+  a passing differential test for cmd/pee.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises pee with standard flag combinations and inputs.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/pee and
+      pee with the same inputs and compares stdout, stderr, and exit codes.
+
+touchpoints:
+  - T1: "cmd/pee — pee pipes stdin to multiple commands (prd113-pee)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all standard flag combinations, confirming
+      full parity with pee.
+    traces:
+      - AC1
+
+out_of_scope:
+  - Platform-specific features not available on macOS.
+
+test_suite: test-rel-14.0

--- a/docs/specs/use-cases/rel14.0-uc003-vidir.yaml
+++ b/docs/specs/use-cases/rel14.0-uc003-vidir.yaml
@@ -1,0 +1,40 @@
+id: rel14.0-uc003-vidir
+title: "Edit directories in a text editor via vidir"
+
+summary: |
+  The operator runs the Go vidir binary. The differential testing harness runs both
+  the Go binary and the reference binary (vidir) with identical inputs and confirms
+  behavior parity.
+
+actor: Human Operator
+
+trigger: |
+  The operator has completed the PRD (prd114-vidir.yaml) and invokes do-work to produce
+  a passing differential test for cmd/vidir.
+
+flow:
+  - id: F1
+    step: |
+      The operator exercises vidir with standard flag combinations and inputs.
+  - id: F2
+    step: |
+      The differential testing harness (pkg/testutils) executes both ./bin/vidir and
+      vidir with the same inputs and compares stdout, stderr, and exit codes.
+
+touchpoints:
+  - T1: "cmd/vidir — vidir enables batch rename/delete (prd114-vidir)"
+  - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
+  - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
+
+success_criteria:
+  - id: S1
+    criterion: |
+      The differential test passes for all standard flag combinations, confirming
+      full parity with vidir.
+    traces:
+      - AC1
+
+out_of_scope:
+  - Platform-specific features not available on macOS.
+
+test_suite: test-rel-14.0


### PR DESCRIPTION
## Summary

Final specification batch completing the full utility catalog. Specifies rel13.0 (df, dir, vdir, dircolors), rel13.1 (pr, ptx), and rel14.0 (chronic, pee, vidir). All 111 utilities are now fully specified across 31 releases.

## Changes

- 9 PRDs (prd106-prd114), 9 use cases, 3 test suites, road-map entries
- 22 files, 1,670 lines added
- 114 PRDs total, 111 utilities specified

## Test plan

- [x] `mage analyze` — 0 errors

Closes #3155