### PR TITLE
GH-4206: Increase weight for requirements that cause long stitch times

### DIFF
--- a/docs/specs/software-requirements/srd005-wc.yaml
+++ b/docs/specs/software-requirements/srd005-wc.yaml
@@ -48,7 +48,7 @@ requirements:
           weight: 1
       - R2.5:
           text: -L must print the length of the longest line in the input, measured in display columns (tab-expanded, treating each tab as advancing to the next multiple of 8). -L is independent of other flags and may be combined with any of them.
-          weight: 1
+          weight: 4
       - R2.6:
           text: 'When flags are combined, must print each requested count in the order: lines (-l), words (-w), chars (-m) or bytes (-c), max-line-length (-L). This is the fixed output column order from wc.c:237-247, not the flag order given by the user.'
           weight: 1
@@ -64,7 +64,7 @@ requirements:
           weight: 1
       - R3.3:
           text: Must support --total=auto (default), --total=always (print total even for one file), --total=only (print only the total, not per-file lines), and --total=never (never print total, even for multiple files).
-          weight: 1
+          weight: 4
 
   R4:
     title: Stdin and special inputs
@@ -80,14 +80,14 @@ requirements:
           weight: 1
       - R4.4:
           text: Must support --files0-from=FILE which reads NUL-delimited filenames from FILE and processes each. When FILE is "-", filenames are read from stdin.
-          weight: 1
+          weight: 4
 
   R5:
     title: Locale handling
     items:
       - R5.1:
           text: Differential tests must set LC_ALL=C to avoid locale-dependent divergence between the Go and reference binary outputs for -m (character count). Document this constraint in the test suite.
-          weight: 1
+          weight: 4
       - R5.2:
           text: Under LC_ALL=C, -m and -c must produce identical counts (each byte counts as one character). The Go implementation must produce the same result.
           weight: 1

--- a/docs/specs/software-requirements/srd006-cat.yaml
+++ b/docs/specs/software-requirements/srd006-cat.yaml
@@ -94,14 +94,14 @@ requirements:
           weight: 1
       - R4.9:
           text: "Transformation flags are compatible with -n, -b, and -s. The order of application is: squeeze blanks (-s), then apply non-printing display (-v/-T), then append end-of-line marker (-E), then prepend line number (-n/-b)."
-          weight: 1
+          weight: 4
 
   R5:
     title: Error handling and exit codes
     items:
       - R5.1:
           text: Must exit 0 when all inputs are processed successfully.
-          weight: 1
+          weight: 4
       - R5.2:
           text: Must exit 1 when any input file cannot be opened. The error message must be written to stderr. cat must continue processing remaining file arguments after the error.
           weight: 1

--- a/docs/specs/software-requirements/srd007-sponge.yaml
+++ b/docs/specs/software-requirements/srd007-sponge.yaml
@@ -38,14 +38,14 @@ requirements:
           weight: 1
       - R1.5:
           text: "Must register a cleanup handler (atexit equivalent in Go: defer or os/signal) that deletes the temp file if the process exits or receives SIGINT, SIGTERM, SIGHUP, or SIGPIPE before the rename completes."
-          weight: 1
+          weight: 4
 
   R2:
     title: Output file handling
     items:
       - R2.1:
           text: When an output filename is given, must attempt an atomic rename of the temp file to the output filename when the output file is a regular file or does not yet exist (sponge.c:371-373).
-          weight: 1
+          weight: 4
       - R2.2:
           text: When the rename fails (e.g., cross-device move), must fall back to a byte-for-byte copy of the temp file content to the output file, then delete the temp file.
           weight: 1

--- a/docs/specs/software-requirements/srd009-du.yaml
+++ b/docs/specs/software-requirements/srd009-du.yaml
@@ -75,7 +75,7 @@ requirements:
           weight: 1
       - R2.4:
           text: -d N (and the long form --max-depth=N) must limit the depth of reported entries. Depth 0 means only the argument itself (equivalent to -s). Depth 1 means the argument and its immediate children. Files and directories deeper than N are accumulated into their parent's total but not printed as separate lines.
-          weight: 1
+          weight: 4
       - R2.5:
           text: -k must report sizes in 1024-byte blocks. Since 1K is already the default, -k has no visible effect but must be accepted without error for compatibility.
           weight: 1

--- a/docs/specs/software-requirements/srd023-fold.yaml
+++ b/docs/specs/software-requirements/srd023-fold.yaml
@@ -20,7 +20,7 @@ requirements:
     items:
       - R1.1:
           text: Must read each file (or stdin when no arguments are given) and write each line wrapped to at most W characters (columns by default, bytes with -b). The default width is 80.
-          weight: 1
+          weight: 4
       - R1.2:
           text: Lines shorter than or equal to the maximum width must be written unchanged (including the trailing newline).
           weight: 1

--- a/docs/specs/software-requirements/srd024-expand.yaml
+++ b/docs/specs/software-requirements/srd024-expand.yaml
@@ -51,7 +51,7 @@ requirements:
     items:
       - R3.1:
           text: Must exit 0 when all inputs are processed successfully.
-          weight: 1
+          weight: 4
       - R3.2:
           text: Must exit 1 when any input file cannot be opened, printing the error to stderr. Processing continues for remaining files.
           weight: 1

--- a/docs/specs/software-requirements/srd026-cut.yaml
+++ b/docs/specs/software-requirements/srd026-cut.yaml
@@ -68,7 +68,7 @@ requirements:
           weight: 1
       - R4.2:
           text: Must exit 1 when any input file cannot be opened, printing the error to stderr. Processing continues for remaining files.
-          weight: 1
+          weight: 4
       - R4.3:
           text: Must exit 1 when a write error occurs on stdout.
           weight: 1

--- a/docs/specs/software-requirements/srd027-paste.yaml
+++ b/docs/specs/software-requirements/srd027-paste.yaml
@@ -20,7 +20,7 @@ requirements:
     items:
       - R1.1:
           text: Must open all named files simultaneously and read one line from each per output line. Lines from files are joined with the delimiter and written to stdout, followed by a newline.
-          weight: 1
+          weight: 4
       - R1.2:
           text: When files have unequal line counts, the shorter files contribute empty fields (the delimiter is still written) until all files are exhausted. The final output line ends with a newline.
           weight: 1

--- a/docs/specs/software-requirements/srd029-comm.yaml
+++ b/docs/specs/software-requirements/srd029-comm.yaml
@@ -52,7 +52,7 @@ requirements:
     items:
       - R3.1:
           text: By default, comm checks that input files are sorted. When a line is encountered that is less than the previous line in the same file, comm prints a warning to stderr and continues.
-          weight: 1
+          weight: 4
       - R3.2:
           text: --check-order makes the ordering check fatal; comm exits non-zero if input is not sorted.
           weight: 1

--- a/docs/specs/software-requirements/srd032-sha256sum.yaml
+++ b/docs/specs/software-requirements/srd032-sha256sum.yaml
@@ -52,14 +52,14 @@ requirements:
           weight: 1
       - R3.2:
           text: --tag produces BSD tag format regardless of -b/-t.
-          weight: 1
+          weight: 4
 
   R4:
     title: Exit codes and SIGPIPE
     items:
       - R4.1:
           text: Must exit 0 when all files are processed and all verified digests match.
-          weight: 1
+          weight: 4
       - R4.2:
           text: Must exit 1 when any file cannot be opened, any digest fails, or the checksum file is unreadable.
           weight: 1

--- a/docs/specs/software-requirements/srd034-mkdir.yaml
+++ b/docs/specs/software-requirements/srd034-mkdir.yaml
@@ -19,7 +19,7 @@ requirements:
     items:
       - R1.1:
           text: Must create a single directory when invoked as 'mkdir DIR'.
-          weight: 1
+          weight: 4
       - R1.2:
           text: Must create multiple directories when invoked with multiple DIR arguments, processing each independently.
           weight: 1
@@ -35,7 +35,7 @@ requirements:
     items:
       - R2.1:
           text: -p or --parents must create intermediate parent directories as needed, similar to 'mkdir -p a/b/c' creating a, a/b, and a/b/c.
-          weight: 1
+          weight: 4
       - R2.2:
           text: Must not report an error when the target directory already exists and -p is given.
           weight: 1
@@ -51,7 +51,7 @@ requirements:
           weight: 1
       - R3.2:
           text: When -m is not given, must create directories with default permissions (0777 modified by the process umask).
-          weight: 1
+          weight: 4
       - R3.3:
           text: When -p is combined with -m, must apply the specified mode only to the final target directory; intermediate directories must be created with default permissions modified by umask.
           weight: 1

--- a/docs/specs/software-requirements/srd035-rmdir.yaml
+++ b/docs/specs/software-requirements/srd035-rmdir.yaml
@@ -35,7 +35,7 @@ requirements:
     items:
       - R2.1:
           text: -p or --parents must remove the target directory and then remove each successive empty parent component of the path, similar to 'rmdir -p a/b/c' removing c, then b, then a.
-          weight: 1
+          weight: 4
       - R2.2:
           text: Must stop ascending when a parent directory is not empty and report an error for that component.
           weight: 1


### PR DESCRIPTION
## Summary

Increase requirement weights from 1 to 4 for 20 requirements across 12 SRDs that caused 5-11 minute stitch times during generation run 40b. Higher weights prevent the measure agent from batching these with other requirements, avoiding timeouts.

## Changes

- Updated 20 requirements across 12 SRD files (srd005, srd006, srd007, srd009, srd023, srd024, srd026, srd027, srd029, srd032, srd034, srd035)
- 6 requirements in 3 SRDs (srd008-ls, srd022-nl, srd111-ptx) were already at weight 4

## Stats

- 12 files changed, 20 weight: 1 → weight: 4
- go_loc: 76,933 (unchanged)

## Test plan

- [x] `mage analyze` passes
- [x] All weight changes verified against run 40b slow task list

Closes #4206