### PR TITLE
GH-3645: Add R-group references to use case touchpoints

### DIFF
--- a/docs/specs/use-cases/rel05.5-uc001-ts.yaml
+++ b/docs/specs/use-cases/rel05.5-uc001-ts.yaml
@@ -35,7 +35,7 @@ flow:
 touchpoints:
   - T1: "cmd/ts — timestamp prefix logic, all flag modes (prd004-ts R1, R2, R3, R4, R5, R6, R7, R8, R10)"
   - T2: "pkg/testutils — RunDiffTests, TimestampNormalizer, binary execution and comparison (rel00.0 infrastructure)"
-  - T3: "Human Operator — triggers use case via do-work after prd004-ts is complete"
+  - T3: "Human Operator — triggers use case via do-work after prd004-ts R1-R10 is complete"
 
 success_criteria:
   - id: S1

--- a/docs/specs/use-cases/rel11.1-uc001-users.yaml
+++ b/docs/specs/use-cases/rel11.1-uc001-users.yaml
@@ -22,7 +22,7 @@ flow:
       gusers with the same inputs and compares stdout, stderr, and exit codes.
 
 touchpoints:
-  - T1: "cmd/users — users prints logged-in usernames (prd096-users)"
+  - T1: "cmd/users — users prints logged-in usernames (prd096-users R1, R2)"
   - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
   - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
 

--- a/docs/specs/use-cases/rel11.1-uc002-who.yaml
+++ b/docs/specs/use-cases/rel11.1-uc002-who.yaml
@@ -22,7 +22,7 @@ flow:
       gwho with the same inputs and compares stdout, stderr, and exit codes.
 
 touchpoints:
-  - T1: "cmd/who — who prints user, terminal, and time info (prd097-who)"
+  - T1: "cmd/who — who prints user, terminal, and time info (prd097-who R1, R2, R3)"
   - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
   - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
 

--- a/docs/specs/use-cases/rel11.1-uc003-pinky.yaml
+++ b/docs/specs/use-cases/rel11.1-uc003-pinky.yaml
@@ -22,7 +22,7 @@ flow:
       gpinky with the same inputs and compares stdout, stderr, and exit codes.
 
 touchpoints:
-  - T1: "cmd/pinky — pinky prints user info in short/long format (prd098-pinky)"
+  - T1: "cmd/pinky — pinky prints user info in short/long format (prd098-pinky R1, R2, R3)"
   - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
   - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
 

--- a/docs/specs/use-cases/rel12.0-uc001-shred.yaml
+++ b/docs/specs/use-cases/rel12.0-uc001-shred.yaml
@@ -22,7 +22,7 @@ flow:
       gshred with the same inputs and compares stdout, stderr, and exit codes.
 
 touchpoints:
-  - T1: "cmd/shred — shred overwrites files with random data (prd099-shred)"
+  - T1: "cmd/shred — shred overwrites files with random data (prd099-shred R1, R2, R3)"
   - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
   - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
 

--- a/docs/specs/use-cases/rel12.0-uc002-chroot.yaml
+++ b/docs/specs/use-cases/rel12.0-uc002-chroot.yaml
@@ -22,7 +22,7 @@ flow:
       gchroot with the same inputs and compares stdout, stderr, and exit codes.
 
 touchpoints:
-  - T1: "cmd/chroot — chroot changes root and executes command (prd100-chroot)"
+  - T1: "cmd/chroot — chroot changes root and executes command (prd100-chroot R1, R2)"
   - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
   - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
 

--- a/docs/specs/use-cases/rel12.0-uc003-install.yaml
+++ b/docs/specs/use-cases/rel12.0-uc003-install.yaml
@@ -22,7 +22,7 @@ flow:
       ginstall with the same inputs and compares stdout, stderr, and exit codes.
 
 touchpoints:
-  - T1: "cmd/install — install copies files with permissions (prd101-install)"
+  - T1: "cmd/install — install copies files with permissions (prd101-install R1, R2, R3)"
   - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
   - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
 

--- a/docs/specs/use-cases/rel12.1-uc001-tsort.yaml
+++ b/docs/specs/use-cases/rel12.1-uc001-tsort.yaml
@@ -22,7 +22,7 @@ flow:
       gtsort with the same inputs and compares stdout, stderr, and exit codes.
 
 touchpoints:
-  - T1: "cmd/tsort — tsort produces topological ordering (prd102-tsort)"
+  - T1: "cmd/tsort — tsort produces topological ordering (prd102-tsort R1, R2)"
   - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
   - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
 

--- a/docs/specs/use-cases/rel12.1-uc002-pathchk.yaml
+++ b/docs/specs/use-cases/rel12.1-uc002-pathchk.yaml
@@ -22,7 +22,7 @@ flow:
       gpathchk with the same inputs and compares stdout, stderr, and exit codes.
 
 touchpoints:
-  - T1: "cmd/pathchk — pathchk validates POSIX pathnames (prd103-pathchk)"
+  - T1: "cmd/pathchk — pathchk validates POSIX pathnames (prd103-pathchk R1, R2)"
   - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
   - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
 

--- a/docs/specs/use-cases/rel12.1-uc003-test.yaml
+++ b/docs/specs/use-cases/rel12.1-uc003-test.yaml
@@ -22,7 +22,7 @@ flow:
       gtest with the same inputs and compares stdout, stderr, and exit codes.
 
 touchpoints:
-  - T1: "cmd/test — test evaluates file, string, integer conditions (prd104-test)"
+  - T1: "cmd/test — test evaluates file, string, integer conditions (prd104-test R1, R2, R3, R4)"
   - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
   - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
 

--- a/docs/specs/use-cases/rel12.1-uc004-stty.yaml
+++ b/docs/specs/use-cases/rel12.1-uc004-stty.yaml
@@ -22,7 +22,7 @@ flow:
       gstty with the same inputs and compares stdout, stderr, and exit codes.
 
 touchpoints:
-  - T1: "cmd/stty — stty prints and changes terminal settings (prd105-stty)"
+  - T1: "cmd/stty — stty prints and changes terminal settings (prd105-stty R1, R2, R3, R4, R5, R6, R7)"
   - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
   - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
 

--- a/docs/specs/use-cases/rel13.0-uc001-df.yaml
+++ b/docs/specs/use-cases/rel13.0-uc001-df.yaml
@@ -22,7 +22,7 @@ flow:
       gdf with the same inputs and compares stdout, stderr, and exit codes.
 
 touchpoints:
-  - T1: "cmd/df — df reports filesystem usage (prd106-df)"
+  - T1: "cmd/df — df reports filesystem usage (prd106-df R1, R2, R3, R4)"
   - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
   - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
 

--- a/docs/specs/use-cases/rel13.0-uc002-dir.yaml
+++ b/docs/specs/use-cases/rel13.0-uc002-dir.yaml
@@ -22,7 +22,7 @@ flow:
       gdir with the same inputs and compares stdout, stderr, and exit codes.
 
 touchpoints:
-  - T1: "cmd/dir — dir lists directory contents (prd107-dir)"
+  - T1: "cmd/dir — dir lists directory contents (prd107-dir R1, R2)"
   - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
   - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
 

--- a/docs/specs/use-cases/rel13.0-uc003-vdir.yaml
+++ b/docs/specs/use-cases/rel13.0-uc003-vdir.yaml
@@ -22,7 +22,7 @@ flow:
       gvdir with the same inputs and compares stdout, stderr, and exit codes.
 
 touchpoints:
-  - T1: "cmd/vdir — vdir lists directory contents verbosely (prd108-vdir)"
+  - T1: "cmd/vdir — vdir lists directory contents verbosely (prd108-vdir R1, R2)"
   - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
   - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
 

--- a/docs/specs/use-cases/rel13.0-uc004-dircolors.yaml
+++ b/docs/specs/use-cases/rel13.0-uc004-dircolors.yaml
@@ -22,7 +22,7 @@ flow:
       gdircolors with the same inputs and compares stdout, stderr, and exit codes.
 
 touchpoints:
-  - T1: "cmd/dircolors — dircolors outputs LS_COLORS shell commands (prd109-dircolors)"
+  - T1: "cmd/dircolors — dircolors outputs LS_COLORS shell commands (prd109-dircolors R1, R2, R3)"
   - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
   - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
 

--- a/docs/specs/use-cases/rel13.1-uc001-pr.yaml
+++ b/docs/specs/use-cases/rel13.1-uc001-pr.yaml
@@ -22,7 +22,7 @@ flow:
       gpr with the same inputs and compares stdout, stderr, and exit codes.
 
 touchpoints:
-  - T1: "cmd/pr — pr paginates text with headers (prd110-pr)"
+  - T1: "cmd/pr — pr paginates text with headers (prd110-pr R1, R2, R3, R4, R5)"
   - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
   - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
 

--- a/docs/specs/use-cases/rel13.1-uc002-ptx.yaml
+++ b/docs/specs/use-cases/rel13.1-uc002-ptx.yaml
@@ -22,7 +22,7 @@ flow:
       gptx with the same inputs and compares stdout, stderr, and exit codes.
 
 touchpoints:
-  - T1: "cmd/ptx — ptx produces KWIC index (prd111-ptx)"
+  - T1: "cmd/ptx — ptx produces KWIC index (prd111-ptx R1, R2, R3, R4, R5)"
   - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
   - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
 

--- a/docs/specs/use-cases/rel14.0-uc001-chronic.yaml
+++ b/docs/specs/use-cases/rel14.0-uc001-chronic.yaml
@@ -22,7 +22,7 @@ flow:
       chronic with the same inputs and compares stdout, stderr, and exit codes.
 
 touchpoints:
-  - T1: "cmd/chronic — chronic suppresses output on success (prd112-chronic)"
+  - T1: "cmd/chronic — chronic suppresses output on success (prd112-chronic R1, R2)"
   - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
   - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
 

--- a/docs/specs/use-cases/rel14.0-uc002-pee.yaml
+++ b/docs/specs/use-cases/rel14.0-uc002-pee.yaml
@@ -22,7 +22,7 @@ flow:
       pee with the same inputs and compares stdout, stderr, and exit codes.
 
 touchpoints:
-  - T1: "cmd/pee — pee pipes stdin to multiple commands (prd113-pee)"
+  - T1: "cmd/pee — pee pipes stdin to multiple commands (prd113-pee R1, R2)"
   - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
   - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
 

--- a/docs/specs/use-cases/rel14.0-uc003-vidir.yaml
+++ b/docs/specs/use-cases/rel14.0-uc003-vidir.yaml
@@ -22,7 +22,7 @@ flow:
       vidir with the same inputs and compares stdout, stderr, and exit codes.
 
 touchpoints:
-  - T1: "cmd/vidir — vidir enables batch rename/delete (prd114-vidir)"
+  - T1: "cmd/vidir — vidir enables batch rename/delete (prd114-vidir R1, R2)"
   - T2: "pkg/testutils — RunDiffTests, binary execution and comparison"
   - T3: "pkg/sys — InstallSIGPIPEHandler for graceful SIGPIPE handling"
 


### PR DESCRIPTION
## Summary

Adds R-group references to 20 use case touchpoints that cited PRDs without specifying which requirement groups are exercised. Fixes cobbler-scaffold#1960 regression.

## Test plan

- [x] `mage analyze` — 0 errors, 0 bare touchpoints

Closes #3645