### PR TITLE
GH-4214: Migrate interfaces from ARCHITECTURE.yaml to docs/interfaces/

### DIFF
--- a/docs/ARCHITECTURE.yaml
+++ b/docs/ARCHITECTURE.yaml
@@ -30,24 +30,9 @@ overview:
 
 interfaces:
   - name: Data Structures
-    summary: |
-      Specification artifacts and runtime data structures used across the pipeline.
-    data_structures:
-      - "SRD (srd[NNN]-<utility>.yaml): per-utility software requirements document with numbered goals, requirements, and acceptance criteria."
-      - "Use case (rel[NN].[N]-uc[NNN]-<utility>.yaml): per-utility use case describing a concrete end-to-end execution path through the system."
-      - "DiffTest: Go struct in pkg/testutils/ defining a single differential test case with fields for input arguments, stdin, environment, expected exit code, and expected output."
-      - "configuration.yaml: orchestrator configuration file at the project root consumed by magefiles/ to configure build, analysis, and generation targets."
-    operations:
-      - "mage build: compiles all cmd/ binaries to bin/."
-      - "mage lint: runs golangci-lint on all Go source under cmd/ and pkg/."
-      - "mage stats:loc: prints Go lines of code (production and test) and documentation word counts."
-      - "mage analyze: runs cross-artifact consistency checks on docs/ (SRDs, use cases, test suites, roadmap)."
-      - "go test ./...: runs all tests including differential tests in each cmd/ package."
+    spec_file: docs/interfaces/ifc-data-structures.yaml
   - name: Events
-    summary: |
-      Observable events emitted by the system during operation.
-    operations:
-      - "Differential test failure: go test reports the divergence with the input that triggered it, the expected output (reference binary), and the actual output (Go binary)."
+    spec_file: docs/interfaces/ifc-events.yaml
 
 components:
   - name: Human Operator

--- a/docs/interfaces/ifc-data-structures.yaml
+++ b/docs/interfaces/ifc-data-structures.yaml
@@ -1,0 +1,107 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-data-structures
+name: Data Structures
+summary: |
+  Specification artifacts and runtime data structures used across the pipeline.
+
+data_structures:
+  - name: SRD
+    description: Per-utility software requirements document with numbered goals, requirements, and acceptance criteria.
+    fields:
+      - name: id
+        type: string
+        description: Unique identifier in the form srd[NNN]-<utility>.
+        required: true
+      - name: title
+        type: string
+        description: Human-readable title of the utility or component.
+        required: true
+      - name: goals
+        type: array
+        description: Numbered goal statements (G1, G2, ...).
+      - name: requirements
+        type: array
+        description: Numbered requirement groups (R1, R2, ...) with sub-items.
+      - name: acceptance_criteria
+        type: array
+        description: Numbered acceptance criteria (AC1, AC2, ...).
+
+  - name: UseCase
+    description: Per-utility use case describing a concrete end-to-end execution path through the system.
+    fields:
+      - name: id
+        type: string
+        description: Unique identifier in the form rel[NN].[N]-uc[NNN]-<utility>.
+        required: true
+      - name: touchpoints
+        type: array
+        description: References to SRD requirements exercised by this use case.
+      - name: success_criteria
+        type: array
+        description: Observable outcomes that confirm the use case succeeds.
+
+  - name: DiffTest
+    description: Go struct in pkg/testutils/ defining a single differential test case.
+    fields:
+      - name: Name
+        type: string
+        description: Human-readable test case name.
+        required: true
+      - name: Args
+        type: array
+        description: Command-line arguments passed to both binaries.
+      - name: Stdin
+        type: string
+        description: Standard input fed to both binaries.
+      - name: Env
+        type: array
+        description: Environment variables set for both binaries.
+      - name: ExitCode
+        type: integer
+        description: Expected exit code from the reference binary.
+
+  - name: Configuration
+    description: Orchestrator configuration file at the project root consumed by magefiles/.
+    fields:
+      - name: project
+        type: object
+        description: Project metadata (name, module path, source directories).
+        required: true
+      - name: cobbler
+        type: object
+        description: Measure and stitch settings (issues repo, Claude args).
+      - name: generation
+        type: object
+        description: Generation run settings (cycles, timeouts, preserve_sources).
+
+operations:
+  - name: build
+    description: Compile all cmd/ binaries to bin/.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: lint
+    description: Run golangci-lint on all Go source under cmd/ and pkg/.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: stats:loc
+    description: Print Go lines of code (production and test) and documentation word counts.
+    parameters: []
+    returns: []
+  - name: analyze
+    description: Run cross-artifact consistency checks on docs/ (SRDs, use cases, test suites, roadmap).
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: test
+    description: Run all tests including differential tests in each cmd/ package.
+    parameters: []
+    returns:
+      - name: error
+        type: error

--- a/docs/interfaces/ifc-events.yaml
+++ b/docs/interfaces/ifc-events.yaml
@@ -1,0 +1,22 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-events
+name: Events
+summary: |
+  Observable events emitted by the system during operation.
+
+operations:
+  - name: DifferentialTestFailure
+    description: Report divergence between Go binary and reference binary output for a given input.
+    parameters:
+      - name: input
+        type: string
+        description: The input (arguments, stdin) that triggered the divergence.
+      - name: expected
+        type: string
+        description: Output from the reference binary.
+      - name: actual
+        type: string
+        description: Output from the Go binary.
+    returns: []


### PR DESCRIPTION
## Summary

Extract the two inline interface definitions (Data Structures, Events) from ARCHITECTURE.yaml into individual typed spec files under docs/interfaces/, matching the format established in cobbler-scaffold v0.20260405.0.

## Changes

- Created `docs/interfaces/ifc-data-structures.yaml` with 4 data structures (SRD, UseCase, DiffTest, Configuration) and 5 operations (build, lint, stats:loc, analyze, test)
- Created `docs/interfaces/ifc-events.yaml` with 1 operation (DifferentialTestFailure)
- Updated `docs/ARCHITECTURE.yaml` to reference spec files via `spec_file` instead of inlining definitions

## Stats

- 3 files changed, 131 insertions, 17 deletions
- go_loc: 76,933 (unchanged)

## Test plan

- [x] `mage analyze` passes (loads 2 interface spec files, 0 broken refs)
- [x] Documentation reviewed for consistency

Closes #4214