### PR TITLE
Restore ts, stty, pr, ptx to original releases

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -49,7 +49,6 @@ project:
         - "13.0"
         - "13.1"
         - "14.0"
-        - "99.0"
 generation:
     prefix: generation-
     cycles: 100

--- a/docs/road-map.yaml
+++ b/docs/road-map.yaml
@@ -544,6 +544,8 @@ releases:
           status: spec_complete
         - id: rel12.1-uc003-test
           status: spec_complete
+        - id: rel12.1-uc004-stty
+          status: spec_complete
     - version: "13.0"
       name: "Batch 13.0 — directory listing and filesystem (df, dir, vdir, dircolors)"
       status: spec_complete
@@ -564,6 +566,20 @@ releases:
           status: spec_complete
         - id: rel13.0-uc004-dircolors
           status: spec_complete
+    - version: "13.1"
+      name: "Batch 13.1 — text formatting (pr, ptx)"
+      status: spec_complete
+      depends_on: ["00.0"]
+      description: |
+        Implement two text formatting utilities. pr paginates text files for printing with
+        headers, page numbers, and multi-column layout. ptx produces a permuted
+        (keyword-in-context) index from text input. Both are verified by differential
+        testing against GNU coreutils reference binaries.
+      use_cases:
+        - id: rel13.1-uc001-pr
+          status: spec_complete
+        - id: rel13.1-uc002-ptx
+          status: spec_complete
     - version: "14.0"
       name: "Batch 14.0 — moreutils (chronic, pee, vidir)"
       status: spec_complete
@@ -580,23 +596,4 @@ releases:
         - id: rel14.0-uc002-pee
           status: spec_complete
         - id: rel14.0-uc003-vidir
-          status: spec_complete
-    - version: "99.0"
-      name: "Deferred — complex utilities requiring restructured PRDs"
-      status: spec_complete
-      depends_on: ["00.0"]
-      description: |
-        Deferred utilities from run 38 that exceeded the stitch time budget due to
-        complex requirement groups containing multiple weight-4 items. PRDs have been
-        restructured (GH-3569) so each weight-4 item is in its own requirement group.
-        ts (prd004) is a large utility with 10 requirement groups. pr and ptx involve
-        complex text formatting algorithms. stty requires terminal ioctl knowledge.
-      use_cases:
-        - id: rel05.5-uc001-ts
-          status: spec_complete
-        - id: rel12.1-uc004-stty
-          status: spec_complete
-        - id: rel13.1-uc001-pr
-          status: spec_complete
-        - id: rel13.1-uc002-ptx
           status: spec_complete


### PR DESCRIPTION
## Summary

Moves ts, stty, pr, ptx back to their original releases. PRDs are already restructured with isolated weight-4 groups so they should complete without timeouts. Removes rel99.0.

## Test plan

- [x] `mage analyze` — 0 errors