### PR TITLE
GH-3149: Add pkg/format imports to df, dir, vdir

### DIFF
--- a/docs/specs/product-requirements/prd106-df.yaml
+++ b/docs/specs/product-requirements/prd106-df.yaml
@@ -213,4 +213,5 @@ acceptance_criteria:
 
 package_contract:
   imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/format
     - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd107-dir.yaml
+++ b/docs/specs/product-requirements/prd107-dir.yaml
@@ -110,4 +110,5 @@ acceptance_criteria:
 
 package_contract:
   imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/format
     - github.com/petar-djukic/go-unix-utils/pkg/sys

--- a/docs/specs/product-requirements/prd108-vdir.yaml
+++ b/docs/specs/product-requirements/prd108-vdir.yaml
@@ -115,4 +115,5 @@ acceptance_criteria:
 
 package_contract:
   imports:
+    - github.com/petar-djukic/go-unix-utils/pkg/format
     - github.com/petar-djukic/go-unix-utils/pkg/sys


### PR DESCRIPTION
## Summary

Second shared code audit. Adds pkg/format imports to df (HumanSize), dir and vdir (column alignment, colors).

## Changes

- prd106-df.yaml, prd107-dir.yaml, prd108-vdir.yaml: added pkg/format import

## Test plan

- [x] `mage analyze` — 0 errors

Closes #3149