### PR TITLE
GH-3615: Post-generation run 40b repository cleanup

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -34,15 +34,28 @@ project:
         - "05.4"
         - "06.0"
         - "06.1"
-        - "15.0"
+        - "07.0"
+        - "07.1"
+        - "08.0"
+        - "08.1"
+        - "09.0"
+        - "09.1"
+        - "10.0"
+        - "10.1"
+        - "11.0"
+        - "11.1"
+        - "12.0"
+        - "12.1"
+        - "13.0"
+        - "14.0"
         - "15.0"
 generation:
     prefix: generation-
-    cycles: 500
+    cycles: 100
 cobbler:
     dir: .cobbler/
     max_stitch_issues_per_cycle: 1
-    max_measure_issues: 4
+    max_measure_issues: 1
     measure_prompt: docs/prompts/measure.yaml
     stitch_prompt: docs/prompts/stitch.yaml
     planning_constitution: docs/constitutions/planning.yaml


### PR DESCRIPTION
## Summary

Post-generation cleanup after run 40b. Restores configuration.yaml releases list (07.0-14.0 lost during merge), resets generation-specific settings, and removes stale branches.

## Changes

- Restored all 33 releases in configuration.yaml (was 20 with missing 07.0-14.0 and duplicate 15.0)
- Reset max_measure_issues: 4 → 1
- Reset cycles: 500 → 100
- Deleted stale branch `task/generation-gh-3652-run40-3662`
- Pruned stale remote refs

## Test plan

- [x] All 33 releases match roadmap
- [x] No stale branches or worktrees
- [x] No open cobbler-labeled issues
- [x] Config values reset to defaults

Closes #3615