### PR TITLE
GH-3646: Upgrade cobbler-scaffold v0.20260327.0 → v0.20260328.0

### DIFF
--- a/docs/constitutions/design.yaml
+++ b/docs/constitutions/design.yaml
@@ -359,6 +359,7 @@ completeness_checklists:
     - id matches filename without extension
     - flow steps are numbered (F1, F2, ...), end-to-end, map to real components
     - touchpoints are numbered (T1, T2, ...) and list interfaces, components, protocols
+    - touchpoints that cite PRDs must include R-group references (e.g., "prd030-md5sum R1, R2, R3"); bare PRD citations without R-groups break codereadiness computation
     - success_criteria are structured objects with id, criterion, and traces to PRD AC IDs
     - test_suite references a corresponding test suite ID
     - Test suite YAML exists and traces back to this use case

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260327.0
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260328.0
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260327.0 h1:e1WEP5f2vsRk4qxE6OxxsklHmYjLJfzUnx52QF52ta0=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260327.0/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260328.0 h1:zyPD5YcuLvOF1f3J7hMJKHlisGcIzcEwBxAJZEsEaso=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260328.0/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Summary

Upgrades scaffold. Fixes codereadiness computation (cobbler-scaffold#1960) and adds mage analyze check for bare touchpoints (#1961). 21 violations now flagged — will be fixed in #3645.

## Test plan

- [x] `mage analyze` detects 21 bare touchpoints (new check works)

Closes #3646