### PR TITLE
GH-3569: Split complex PRDs and move to rel99.0

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -49,6 +49,7 @@ project:
         - "13.0"
         - "13.1"
         - "14.0"
+        - "99.0"
 generation:
     prefix: generation-
     cycles: 100

--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -544,8 +544,6 @@ releases:
           status: spec_complete
         - id: rel12.1-uc003-test
           status: spec_complete
-        - id: rel12.1-uc004-stty
-          status: spec_complete
     - version: "13.0"
       name: "Batch 13.0 — directory listing and filesystem (df, dir, vdir, dircolors)"
       status: spec_complete
@@ -566,20 +564,6 @@ releases:
           status: spec_complete
         - id: rel13.0-uc004-dircolors
           status: spec_complete
-    - version: "13.1"
-      name: "Batch 13.1 — text formatting (pr, ptx)"
-      status: spec_complete
-      depends_on: ["00.0"]
-      description: |
-        Implement two text formatting utilities. pr paginates text files for printing with
-        headers, page numbers, and multi-column layout. ptx produces a permuted
-        (keyword-in-context) index from text input. Both are verified by differential
-        testing against GNU coreutils reference binaries.
-      use_cases:
-        - id: rel13.1-uc001-pr
-          status: spec_complete
-        - id: rel13.1-uc002-ptx
-          status: spec_complete
     - version: "14.0"
       name: "Batch 14.0 — moreutils (chronic, pee, vidir)"
       status: spec_complete
@@ -596,4 +580,23 @@ releases:
         - id: rel14.0-uc002-pee
           status: spec_complete
         - id: rel14.0-uc003-vidir
+          status: spec_complete
+    - version: "99.0"
+      name: "Deferred — complex utilities requiring restructured PRDs"
+      status: spec_complete
+      depends_on: ["00.0"]
+      description: |
+        Deferred utilities from run 38 that exceeded the stitch time budget due to
+        complex requirement groups containing multiple weight-4 items. PRDs have been
+        restructured (GH-3569) so each weight-4 item is in its own requirement group.
+        ts (prd004) is a large utility with 10 requirement groups. pr and ptx involve
+        complex text formatting algorithms. stty requires terminal ioctl knowledge.
+      use_cases:
+        - id: rel05.5-uc001-ts
+          status: spec_complete
+        - id: rel12.1-uc004-stty
+          status: spec_complete
+        - id: rel13.1-uc001-pr
+          status: spec_complete
+        - id: rel13.1-uc002-ptx
           status: spec_complete

--- a/docs/specs/product-requirements/prd070-fmt.yaml
+++ b/docs/specs/product-requirements/prd070-fmt.yaml
@@ -16,70 +16,102 @@ goals:
 
 requirements:
   R1:
-    title: Default formatting behavior
+    title: Default formatting
     items:
       - R1.1:
           text: When invoked with no options, must reformat each paragraph of input text to fit within 75 characters (the GNU default width).
           weight: 4
-      - R1.2:
-          text: Must treat blank lines as paragraph separators. Must not merge text across blank lines.
-          weight: 4
-      - R1.3:
-          text: Must preserve the indentation of the first line of each paragraph. Subsequent lines in the same paragraph are filled to match the second line's indentation (or the first if only one line).
-          weight: 4
-      - R1.4:
-          text: When given one or more FILE arguments, must read and format each file in order. When no file is given or "-" is given, must read from stdin.
-          weight: 4
 
   R2:
-    title: Width control and goal width
+    title: Blank line handling
     items:
       - R2.1:
-          text: "-w WIDTH or --width=WIDTH must set the maximum line width (default 75)."
-          weight: 4
-      - R2.2:
-          text: "-g GOAL or --goal=GOAL must set the goal line width. Lines are filled to approximately GOAL characters. Default goal is 93% of width."
-          weight: 4
-      - R2.3:
-          text: Must break lines at word boundaries (spaces). Must not break in the middle of a word unless the word exceeds the maximum width.
-          weight: 4
-      - R2.4:
-          text: Must collapse multiple spaces between words to a single space, except after sentence-ending punctuation (. ! ?) where two spaces are preserved.
+          text: Must treat blank lines as paragraph separators. Must not merge text across blank lines.
           weight: 4
 
   R3:
-    title: Split-only and uniform-spacing modes
+    title: Indentation preservation
     items:
       - R3.1:
-          text: "-s or --split-only must split long lines but not join short lines. Lines shorter than the goal width are left as-is."
-          weight: 4
-      - R3.2:
-          text: "-u or --uniform-spacing must use one space between words and two spaces after sentence-ending punctuation uniformly."
+          text: Must preserve the indentation of the first line of each paragraph. Subsequent lines in the same paragraph are filled to match the second line's indentation (or the first if only one line).
           weight: 4
 
   R4:
-    title: Prefix mode and tagged-paragraph
+    title: File and stdin input
     items:
       - R4.1:
-          text: "-p PREFIX or --prefix=PREFIX must only reformat lines beginning with PREFIX (after optional whitespace). Must remove the prefix before formatting and re-add it afterward."
-          weight: 4
-      - R4.2:
-          text: "-t or --tagged-paragraph must treat the first line of each paragraph as having a different indentation from subsequent lines, preserving the tagged-paragraph format."
+          text: When given one or more FILE arguments, must read and format each file in order. When no file is given or "-" is given, must read from stdin.
           weight: 4
 
   R5:
-    title: Exit codes and differential testing
+    title: Width control
     items:
       - R5.1:
+          text: "-w WIDTH or --width=WIDTH must set the maximum line width (default 75)."
+          weight: 4
+
+  R6:
+    title: Goal width
+    items:
+      - R6.1:
+          text: "-g GOAL or --goal=GOAL must set the goal line width. Lines are filled to approximately GOAL characters. Default goal is 93% of width."
+          weight: 4
+
+  R7:
+    title: Word boundaries
+    items:
+      - R7.1:
+          text: Must break lines at word boundaries (spaces). Must not break in the middle of a word unless the word exceeds the maximum width.
+          weight: 4
+
+  R8:
+    title: Space collapsing
+    items:
+      - R8.1:
+          text: Must collapse multiple spaces between words to a single space, except after sentence-ending punctuation (. ! ?) where two spaces are preserved.
+          weight: 4
+
+  R9:
+    title: Split-only mode
+    items:
+      - R9.1:
+          text: "-s or --split-only must split long lines but not join short lines. Lines shorter than the goal width are left as-is."
+          weight: 4
+
+  R10:
+    title: Uniform spacing
+    items:
+      - R10.1:
+          text: "-u or --uniform-spacing must use one space between words and two spaces after sentence-ending punctuation uniformly."
+          weight: 4
+
+  R11:
+    title: Prefix mode
+    items:
+      - R11.1:
+          text: "-p PREFIX or --prefix=PREFIX must only reformat lines beginning with PREFIX (after optional whitespace). Must remove the prefix before formatting and re-add it afterward."
+          weight: 4
+
+  R12:
+    title: Tagged-paragraph mode
+    items:
+      - R12.1:
+          text: "-t or --tagged-paragraph must treat the first line of each paragraph as having a different indentation from subsequent lines, preserving the tagged-paragraph format."
+          weight: 4
+
+  R13:
+    title: Exit codes and differential testing
+    items:
+      - R13.1:
           text: Must exit 0 when formatting completes successfully.
           weight: 1
-      - R5.2:
+      - R13.2:
           text: Must exit 1 when an invalid option is given or a file cannot be opened.
           weight: 1
-      - R5.3:
+      - R13.3:
           text: "Differential tests must compare stdout and exit codes between the Go binary and the reference binary via pkg/testutils."
           weight: 1
-      - R5.4:
+      - R13.4:
           text: "Tests must cover: default 75-char formatting, -w custom width, -g goal width, -s split-only, -u uniform spacing, -p prefix mode, -t tagged paragraph, multi-file input, stdin input, blank line paragraph boundaries, indentation preservation, and error cases (invalid width, missing file)."
           weight: 1
 
@@ -92,49 +124,49 @@ acceptance_criteria:
     criterion: "echo 'short line' | go run ./cmd/fmt produces 'short line' unchanged, matching gfmt."
     traces:
       - R1.1
-      - R1.4
+      - R4.1
   - id: AC2
     criterion: "go run ./cmd/fmt -w 20 on a paragraph of text wraps lines at 20 characters, matching gfmt."
     traces:
-      - R2.1
-      - R2.3
+      - R5.1
+      - R7.1
   - id: AC3
     criterion: "go run ./cmd/fmt -s on text with long and short lines splits long lines without joining short ones, matching gfmt."
     traces:
-      - R3.1
+      - R9.1
   - id: AC4
     criterion: "go run ./cmd/fmt -u on text with inconsistent spacing normalizes to uniform spacing, matching gfmt."
     traces:
-      - R3.2
+      - R10.1
   - id: AC5
     criterion: "go run ./cmd/fmt -p '>' on text with prefixed and non-prefixed lines reformats only prefixed lines, matching gfmt."
     traces:
-      - R4.1
+      - R11.1
   - id: AC6
     criterion: "go run ./cmd/fmt -t on text with tagged paragraphs preserves first-line indentation, matching gfmt."
     traces:
-      - R4.2
+      - R12.1
   - id: AC7
-    criterion: "Differential test against gfmt passes for all flag combinations listed in R5.4."
+    criterion: "Differential test against gfmt passes for all flag combinations listed in R13.4."
     traces:
-      - R5.3
-      - R5.4
+      - R13.3
+      - R13.4
   - id: AC8
     criterion: "cmd/fmt compiles with no warnings under golangci-lint."
     traces:
       - R1.1
-      - R1.2
-      - R1.3
-      - R1.4
       - R2.1
-      - R2.2
-      - R2.3
-      - R2.4
       - R3.1
-      - R3.2
       - R4.1
-      - R4.2
       - R5.1
-      - R5.2
-      - R5.3
-      - R5.4
+      - R6.1
+      - R7.1
+      - R8.1
+      - R9.1
+      - R10.1
+      - R11.1
+      - R12.1
+      - R13.1
+      - R13.2
+      - R13.3
+      - R13.4

--- a/docs/specs/product-requirements/prd082-stat.yaml
+++ b/docs/specs/product-requirements/prd082-stat.yaml
@@ -21,49 +21,61 @@ requirements:
       - R1.1:
           text: Must display file status for each named file argument using the default multi-line format matching GNU stat output (File, Size, Blocks, IO Block, file type, Device, Inode, Links, Access mode, Uid, Gid, Access time, Modify time, Change time, Birth time).
           weight: 4
-      - R1.2:
+
+  R2:
+    title: File listing options
+    items:
+      - R2.1:
           text: Must process multiple file arguments in order, printing status for each.
           weight: 1
-      - R1.3:
+      - R2.2:
           text: "-L or --dereference must follow symlinks and report the target file's status instead of the link itself."
           weight: 1
-      - R1.4:
+      - R2.3:
           text: Must exit 1 when any named file does not exist or cannot be accessed, printing an error to stderr, and continue processing remaining files.
           weight: 1
 
-  R2:
+  R3:
     title: Format strings
     items:
-      - R2.1:
-          text: "-c FORMAT or --format=FORMAT must use FORMAT as a printf-style format string. Must support directives: %a (access rights octal), %A (access rights human), %b (blocks allocated), %B (block size), %d (device number decimal), %D (device number hex), %f (raw mode hex), %F (file type), %g (group ID), %G (group name), %h (hard links), %i (inode), %m (mount point), %n (file name), %N (quoted file name with symlink target), %o (optimal I/O size), %s (total size bytes), %t (major device type hex), %T (minor device type hex), %u (user ID), %U (user name), %w (birth time human), %W (birth time epoch), %x (access time human), %X (access time epoch), %y (modify time human), %Y (modify time epoch), %z (change time human), %Z (change time epoch)."
-          weight: 4
-      - R2.2:
-          text: "--printf=FORMAT must work like --format but interpret backslash escapes (\\n, \\t, etc.) and not append a trailing newline."
-          weight: 1
-      - R2.3:
-          text: "-t or --terse must produce terse output (single line of space-separated fields) matching GNU stat --terse format."
-          weight: 1
-
-  R3:
-    title: Filesystem status mode
-    items:
       - R3.1:
-          text: "-f or --file-system must display filesystem status instead of file status. Output includes filesystem type, block size, total/free/available blocks and inodes."
-          weight: 4
-      - R3.2:
-          text: "Format directives in --file-system mode differ from file mode: %a (free blocks available to non-root), %b (total blocks), %c (total inodes), %d (free inodes), %f (free blocks), %i (filesystem ID hex), %l (max filename length), %n (file name), %s (block size optimal), %S (fundamental block size), %t (filesystem type hex), %T (filesystem type name)."
+          text: "-c FORMAT or --format=FORMAT must use FORMAT as a printf-style format string. Must support directives: %a (access rights octal), %A (access rights human), %b (blocks allocated), %B (block size), %d (device number decimal), %D (device number hex), %f (raw mode hex), %F (file type), %g (group ID), %G (group name), %h (hard links), %i (inode), %m (mount point), %n (file name), %N (quoted file name with symlink target), %o (optimal I/O size), %s (total size bytes), %t (major device type hex), %T (minor device type hex), %u (user ID), %U (user name), %w (birth time human), %W (birth time epoch), %x (access time human), %X (access time epoch), %y (modify time human), %Y (modify time epoch), %z (change time human), %Z (change time epoch)."
           weight: 4
 
   R4:
-    title: Exit codes and SIGPIPE
+    title: Printf and terse output
     items:
       - R4.1:
-          text: Must exit 0 when all files are processed successfully.
+          text: "--printf=FORMAT must work like --format but interpret backslash escapes (\\n, \\t, etc.) and not append a trailing newline."
           weight: 1
       - R4.2:
+          text: "-t or --terse must produce terse output (single line of space-separated fields) matching GNU stat --terse format."
+          weight: 1
+
+  R5:
+    title: Filesystem status
+    items:
+      - R5.1:
+          text: "-f or --file-system must display filesystem status instead of file status. Output includes filesystem type, block size, total/free/available blocks and inodes."
+          weight: 4
+
+  R6:
+    title: Filesystem format directives
+    items:
+      - R6.1:
+          text: "Format directives in --file-system mode differ from file mode: %a (free blocks available to non-root), %b (total blocks), %c (total inodes), %d (free inodes), %f (free blocks), %i (filesystem ID hex), %l (max filename length), %n (file name), %s (block size optimal), %S (fundamental block size), %t (filesystem type hex), %T (filesystem type name)."
+          weight: 4
+
+  R7:
+    title: Exit codes and SIGPIPE
+    items:
+      - R7.1:
+          text: Must exit 0 when all files are processed successfully.
+          weight: 1
+      - R7.2:
           text: Must exit 1 when any file cannot be accessed or an invalid format directive is used.
           weight: 1
-      - R4.3:
+      - R7.3:
           text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
           weight: 1
 
@@ -75,35 +87,35 @@ acceptance_criteria:
     criterion: "stat on a regular file produces multi-line status output matching gstat."
     traces:
       - R1.1
-      - R1.2
-      - R1.4
+      - R2.1
+      - R2.3
   - id: AC2
     criterion: "stat -c '%s %n' file produces size and name, matching gstat -c '%s %n'."
     traces:
-      - R2.1
+      - R3.1
   - id: AC3
     criterion: "stat -f / produces filesystem status matching gstat -f /."
     traces:
-      - R3.1
-      - R3.2
+      - R5.1
+      - R6.1
   - id: AC4
     criterion: "Differential test against gstat passes for all required test cases."
     traces:
       - R1.1
-      - R2.1
       - R3.1
+      - R5.1
   - id: AC5
     criterion: "cmd/stat compiles with no warnings under golangci-lint."
     traces:
       - R1.1
-      - R1.2
-      - R1.3
-      - R1.4
       - R2.1
       - R2.2
       - R2.3
       - R3.1
-      - R3.2
       - R4.1
       - R4.2
-      - R4.3
+      - R5.1
+      - R6.1
+      - R7.1
+      - R7.2
+      - R7.3

--- a/docs/specs/product-requirements/prd105-stty.yaml
+++ b/docs/specs/product-requirements/prd105-stty.yaml
@@ -14,47 +14,63 @@ goals:
 
 requirements:
   R1:
-    title: Display terminal settings
+    title: Default display
     items:
       - R1.1:
           text: When invoked with no arguments, must print a summary of current terminal settings (speed, line discipline, changed-from-default settings) matching GNU stty output format.
           weight: 4
-      - R1.2:
+
+  R2:
+    title: All settings display
+    items:
+      - R2.1:
           text: "-a or --all must print all current terminal settings in a human-readable format."
           weight: 4
-      - R1.3:
+
+  R3:
+    title: Save/restore and device
+    items:
+      - R3.1:
           text: "-g or --save must print all current terminal settings in a machine-readable format (stty-readable) that can be passed back as arguments to restore settings."
           weight: 1
-      - R1.4:
+      - R3.2:
           text: "-F DEVICE or --file=DEVICE must operate on the specified terminal device instead of stdin."
           weight: 1
 
-  R2:
-    title: Change terminal settings
+  R4:
+    title: Change settings
     items:
-      - R2.1:
+      - R4.1:
           text: "Must accept setting names as arguments to enable them, and names prefixed with - to disable them (e.g., stty -echo disables echo, stty echo enables it)."
           weight: 4
-      - R2.2:
+
+  R5:
+    title: Special characters
+    items:
+      - R5.1:
           text: "Must support special characters: intr, quit, erase, kill, eof, eol, eol2, swtch, start, stop, susp, rprnt, werase, lnext, discard, min, time."
           weight: 4
-      - R2.3:
+
+  R6:
+    title: Combination and speed settings
+    items:
+      - R6.1:
           text: "Must support combination settings: sane (reset to reasonable defaults), cooked (same as -raw), raw (set raw mode), evenp/parity (set even parity), oddp (set odd parity)."
           weight: 1
-      - R2.4:
+      - R6.2:
           text: "Must support speed setting: ispeed N, ospeed N, or N alone to set both input and output speed."
           weight: 1
 
-  R3:
+  R7:
     title: Exit codes and SIGPIPE
     items:
-      - R3.1:
+      - R7.1:
           text: Must exit 0 on success.
           weight: 1
-      - R3.2:
+      - R7.2:
           text: Must exit 1 on any error (invalid setting, cannot open device).
           weight: 1
-      - R3.3:
+      - R7.3:
           text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
           weight: 1
 
@@ -69,31 +85,31 @@ acceptance_criteria:
   - id: AC2
     criterion: "stty -a prints all settings, matching gstty -a."
     traces:
-      - R1.2
+      - R2.1
   - id: AC3
     criterion: "stty -g prints machine-readable settings, matching gstty -g."
     traces:
-      - R1.3
+      - R3.1
   - id: AC4
     criterion: "Differential test against gstty passes."
     traces:
       - R1.1
-      - R1.2
-      - R1.3
+      - R2.1
+      - R3.1
   - id: AC5
     criterion: "cmd/stty compiles with no warnings under golangci-lint."
     traces:
       - R1.1
-      - R1.2
-      - R1.3
-      - R1.4
       - R2.1
-      - R2.2
-      - R2.3
-      - R2.4
       - R3.1
       - R3.2
-      - R3.3
+      - R4.1
+      - R5.1
+      - R6.1
+      - R6.2
+      - R7.1
+      - R7.2
+      - R7.3
 
 package_contract:
   imports:

--- a/docs/specs/product-requirements/prd110-pr.yaml
+++ b/docs/specs/product-requirements/prd110-pr.yaml
@@ -18,39 +18,47 @@ requirements:
       - R1.1:
           text: Must format input into pages of 66 lines by default (header 5 lines, body 56 lines, footer 5 lines). Each page header shows the date, filename, and page number.
           weight: 4
-      - R1.2:
+
+  R2:
+    title: Page options
+    items:
+      - R2.1:
           text: "-l N or --length=N must set the page length to N lines. -h HEADER or --header=HEADER must replace the filename in the header."
           weight: 1
-      - R1.3:
+      - R2.2:
           text: "-t or --omit-header must suppress the 5-line header and 5-line footer. -T or --omit-pagination must suppress header/footer and do not pad page bottom."
           weight: 1
-      - R1.4:
+      - R2.3:
           text: Must read from FILE arguments or stdin when no file or "-" is given.
           weight: 1
 
-  R2:
-    title: Columns and formatting
+  R3:
+    title: Multi-column output
     items:
-      - R2.1:
+      - R3.1:
           text: "-COLUMN or --columns=COLUMN must produce multi-column output. Columns are filled down by default. -a or --across fills across instead."
           weight: 4
-      - R2.2:
+
+  R4:
+    title: Formatting options
+    items:
+      - R4.1:
           text: "-n[CHAR[WIDTH]] or --number-lines[=CHAR[WIDTH]] must number output lines. CHAR is the separator (default tab), WIDTH is the number field width (default 5)."
           weight: 1
-      - R2.3:
+      - R4.2:
           text: "-o MARGIN or --indent=MARGIN must indent each line by MARGIN spaces. -w WIDTH or --width=WIDTH must set the page width (default 72)."
           weight: 1
-      - R2.4:
+      - R4.3:
           text: "-d or --double-space must double-space the output. -s CHAR or --separator=CHAR must use CHAR as the column separator (default tab)."
           weight: 1
 
-  R3:
+  R5:
     title: Exit codes and SIGPIPE
     items:
-      - R3.1:
+      - R5.1:
           text: Must exit 0 on success. Must exit 1 on any error.
           weight: 1
-      - R3.2:
+      - R5.2:
           text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
           weight: 1
 
@@ -62,29 +70,29 @@ acceptance_criteria:
     criterion: "pr on a text file produces paginated output with header, matching gpr."
     traces:
       - R1.1
-      - R1.4
+      - R2.3
   - id: AC2
     criterion: "pr -2 produces two-column output, matching gpr -2."
     traces:
-      - R2.1
+      - R3.1
   - id: AC3
     criterion: "Differential test against gpr passes."
     traces:
       - R1.1
-      - R2.1
+      - R3.1
   - id: AC4
     criterion: "cmd/pr compiles with no warnings under golangci-lint."
     traces:
       - R1.1
-      - R1.2
-      - R1.3
-      - R1.4
       - R2.1
       - R2.2
       - R2.3
-      - R2.4
       - R3.1
-      - R3.2
+      - R4.1
+      - R4.2
+      - R4.3
+      - R5.1
+      - R5.2
 
 package_contract:
   imports:

--- a/docs/specs/product-requirements/prd111-ptx.yaml
+++ b/docs/specs/product-requirements/prd111-ptx.yaml
@@ -13,41 +13,49 @@ goals:
 
 requirements:
   R1:
-    title: Index generation
+    title: KWIC index generation
     items:
       - R1.1:
           text: Must read input lines and produce a permuted index where each significant word appears as a keyword in context, with the surrounding text shown on either side.
           weight: 4
-      - R1.2:
+
+  R2:
+    title: Index options
+    items:
+      - R2.1:
           text: "-w N or --width=N must set the output line width (default 72). -g N or --gap-size=N must set the minimum gap between columns (default 3)."
           weight: 1
-      - R1.3:
+      - R2.2:
           text: "-f or --ignore-case must fold lowercase to uppercase for sorting purposes."
           weight: 1
-      - R1.4:
+      - R2.3:
           text: Must read from FILE or stdin when no file or "-" is given.
           weight: 1
 
-  R2:
-    title: Reference and word control
+  R3:
+    title: Word regexp
     items:
-      - R2.1:
-          text: "-A or --auto-reference must produce automatically generated references based on file name and line number."
-          weight: 1
-      - R2.2:
-          text: "-r or --references must treat the first field of each line as a reference and exclude it from the index."
-          weight: 1
-      - R2.3:
+      - R3.1:
           text: "-W REGEXP or --word-regexp=REGEXP must use REGEXP to define what constitutes a word."
           weight: 4
 
-  R3:
+  R4:
+    title: Reference control
+    items:
+      - R4.1:
+          text: "-A or --auto-reference must produce automatically generated references based on file name and line number."
+          weight: 1
+      - R4.2:
+          text: "-r or --references must treat the first field of each line as a reference and exclude it from the index."
+          weight: 1
+
+  R5:
     title: Exit codes and SIGPIPE
     items:
-      - R3.1:
+      - R5.1:
           text: Must exit 0 on success. Must exit 1 on any error.
           weight: 1
-      - R3.2:
+      - R5.2:
           text: Must handle SIGPIPE gracefully (exit 0) using pkg/sys.InstallSIGPIPEHandler.
           weight: 1
 
@@ -59,11 +67,11 @@ acceptance_criteria:
     criterion: "ptx on a text file produces a permuted index, matching gptx."
     traces:
       - R1.1
-      - R1.4
+      - R2.3
   - id: AC2
     criterion: "ptx -f folds case for sorting, matching gptx -f."
     traces:
-      - R1.3
+      - R2.2
   - id: AC3
     criterion: "Differential test against gptx passes."
     traces:
@@ -72,14 +80,14 @@ acceptance_criteria:
     criterion: "cmd/ptx compiles with no warnings under golangci-lint."
     traces:
       - R1.1
-      - R1.2
-      - R1.3
-      - R1.4
       - R2.1
       - R2.2
       - R2.3
       - R3.1
-      - R3.2
+      - R4.1
+      - R4.2
+      - R5.1
+      - R5.2
 
 package_contract:
   imports:


### PR DESCRIPTION
## Summary

Restructures 5 complex PRDs so each weight-4 requirement is isolated in its own group, preventing overweight stitch tasks. Moves ts, stty, pr, ptx to rel99.0 so they generate last and don't block other utilities.

## Changes

- 5 PRDs restructured (fmt: 13 groups, stat: 7, stty: 7, pr: 5, ptx: 5)
- road-map.yaml: moved 4 utilities to rel99.0
- configuration.yaml: added rel99.0

## Test plan

- [x] `mage analyze` — 0 errors
- [x] No group has more than 1 weight-4 item

Closes #3569