### PR TITLE
GH-5034: refine bash_command_class — pipeline-aware classification

### DIFF
--- a/analysis/datasets/tools.csv
+++ b/analysis/datasets/tools.csv
@@ -13,9 +13,9 @@ generation-2026-02-25-07-08-59-0ya,slug,2026-02-25-07-08-59,a960d19a-bd69-42c3-9
 generation-2026-02-25-07-08-59-0ya,slug,2026-02-25-07-08-59,a960d19a-bd69-42c3-9afa-26ef3f3c7b02,,16,12,TodoWrite,"{""todos"": [{""content"": ""Review existing project files (go.mod, existing pkg/ structure)"", ""status"": ""completed"", ""activeForm"": ""Reviewing existing project files""}, {""content"": ""Implement pkg/testutils",,False,160,0
 generation-2026-02-25-07-08-59-0ya,slug,2026-02-25-07-08-59,a960d19a-bd69-42c3-9afa-26ef3f3c7b02,,17,13,Bash,go test ./pkg/testutils/... -v 2>&1,go_test,False,72,0
 generation-2026-02-25-07-08-59-0ya,slug,2026-02-25-07-08-59,a960d19a-bd69-42c3-9afa-26ef3f3c7b02,,19,14,Bash,go vet ./pkg/testutils/... 2>&1,go_vet,False,0,0
-generation-2026-02-25-07-08-59-0ya,slug,2026-02-25-07-08-59,a960d19a-bd69-42c3-9afa-26ef3f3c7b02,,20,15,Bash,which golangci-lint 2>&1 || go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest 2>&1,other,False,33,0
+generation-2026-02-25-07-08-59-0ya,slug,2026-02-25-07-08-59,a960d19a-bd69-42c3-9afa-26ef3f3c7b02,,20,15,Bash,which golangci-lint 2>&1 || go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest 2>&1,env_check,False,33,0
 generation-2026-02-25-07-08-59-0ya,slug,2026-02-25-07-08-59,a960d19a-bd69-42c3-9afa-26ef3f3c7b02,,21,16,TodoWrite,"{""todos"": [{""content"": ""Review existing project files (go.mod, existing pkg/ structure)"", ""status"": ""completed"", ""activeForm"": ""Reviewing existing project files""}, {""content"": ""Implement pkg/testutils",,False,160,0
-generation-2026-02-25-07-08-59-0ya,slug,2026-02-25-07-08-59,a960d19a-bd69-42c3-9afa-26ef3f3c7b02,,22,17,Bash,golangci-lint run ./pkg/testutils/... 2>&1,other,False,9,0
+generation-2026-02-25-07-08-59-0ya,slug,2026-02-25-07-08-59,a960d19a-bd69-42c3-9afa-26ef3f3c7b02,,22,17,Bash,golangci-lint run ./pkg/testutils/... 2>&1,lint,False,9,0
 generation-2026-02-25-07-08-59-0ya,slug,2026-02-25-07-08-59,a960d19a-bd69-42c3-9afa-26ef3f3c7b02,,24,18,TodoWrite,"{""todos"": [{""content"": ""Review existing project files (go.mod, existing pkg/ structure)"", ""status"": ""completed"", ""activeForm"": ""Reviewing existing project files""}, {""content"": ""Implement pkg/testutils",,False,160,0
 generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,2,1,TodoWrite,"{""todos"": [{""content"": ""Review provided context and plan approach"", ""status"": ""in_progress"", ""activeForm"": ""Reviewing provided context and planning approach""}, {""content"": ""Implement cmd/ts/main.go"", ",,False,160,0
 generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,5,2,Read,/var/folders/k1/vt4zxn952wv_8xjqtntq1ycr0000gn/T/go-unix-utils-worktrees/generation-2026-02-25-07-08-59-rt3/go.mod,,False,151,0
@@ -24,15 +24,15 @@ generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b
 generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,12,5,Write,/var/folders/k1/vt4zxn952wv_8xjqtntq1ycr0000gn/T/go-unix-utils-worktrees/generation-2026-02-25-07-08-59-rt3/cmd/ts/main.go,,False,152,0
 generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,13,6,TodoWrite,"{""todos"": [{""content"": ""Review provided context and plan approach"", ""status"": ""completed"", ""activeForm"": ""Reviewing provided context and planning approach""}, {""content"": ""Implement cmd/ts/main.go"", ""s",,False,160,0
 generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,14,7,Bash,go build ./cmd/ts/ 2>&1,go_build,False,0,0
-generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,16,8,Bash,echo 'hello world' | go run ./cmd/ts 2>&1,echo,False,27,0
-generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,17,9,Bash,printf 'a\nb\nc\n' | go run ./cmd/ts -s 2>&1,other,False,32,0
-generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,18,10,Bash,"go run ./cmd/ts -z 2>&1; echo ""exit: $?""",go_other,False,89,0
-generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,19,11,Bash,"printf '' | go run ./cmd/ts 2>&1; echo ""exit: $?""",other,False,5,0
-generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,20,12,Bash,"go run ./cmd/ts -i -s 2>&1; echo ""exit: $?""",go_other,False,97,0
-generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,21,13,Bash,printf 'no timestamp here\n' | go run ./cmd/ts -r 2>&1,other,False,17,0
-generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,23,14,Bash,"printf '' | go run ./cmd/ts 2>&1; echo ""EXIT:$?""",other,False,5,0
-generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,25,15,Bash,"printf '' | go run ./cmd/ts; echo ""CODE=$?""",other,False,5,0
-generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,27,16,Bash,"printf '' | go run ./cmd/ts 2>/dev/null && echo ""SUCCESS"" || echo ""FAILED""",other,False,7,0
+generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,16,8,Bash,echo 'hello world' | go run ./cmd/ts 2>&1,binary_exercise,False,27,0
+generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,17,9,Bash,printf 'a\nb\nc\n' | go run ./cmd/ts -s 2>&1,binary_exercise,False,32,0
+generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,18,10,Bash,"go run ./cmd/ts -z 2>&1; echo ""exit: $?""",binary_run,False,89,0
+generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,19,11,Bash,"printf '' | go run ./cmd/ts 2>&1; echo ""exit: $?""",binary_exercise,False,5,0
+generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,20,12,Bash,"go run ./cmd/ts -i -s 2>&1; echo ""exit: $?""",binary_run,False,97,0
+generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,21,13,Bash,printf 'no timestamp here\n' | go run ./cmd/ts -r 2>&1,binary_exercise,False,17,0
+generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,23,14,Bash,"printf '' | go run ./cmd/ts 2>&1; echo ""EXIT:$?""",binary_exercise,False,5,0
+generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,25,15,Bash,"printf '' | go run ./cmd/ts; echo ""CODE=$?""",binary_exercise,False,5,0
+generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,27,16,Bash,"printf '' | go run ./cmd/ts 2>/dev/null && echo ""SUCCESS"" || echo ""FAILED""",binary_exercise,False,7,0
 generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,29,17,Read,/var/folders/k1/vt4zxn952wv_8xjqtntq1ycr0000gn/T/go-unix-utils-worktrees/generation-2026-02-25-07-08-59-rt3/cmd/ts/main.go,,False,1052,0
 generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,31,18,Edit,/var/folders/k1/vt4zxn952wv_8xjqtntq1ycr0000gn/T/go-unix-utils-worktrees/generation-2026-02-25-07-08-59-rt3/cmd/ts/main.go,,False,162,0
 generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,32,19,Edit,/var/folders/k1/vt4zxn952wv_8xjqtntq1ycr0000gn/T/go-unix-utils-worktrees/generation-2026-02-25-07-08-59-rt3/cmd/ts/main.go,,False,162,0
@@ -40,27 +40,27 @@ generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b
 generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,35,21,Edit,/var/folders/k1/vt4zxn952wv_8xjqtntq1ycr0000gn/T/go-unix-utils-worktrees/generation-2026-02-25-07-08-59-rt3/cmd/ts/main.go,,False,162,0
 generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,37,22,Bash,go build ./cmd/ts/ 2>&1,go_build,False,0,0
 generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,38,23,Bash,go vet ./cmd/ts/ 2>&1,go_vet,False,0,0
-generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,39,24,Bash,"which golangci-lint 2>&1 || echo ""NOT FOUND""",other,False,33,0
-generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,40,25,Bash,golangci-lint run ./cmd/ts/... 2>&1,other,True,1098,0
+generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,39,24,Bash,"which golangci-lint 2>&1 || echo ""NOT FOUND""",env_check,False,33,0
+generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,40,25,Bash,golangci-lint run ./cmd/ts/... 2>&1,lint,True,1098,0
 generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,42,26,Edit,/var/folders/k1/vt4zxn952wv_8xjqtntq1ycr0000gn/T/go-unix-utils-worktrees/generation-2026-02-25-07-08-59-rt3/cmd/ts/main.go,,False,162,0
 generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,43,27,Edit,/var/folders/k1/vt4zxn952wv_8xjqtntq1ycr0000gn/T/go-unix-utils-worktrees/generation-2026-02-25-07-08-59-rt3/cmd/ts/main.go,,False,162,0
-generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,44,28,Bash,golangci-lint run ./cmd/ts/... 2>&1,other,False,9,0
-generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,46,29,Bash,echo 'hello world' | go run ./cmd/ts 2>&1,echo,False,27,0
-generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,47,30,Bash,printf 'a\nb\nc\n' | go run ./cmd/ts -s 2>&1,other,False,32,0
-generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,48,31,Bash,"go run ./cmd/ts -z </dev/null 2>&1; echo ""EXIT=$?""",go_other,False,88,0
-generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,49,32,Bash,"go run ./cmd/ts </dev/null 2>&1 && echo ""EXIT=0"" || echo ""EXIT=FAIL""",go_other,False,6,0
-generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,50,33,Bash,"go run ./cmd/ts -i -s </dev/null 2>&1; echo ""EXIT=$?""",go_other,False,96,0
-generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,51,34,Bash,printf 'no timestamp here\n' | go run ./cmd/ts -r 2>&1,other,False,17,0
+generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,44,28,Bash,golangci-lint run ./cmd/ts/... 2>&1,lint,False,9,0
+generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,46,29,Bash,echo 'hello world' | go run ./cmd/ts 2>&1,binary_exercise,False,27,0
+generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,47,30,Bash,printf 'a\nb\nc\n' | go run ./cmd/ts -s 2>&1,binary_exercise,False,32,0
+generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,48,31,Bash,"go run ./cmd/ts -z </dev/null 2>&1; echo ""EXIT=$?""",binary_run,False,88,0
+generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,49,32,Bash,"go run ./cmd/ts </dev/null 2>&1 && echo ""EXIT=0"" || echo ""EXIT=FAIL""",binary_run,False,6,0
+generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,50,33,Bash,"go run ./cmd/ts -i -s </dev/null 2>&1; echo ""EXIT=$?""",binary_run,False,96,0
+generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,51,34,Bash,printf 'no timestamp here\n' | go run ./cmd/ts -r 2>&1,binary_exercise,False,17,0
 generation-2026-02-25-07-08-59-rt3,slug,2026-02-25-07-08-59,1d62ce98-2e02-4a75-b0d3-3740033df4a4,,53,35,TodoWrite,"{""todos"": [{""content"": ""Review provided context and plan approach"", ""status"": ""completed"", ""activeForm"": ""Reviewing provided context and planning approach""}, {""content"": ""Implement cmd/ts/main.go"", ""s",,False,160,0
 generation-2026-02-25-07-46-59-g96,slug,2026-02-25-07-46-59,6ad0342b-f566-466d-a272-c57cffc3c4de,,2,1,TodoWrite,"{""todos"": [{""content"": ""Review provided context and plan approach"", ""status"": ""in_progress"", ""activeForm"": ""Reviewing provided context and planning approach""}, {""content"": ""Implement cmd/ts/ts_test.go",,False,160,0
 generation-2026-02-25-07-46-59-g96,slug,2026-02-25-07-46-59,6ad0342b-f566-466d-a272-c57cffc3c4de,,5,2,TodoWrite,"{""todos"": [{""content"": ""Review provided context and plan approach"", ""status"": ""completed"", ""activeForm"": ""Reviewing provided context and planning approach""}, {""content"": ""Implement cmd/ts/ts_test.go w",,False,160,0
 generation-2026-02-25-07-46-59-g96,slug,2026-02-25-07-46-59,6ad0342b-f566-466d-a272-c57cffc3c4de,,6,3,Write,/var/folders/k1/vt4zxn952wv_8xjqtntq1ycr0000gn/T/go-unix-utils-worktrees/generation-2026-02-25-07-46-59-g96/cmd/ts/ts_test.go,,False,155,0
 generation-2026-02-25-07-46-59-g96,slug,2026-02-25-07-46-59,6ad0342b-f566-466d-a272-c57cffc3c4de,,7,4,TodoWrite,"{""todos"": [{""content"": ""Review provided context and plan approach"", ""status"": ""completed"", ""activeForm"": ""Reviewing provided context and planning approach""}, {""content"": ""Implement cmd/ts/ts_test.go w",,False,160,0
 generation-2026-02-25-07-46-59-g96,slug,2026-02-25-07-46-59,6ad0342b-f566-466d-a272-c57cffc3c4de,,9,5,Bash,go vet ./cmd/ts/... 2>&1,go_vet,False,0,0
-generation-2026-02-25-07-46-59-g96,slug,2026-02-25-07-46-59,6ad0342b-f566-466d-a272-c57cffc3c4de,,11,6,Bash,"which ts 2>&1 || echo ""ts not found on PATH""",other,False,20,0
+generation-2026-02-25-07-46-59-g96,slug,2026-02-25-07-46-59,6ad0342b-f566-466d-a272-c57cffc3c4de,,11,6,Bash,"which ts 2>&1 || echo ""ts not found on PATH""",env_check,False,20,0
 generation-2026-02-25-07-46-59-g96,slug,2026-02-25-07-46-59,6ad0342b-f566-466d-a272-c57cffc3c4de,,13,7,Bash,go test -v ./cmd/ts/... 2>&1,go_test,False,238,0
-generation-2026-02-25-07-46-59-g96,slug,2026-02-25-07-46-59,6ad0342b-f566-466d-a272-c57cffc3c4de,,15,8,Bash,"which golangci-lint 2>&1 || echo ""golangci-lint not found""",other,False,33,0
-generation-2026-02-25-07-46-59-g96,slug,2026-02-25-07-46-59,6ad0342b-f566-466d-a272-c57cffc3c4de,,16,9,Bash,golangci-lint run ./cmd/ts/... 2>&1,other,False,9,0
+generation-2026-02-25-07-46-59-g96,slug,2026-02-25-07-46-59,6ad0342b-f566-466d-a272-c57cffc3c4de,,15,8,Bash,"which golangci-lint 2>&1 || echo ""golangci-lint not found""",env_check,False,33,0
+generation-2026-02-25-07-46-59-g96,slug,2026-02-25-07-46-59,6ad0342b-f566-466d-a272-c57cffc3c4de,,16,9,Bash,golangci-lint run ./cmd/ts/... 2>&1,lint,False,9,0
 generation-2026-02-25-07-46-59-g96,slug,2026-02-25-07-46-59,6ad0342b-f566-466d-a272-c57cffc3c4de,,18,10,TodoWrite,"{""todos"": [{""content"": ""Review provided context and plan approach"", ""status"": ""completed"", ""activeForm"": ""Reviewing provided context and planning approach""}, {""content"": ""Implement cmd/ts/ts_test.go w",,False,160,0
 generation-2026-02-25-07-46-59-g96,slug,2026-02-25-07-46-59,6ad0342b-f566-466d-a272-c57cffc3c4de,,20,11,Grep,"Name:\s+""",,False,616,0
 generation-2026-02-25-07-46-59-g96,slug,2026-02-25-07-46-59,6ad0342b-f566-466d-a272-c57cffc3c4de,,22,12,Grep,Normalize:,,False,796,0
@@ -73,31 +73,31 @@ generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-b
 generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,8,5,Write,/var/folders/k1/vt4zxn952wv_8xjqtntq1ycr0000gn/T/go-unix-utils-worktrees/generation-2026-02-25-07-46-59-m1j/cmd/cat/main.go,,False,153,0
 generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,10,6,TodoWrite,"{""todos"": [{""content"": ""Review provided context and plan approach"", ""status"": ""completed"", ""activeForm"": ""Reviewing provided context and planning approach""}, {""content"": ""Implement cmd/cat/main.go"", """,,False,160,0
 generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,11,7,Bash,go build ./cmd/cat/...,go_build,False,0,0
-generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,13,8,Bash,printf 'hello\nworld\n' | go run ./cmd/cat | xxd,other,False,63,0
-generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,14,9,Bash,printf 'hello\nworld\n' | xxd,other,False,63,0
-generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,16,10,Bash,printf 'alpha\n\nbeta\n' | go run ./cmd/cat -n,other,False,32,0
-generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,18,11,Bash,printf 'first\n\n\nsecond\n' | go run ./cmd/cat -b,other,False,28,0
-generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,20,12,Bash,printf 'a\n\n\n\nb\n' | go run ./cmd/cat -s,other,False,4,0
-generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,22,13,Bash,printf '\x01\x09\x1b\x7f\x80\xff' | go run ./cmd/cat -v | xxd,other,False,66,0
-generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,24,14,Bash,printf '\x01\thello\n' | go run ./cmd/cat -A,other,False,10,0
-generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,26,15,Bash,"printf 'real content\n' > /tmp/cat_test_real.txt && go run ./cmd/cat /tmp/cat_test_nonexistent.txt /tmp/cat_test_real.txt; echo ""exit code: $?""",other,False,101,0
-generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,29,16,Bash,"printf '' | go run ./cmd/cat; echo ""exit: $?""",other,False,5,0
-generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,30,17,Bash,"printf 'test\n' | go run ./cmd/cat -u; echo ""exit: $?""",other,False,10,0
-generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,31,18,Bash,printf 'a\n\n\n\nb\n' | go run ./cmd/cat -ns,other,False,25,0
-generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,33,19,Bash,printf 'a\n\n\n\nb\n' | go run ./cmd/cat -ns | xxd,other,False,129,0
-generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,35,20,Bash,printf 'line one\nline two\n' | go run ./cmd/cat -E,other,False,19,0
-generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,36,21,Bash,printf 'col1\tcol2\n' | go run ./cmd/cat -T,other,False,10,0
-generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,37,22,Bash,printf '\x01hello\n' | go run ./cmd/cat -e,other,False,8,0
-generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,38,23,Bash,printf '\x01\thello\n' | go run ./cmd/cat -t,other,False,9,0
-generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,39,24,Bash,"go run ./cmd/cat -z 2>&1; echo ""exit: $?""",go_other,False,48,0
+generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,13,8,Bash,printf 'hello\nworld\n' | go run ./cmd/cat | xxd,binary_exercise,False,63,0
+generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,14,9,Bash,printf 'hello\nworld\n' | xxd,binary_exercise,False,63,0
+generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,16,10,Bash,printf 'alpha\n\nbeta\n' | go run ./cmd/cat -n,binary_exercise,False,32,0
+generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,18,11,Bash,printf 'first\n\n\nsecond\n' | go run ./cmd/cat -b,binary_exercise,False,28,0
+generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,20,12,Bash,printf 'a\n\n\n\nb\n' | go run ./cmd/cat -s,binary_exercise,False,4,0
+generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,22,13,Bash,printf '\x01\x09\x1b\x7f\x80\xff' | go run ./cmd/cat -v | xxd,binary_exercise,False,66,0
+generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,24,14,Bash,printf '\x01\thello\n' | go run ./cmd/cat -A,binary_exercise,False,10,0
+generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,26,15,Bash,"printf 'real content\n' > /tmp/cat_test_real.txt && go run ./cmd/cat /tmp/cat_test_nonexistent.txt /tmp/cat_test_real.txt; echo ""exit code: $?""",binary_exercise,False,101,0
+generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,29,16,Bash,"printf '' | go run ./cmd/cat; echo ""exit: $?""",binary_exercise,False,5,0
+generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,30,17,Bash,"printf 'test\n' | go run ./cmd/cat -u; echo ""exit: $?""",binary_exercise,False,10,0
+generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,31,18,Bash,printf 'a\n\n\n\nb\n' | go run ./cmd/cat -ns,binary_exercise,False,25,0
+generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,33,19,Bash,printf 'a\n\n\n\nb\n' | go run ./cmd/cat -ns | xxd,binary_exercise,False,129,0
+generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,35,20,Bash,printf 'line one\nline two\n' | go run ./cmd/cat -E,binary_exercise,False,19,0
+generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,36,21,Bash,printf 'col1\tcol2\n' | go run ./cmd/cat -T,binary_exercise,False,10,0
+generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,37,22,Bash,printf '\x01hello\n' | go run ./cmd/cat -e,binary_exercise,False,8,0
+generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,38,23,Bash,printf '\x01\thello\n' | go run ./cmd/cat -t,binary_exercise,False,9,0
+generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,39,24,Bash,"go run ./cmd/cat -z 2>&1; echo ""exit: $?""",binary_run,False,48,0
 generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,40,25,Bash,"# Test squeeze across file boundaries (R3.2)
-printf 'a\n\n' > /tmp/cat_f1.txt && printf '\nb\n' > /tmp/cat_f2.txt && go run ./cmd/cat -s /tmp/cat_f1.txt /tmp/cat_f2.txt | xxd",other,False,56,0
+printf 'a\n\n' > /tmp/cat_f1.txt && printf '\nb\n' > /tmp/cat_f2.txt && go run ./cmd/cat -s /tmp/cat_f1.txt /tmp/cat_f2.txt | xxd",binary_exercise,False,56,0
 generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,43,26,Bash,"# Test binary passthrough (R1.4) - generate all 256 byte values
 python3 -c ""import sys; sys.stdout.buffer.write(bytes(range(256)))"" | go run ./cmd/cat | wc -c",other,False,47,0
 generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,44,27,Bash,"# Test binary passthrough with Go helper
-printf '\x00\x01\x02\x03\xff\xfe\xfd' > /tmp/cat_bin_test.bin && go run ./cmd/cat /tmp/cat_bin_test.bin | xxd",other,False,58,0
+printf '\x00\x01\x02\x03\xff\xfe\xfd' > /tmp/cat_bin_test.bin && go run ./cmd/cat /tmp/cat_bin_test.bin | xxd",binary_exercise,False,58,0
 generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,46,28,Bash,"# Test line numbering does not reset per file (R2.1)
-printf 'a\nb\n' > /tmp/cat_n1.txt && printf 'c\nd\n' > /tmp/cat_n2.txt && go run ./cmd/cat -n /tmp/cat_n1.txt /tmp/cat_n2.txt",other,False,35,0
+printf 'a\nb\n' > /tmp/cat_n1.txt && printf 'c\nd\n' > /tmp/cat_n2.txt && go run ./cmd/cat -n /tmp/cat_n1.txt /tmp/cat_n2.txt",binary_exercise,False,35,0
 generation-2026-02-25-07-46-59-m1j,slug,2026-02-25-07-46-59,db497b30-e06d-4899-bad8-0347d99e464d,,48,29,TodoWrite,"{""todos"": [{""content"": ""Review provided context and plan approach"", ""status"": ""completed"", ""activeForm"": ""Reviewing provided context and planning approach""}, {""content"": ""Implement cmd/cat/main.go"", """,,False,160,0
 generation-2026-02-25-07-46-59-7x7,slug,2026-02-25-07-46-59,880030d1-66bc-4405-adce-23d496396eb9,,2,1,TodoWrite,"{""todos"": [{""content"": ""Review provided context and plan approach"", ""status"": ""in_progress"", ""activeForm"": ""Reviewing provided context and planning approach""}, {""content"": ""Implement cmd/cat/cat_test.",,False,160,0
 generation-2026-02-25-07-46-59-7x7,slug,2026-02-25-07-46-59,880030d1-66bc-4405-adce-23d496396eb9,,5,2,TodoWrite,"{""todos"": [{""content"": ""Review provided context and plan approach"", ""status"": ""completed"", ""activeForm"": ""Reviewing provided context and planning approach""}, {""content"": ""Implement cmd/cat/cat_test.go",,False,160,0
@@ -119,48 +119,48 @@ generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,12,7,TodoWrite,"{""todos"": [{""content"": ""Review provided context and plan approach"", ""status"": ""completed"", ""activeForm"": ""Reviewing provided context and planning approach""}, {""content"": ""Implement cmd/wc/main.go"", ""s",,False,160,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,13,8,Bash,go build ./cmd/wc/ 2>&1,go_build,False,0,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,15,9,TodoWrite,"{""todos"": [{""content"": ""Review provided context and plan approach"", ""status"": ""completed"", ""activeForm"": ""Reviewing provided context and planning approach""}, {""content"": ""Implement cmd/wc/main.go"", ""s",,False,160,0
-generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,16,10,Bash,printf 'foo\nbar baz\n' | go run ./cmd/wc/,other,False,8,0
+generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,16,10,Bash,printf 'foo\nbar baz\n' | go run ./cmd/wc/,binary_exercise,False,8,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,17,11,Bash,"# AC3: Combined flags in different order should produce counts in fixed order (lines, words, bytes)
-printf 'foo\nbar baz\n' | go run ./cmd/wc/ -w -l -c",other,False,8,0
+printf 'foo\nbar baz\n' | go run ./cmd/wc/ -w -l -c",binary_exercise,False,8,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,18,12,Bash,"# AC4: Two-file input with per-file and total line
-cd /tmp && mkdir -p wc_test_ac4 && printf 'hello\nworld\n' > /tmp/wc_test_ac4/file1.txt && printf 'foo bar baz\n' > /tmp/wc_test_ac4/file2.txt && go ",other,True,200,0
+cd /tmp && mkdir -p wc_test_ac4 && printf 'hello\nworld\n' > /tmp/wc_test_ac4/file1.txt && printf 'foo bar baz\n' > /tmp/wc_test_ac4/file2.txt && go ",env_inspect,True,200,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,19,13,Bash,"# AC4: Two-file input
-printf 'hello\nworld\n' > /tmp/wc_file1.txt && printf 'foo bar baz\n' > /tmp/wc_file2.txt && go run ./cmd/wc/ /tmp/wc_file1.txt /tmp/wc_file2.txt",other,False,68,0
+printf 'hello\nworld\n' > /tmp/wc_file1.txt && printf 'foo bar baz\n' > /tmp/wc_file2.txt && go run ./cmd/wc/ /tmp/wc_file1.txt /tmp/wc_file2.txt",binary_exercise,False,68,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,20,14,Bash,"# AC5: --total=never and --total=only
-echo ""--- total=never ---"" && go run ./cmd/wc/ --total=never /tmp/wc_file1.txt /tmp/wc_file2.txt && echo ""--- total=only ---"" && go run ./cmd/wc/ --total=only /tm",other,False,107,0
+echo ""--- total=never ---"" && go run ./cmd/wc/ --total=never /tmp/wc_file1.txt /tmp/wc_file2.txt && echo ""--- total=only ---"" && go run ./cmd/wc/ --total=only /tm",binary_exercise,False,107,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,21,15,Bash,"# AC6: Non-existent file with other valid files
-go run ./cmd/wc/ /tmp/nonexistent_wc_file.txt /tmp/wc_file1.txt 2>&1; echo ""exit=$?""",other,False,160,0
+go run ./cmd/wc/ /tmp/nonexistent_wc_file.txt /tmp/wc_file1.txt 2>&1; echo ""exit=$?""",binary_run,False,160,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,23,16,Read,/var/folders/k1/vt4zxn952wv_8xjqtntq1ycr0000gn/T/go-unix-utils-worktrees/generation-2026-02-25-07-46-59-ybr/cmd/wc/main.go,,False,1334,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,25,17,Edit,/var/folders/k1/vt4zxn952wv_8xjqtntq1ycr0000gn/T/go-unix-utils-worktrees/generation-2026-02-25-07-46-59-ybr/cmd/wc/main.go,,False,162,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,27,18,Bash,go build ./cmd/wc/ 2>&1,go_build,False,0,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,28,19,Bash,"# AC2: default mode
-printf 'foo\nbar baz\n' | go run ./cmd/wc/",other,False,8,0
+printf 'foo\nbar baz\n' | go run ./cmd/wc/",binary_exercise,False,8,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,29,20,Bash,"# AC3: combined flags in different order
-printf 'foo\nbar baz\n' | go run ./cmd/wc/ -w -l -c",other,False,8,0
+printf 'foo\nbar baz\n' | go run ./cmd/wc/ -w -l -c",binary_exercise,False,8,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,30,21,Bash,"# AC4: Two-file input with total
-go run ./cmd/wc/ /tmp/wc_file1.txt /tmp/wc_file2.txt",other,False,68,0
+go run ./cmd/wc/ /tmp/wc_file1.txt /tmp/wc_file2.txt",binary_run,False,68,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,31,22,Bash,"# AC5: --total=never and --total=only
-echo ""--- total=never ---"" && go run ./cmd/wc/ --total=never /tmp/wc_file1.txt /tmp/wc_file2.txt && echo ""--- total=only ---"" && go run ./cmd/wc/ --total=only /tm",other,False,107,0
+echo ""--- total=never ---"" && go run ./cmd/wc/ --total=never /tmp/wc_file1.txt /tmp/wc_file2.txt && echo ""--- total=only ---"" && go run ./cmd/wc/ --total=only /tm",binary_exercise,False,107,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,32,23,Bash,"# AC6: Non-existent file with valid files
-go run ./cmd/wc/ /tmp/nonexistent_wc_file.txt /tmp/wc_file1.txt 2>&1; echo ""exit=$?""",other,False,122,0
+go run ./cmd/wc/ /tmp/nonexistent_wc_file.txt /tmp/wc_file1.txt 2>&1; echo ""exit=$?""",binary_run,False,122,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,34,24,Bash,"# AC7: Empty stdin
-printf '' | go run ./cmd/wc/",other,False,5,0
+printf '' | go run ./cmd/wc/",binary_exercise,False,5,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,36,25,TodoWrite,"{""todos"": [{""content"": ""Review provided context and plan approach"", ""status"": ""completed"", ""activeForm"": ""Reviewing provided context and planning approach""}, {""content"": ""Implement cmd/wc/main.go"", ""s",,False,160,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,37,26,Bash,go vet ./cmd/wc/ 2>&1,go_vet,False,0,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,39,27,Bash,"# Additional verification: -l only
 printf 'one\ntwo\nthree\n' | go run ./cmd/wc/ -l && echo ""---"" && \
 # -w only
-printf 'hello world\ngoodbye  cruel   world\n' | go run ./cmd/wc/ -w && echo ""---"" && \",other,False,26,0
+printf 'hello world\ngoodbye  cruel   world\n' | go run ./cmd/wc/ -w && echo ""---"" && \",binary_exercise,False,26,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,40,28,Bash,"# Check -L max line length against the expected value: ""a much longer line here"" is 22 chars
-printf 'a much longer line here' | wc -c",other,False,2,0
+printf 'a much longer line here' | wc -c",binary_exercise,False,2,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,42,29,Bash,"# Check actual length of each line
-printf 'short' | wc -c && printf 'a much longer line here' | wc -c && printf 'med' | wc -c",other,False,6,0
+printf 'short' | wc -c && printf 'a much longer line here' | wc -c && printf 'med' | wc -c",binary_exercise,False,6,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,44,30,Bash,"# Check what gwc reports for -L
-which gwc 2>/dev/null && printf 'short\na much longer line here\nmed\n' | gwc -L || echo ""gwc not available""",other,False,17,0
+which gwc 2>/dev/null && printf 'short\na much longer line here\nmed\n' | gwc -L || echo ""gwc not available""",env_check,False,17,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,46,31,Bash,"# Verify ""-"" as stdin filename argument
 printf 'stdin content\n' | go run ./cmd/wc/ - && echo ""---"" && \
 # Verify --files0-from
-printf '/tmp/wc_file1.txt\0/tmp/wc_file2.txt\0' > /tmp/wc_files0.txt && ",other,False,81,0
+printf '/tmp/wc_file1.txt\0/tmp/wc_file2.txt\0' > /tmp/wc_files0.txt && ",binary_exercise,False,81,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,48,32,Edit,/var/folders/k1/vt4zxn952wv_8xjqtntq1ycr0000gn/T/go-unix-utils-worktrees/generation-2026-02-25-07-46-59-ybr/cmd/wc/main.go,,False,162,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,50,33,Edit,/var/folders/k1/vt4zxn952wv_8xjqtntq1ycr0000gn/T/go-unix-utils-worktrees/generation-2026-02-25-07-46-59-ybr/cmd/wc/main.go,,False,162,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,52,34,Bash,go build ./cmd/wc/ 2>&1 && go vet ./cmd/wc/ 2>&1,go_build,False,0,0
@@ -168,9 +168,9 @@ generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9
 echo ""=== AC2: default mode ==="" && \
 printf 'foo\nbar baz\n' | go run ./cmd/wc/ && \
 echo ""=== AC3: combined flags fixed order ==="" && \
-printf 'foo\nbar baz\n' ",other,False,340,0
+printf 'foo\nbar baz\n' ",binary_exercise,False,340,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,54,36,Bash,"# AC6: Non-existent file error handling
-go run ./cmd/wc/ /tmp/nonexistent_wc_file.txt /tmp/wc_file1.txt 2>/tmp/wc_stderr.txt; echo ""exit=$?""; echo ""=== stderr ==="" && cat /tmp/wc_stderr.txt && echo ""=",other,False,152,0
+go run ./cmd/wc/ /tmp/nonexistent_wc_file.txt /tmp/wc_file1.txt 2>/tmp/wc_stderr.txt; echo ""exit=$?""; echo ""=== stderr ==="" && cat /tmp/wc_stderr.txt && echo ""=",binary_run,False,152,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,56,37,Bash,"go build -o /tmp/wc_test_bin ./cmd/wc/ && /tmp/wc_test_bin /tmp/nonexistent_wc_file.txt /tmp/wc_file1.txt 2>/tmp/wc_stderr.txt; echo ""exit=$?""; echo ""--- stderr ---""; cat /tmp/wc_stderr.txt",go_build,False,123,0
 generation-2026-02-25-07-46-59-ybr,slug,2026-02-25-07-46-59,70f4e02b-d9c0-410d-9d9f-34bb303622bd,,58,38,Bash,"# Check with two successful files
 /tmp/wc_test_bin /tmp/wc_file1.txt /tmp/wc_file2.txt",other,False,68,0
@@ -192,12 +192,12 @@ generation-2026-02-25-07-46-59-aa1,slug,2026-02-25-07-46-59,4436eefb-e1ea-49fc-9
 generation-2026-02-25-07-46-59-aa1,slug,2026-02-25-07-46-59,4436eefb-e1ea-49fc-984f-7fffcc0bc527,,10,6,Bash,go build ./cmd/sponge/,go_build,False,0,0
 generation-2026-02-25-07-46-59-aa1,slug,2026-02-25-07-46-59,4436eefb-e1ea-49fc-984f-7fffcc0bc527,,12,7,TodoWrite,"{""todos"": [{""content"": ""Review required reading and plan implementation"", ""status"": ""completed"", ""activeForm"": ""Reviewing required reading and planning implementation""}, {""content"": ""Implement cmd/spo",,False,160,0
 generation-2026-02-25-07-46-59-aa1,slug,2026-02-25-07-46-59,4436eefb-e1ea-49fc-984f-7fffcc0bc527,,13,8,Bash,seq 1 100 | go run ./cmd/sponge /tmp/sponge-test-out.txt && wc -l /tmp/sponge-test-out.txt && head -3 /tmp/sponge-test-out.txt && tail -3 /tmp/sponge-test-out.txt,other,False,44,0
-generation-2026-02-25-07-46-59-aa1,slug,2026-02-25-07-46-59,4436eefb-e1ea-49fc-984f-7fffcc0bc527,,15,9,Bash,printf 'hello' | go run ./cmd/sponge,other,False,5,0
-generation-2026-02-25-07-46-59-aa1,slug,2026-02-25-07-46-59,4436eefb-e1ea-49fc-984f-7fffcc0bc527,,17,10,Bash,printf 'original line\n' > /tmp/sponge-append-test.txt && printf 'appended line\n' | go run ./cmd/sponge -a /tmp/sponge-append-test.txt && cat /tmp/sponge-append-test.txt,other,False,27,0
-generation-2026-02-25-07-46-59-aa1,slug,2026-02-25-07-46-59,4436eefb-e1ea-49fc-984f-7fffcc0bc527,,19,11,Bash,printf 'old content\n' > /tmp/sponge-mode-test.txt && chmod 0640 /tmp/sponge-mode-test.txt && stat -c '%a' /tmp/sponge-mode-test.txt && printf 'new content\n' | go run ./cmd/sponge /tmp/sponge-mode-te,other,False,19,0
+generation-2026-02-25-07-46-59-aa1,slug,2026-02-25-07-46-59,4436eefb-e1ea-49fc-984f-7fffcc0bc527,,15,9,Bash,printf 'hello' | go run ./cmd/sponge,binary_exercise,False,5,0
+generation-2026-02-25-07-46-59-aa1,slug,2026-02-25-07-46-59,4436eefb-e1ea-49fc-984f-7fffcc0bc527,,17,10,Bash,printf 'original line\n' > /tmp/sponge-append-test.txt && printf 'appended line\n' | go run ./cmd/sponge -a /tmp/sponge-append-test.txt && cat /tmp/sponge-append-test.txt,binary_exercise,False,27,0
+generation-2026-02-25-07-46-59-aa1,slug,2026-02-25-07-46-59,4436eefb-e1ea-49fc-984f-7fffcc0bc527,,19,11,Bash,printf 'old content\n' > /tmp/sponge-mode-test.txt && chmod 0640 /tmp/sponge-mode-test.txt && stat -c '%a' /tmp/sponge-mode-test.txt && printf 'new content\n' | go run ./cmd/sponge /tmp/sponge-mode-te,binary_exercise,False,19,0
 generation-2026-02-25-07-46-59-aa1,slug,2026-02-25-07-46-59,4436eefb-e1ea-49fc-984f-7fffcc0bc527,,21,12,Bash,"# Check that no sponge temp files persist after normal operation
-ls /tmp/sponge* 2>/dev/null | grep -v sponge-test-out | grep -v sponge-append-test | grep -v sponge-mode-test || echo ""No stray sponge ",other,False,32,0
-generation-2026-02-25-07-46-59-aa1,slug,2026-02-25-07-46-59,4436eefb-e1ea-49fc-984f-7fffcc0bc527,,23,13,Bash,"printf 'data\n' | go run ./cmd/sponge /nonexistent/path/file.txt 2>&1; echo ""exit code: $?""",other,False,126,0
+ls /tmp/sponge* 2>/dev/null | grep -v sponge-test-out | grep -v sponge-append-test | grep -v sponge-mode-test || echo ""No stray sponge ",ls,False,32,0
+generation-2026-02-25-07-46-59-aa1,slug,2026-02-25-07-46-59,4436eefb-e1ea-49fc-984f-7fffcc0bc527,,23,13,Bash,"printf 'data\n' | go run ./cmd/sponge /nonexistent/path/file.txt 2>&1; echo ""exit code: $?""",binary_exercise,False,126,0
 generation-2026-02-25-07-46-59-aa1,slug,2026-02-25-07-46-59,4436eefb-e1ea-49fc-984f-7fffcc0bc527,,25,14,Bash,rm -f /tmp/sponge-test-out.txt /tmp/sponge-append-test.txt /tmp/sponge-mode-test.txt,rm,False,0,0
 generation-2026-02-25-07-46-59-aa1,slug,2026-02-25-07-46-59,4436eefb-e1ea-49fc-984f-7fffcc0bc527,,26,15,TodoWrite,"{""todos"": [{""content"": ""Review required reading and plan implementation"", ""status"": ""completed"", ""activeForm"": ""Reviewing required reading and planning implementation""}, {""content"": ""Implement cmd/spo",,False,160,0
 generation-2026-02-25-07-46-59-m0c,slug,2026-02-25-07-46-59,f4c02187-d0b6-4588-a0a6-375e68cc60a9,,2,1,TodoWrite,"{""todos"": [{""content"": ""Review provided context and plan approach"", ""status"": ""in_progress"", ""activeForm"": ""Reviewing provided context and planning approach""}, {""content"": ""Implement cmd/sponge/sponge",,False,160,0
@@ -207,8 +207,8 @@ generation-2026-02-25-07-46-59-m0c,slug,2026-02-25-07-46-59,f4c02187-d0b6-4588-a
 generation-2026-02-25-07-46-59-m0c,slug,2026-02-25-07-46-59,f4c02187-d0b6-4588-a0a6-375e68cc60a9,,9,5,Bash,go build ./cmd/sponge/...,go_build,False,0,0
 generation-2026-02-25-07-46-59-m0c,slug,2026-02-25-07-46-59,f4c02187-d0b6-4588-a0a6-375e68cc60a9,,10,6,Bash,go vet ./cmd/sponge/...,go_vet,False,0,0
 generation-2026-02-25-07-46-59-m0c,slug,2026-02-25-07-46-59,f4c02187-d0b6-4588-a0a6-375e68cc60a9,,12,7,Bash,go test -c -o /dev/null ./cmd/sponge/...,go_test,False,0,0
-generation-2026-02-25-07-46-59-m0c,slug,2026-02-25-07-46-59,f4c02187-d0b6-4588-a0a6-375e68cc60a9,,14,8,Bash,"which golangci-lint 2>/dev/null && golangci-lint run ./cmd/sponge/... || echo ""golangci-lint not found, skipping""",other,False,1553,0
-generation-2026-02-25-07-46-59-m0c,slug,2026-02-25-07-46-59,f4c02187-d0b6-4588-a0a6-375e68cc60a9,,17,9,Bash,"golangci-lint run ./cmd/sponge/sponge_test.go 2>&1 | grep -v ""main.go"" || echo ""No lint issues in test file""",other,False,9,0
+generation-2026-02-25-07-46-59-m0c,slug,2026-02-25-07-46-59,f4c02187-d0b6-4588-a0a6-375e68cc60a9,,14,8,Bash,"which golangci-lint 2>/dev/null && golangci-lint run ./cmd/sponge/... || echo ""golangci-lint not found, skipping""",env_check,False,1553,0
+generation-2026-02-25-07-46-59-m0c,slug,2026-02-25-07-46-59,f4c02187-d0b6-4588-a0a6-375e68cc60a9,,17,9,Bash,"golangci-lint run ./cmd/sponge/sponge_test.go 2>&1 | grep -v ""main.go"" || echo ""No lint issues in test file""",lint,False,9,0
 generation-2026-02-25-07-46-59-m0c,slug,2026-02-25-07-46-59,f4c02187-d0b6-4588-a0a6-375e68cc60a9,,19,10,Bash,go test -v ./cmd/sponge/... -count=1 2>&1 | head -80,go_test,False,495,0
 generation-2026-02-25-07-46-59-m0c,slug,2026-02-25-07-46-59,f4c02187-d0b6-4588-a0a6-375e68cc60a9,,21,11,Bash,"go test -v -run ""TestSpongeDifferentialPassthrough"" ./cmd/sponge/... -count=1 2>&1",go_test,False,281,0
 generation-2026-02-25-07-46-59-m0c,slug,2026-02-25-07-46-59,f4c02187-d0b6-4588-a0a6-375e68cc60a9,,23,12,TodoWrite,"{""todos"": [{""content"": ""Review provided context and plan approach"", ""status"": ""completed"", ""activeForm"": ""Reviewing provided context and planning approach""}, {""content"": ""Implement cmd/sponge/sponge_t",,False,160,0
@@ -236,15 +236,15 @@ generation-2026-02-25-08-44-27-tyr,slug,2026-02-25-08-44-27,67b50bca-6f65-43a4-b
 generation-2026-02-25-08-44-27-tyr,slug,2026-02-25-08-44-27,67b50bca-6f65-43a4-b4fa-2734b1eda8ae,,27,21,Bash,go build ./pkg/sys/,go_build,False,0,0
 generation-2026-02-25-08-44-27-tyr,slug,2026-02-25-08-44-27,67b50bca-6f65-43a4-b4fa-2734b1eda8ae,,28,22,Bash,go test ./pkg/sys/ -v,go_test,False,774,0
 generation-2026-02-25-08-44-27-tyr,slug,2026-02-25-08-44-27,67b50bca-6f65-43a4-b4fa-2734b1eda8ae,,30,23,Bash,go build ./...,go_build,False,0,0
-generation-2026-02-25-08-44-27-tyr,slug,2026-02-25-08-44-27,67b50bca-6f65-43a4-b4fa-2734b1eda8ae,,31,24,Bash,GOOS=darwin GOARCH=arm64 go build ./pkg/sys/,other,False,0,0
-generation-2026-02-25-08-44-27-tyr,slug,2026-02-25-08-44-27,67b50bca-6f65-43a4-b4fa-2734b1eda8ae,,32,25,Bash,GOOS=linux GOARCH=amd64 go build ./pkg/sys/,other,False,0,0
+generation-2026-02-25-08-44-27-tyr,slug,2026-02-25-08-44-27,67b50bca-6f65-43a4-b4fa-2734b1eda8ae,,31,24,Bash,GOOS=darwin GOARCH=arm64 go build ./pkg/sys/,go_build,False,0,0
+generation-2026-02-25-08-44-27-tyr,slug,2026-02-25-08-44-27,67b50bca-6f65-43a4-b4fa-2734b1eda8ae,,32,25,Bash,GOOS=linux GOARCH=amd64 go build ./pkg/sys/,go_build,False,0,0
 generation-2026-02-25-08-44-27-tyr,slug,2026-02-25-08-44-27,67b50bca-6f65-43a4-b4fa-2734b1eda8ae,,34,26,TodoWrite,"{""todos"": [{""content"": ""Review go.mod and existing pkg/sys files"", ""status"": ""completed"", ""activeForm"": ""Reviewing go.mod and existing pkg/sys files""}, {""content"": ""Create pkg/sys/terminal.go (Termina",,False,160,0
-generation-2026-02-25-08-44-27-tyr,slug,2026-02-25-08-44-27,67b50bca-6f65-43a4-b4fa-2734b1eda8ae,,35,27,Bash,"which golangci-lint 2>/dev/null && golangci-lint run ./pkg/sys/ || echo ""golangci-lint not found, checking go vet instead""",other,False,342,0
+generation-2026-02-25-08-44-27-tyr,slug,2026-02-25-08-44-27,67b50bca-6f65-43a4-b4fa-2734b1eda8ae,,35,27,Bash,"which golangci-lint 2>/dev/null && golangci-lint run ./pkg/sys/ || echo ""golangci-lint not found, checking go vet instead""",env_check,False,342,0
 generation-2026-02-25-08-44-27-tyr,slug,2026-02-25-08-44-27,67b50bca-6f65-43a4-b4fa-2734b1eda8ae,,38,28,Read,/var/folders/k1/vt4zxn952wv_8xjqtntq1ycr0000gn/T/go-unix-utils-worktrees/generation-2026-02-25-08-44-27-tyr/pkg/sys/sys_test.go,,False,456,0
 generation-2026-02-25-08-44-27-tyr,slug,2026-02-25-08-44-27,67b50bca-6f65-43a4-b4fa-2734b1eda8ae,,39,29,Edit,/var/folders/k1/vt4zxn952wv_8xjqtntq1ycr0000gn/T/go-unix-utils-worktrees/generation-2026-02-25-08-44-27-tyr/pkg/sys/sys_test.go,,False,167,0
-generation-2026-02-25-08-44-27-tyr,slug,2026-02-25-08-44-27,67b50bca-6f65-43a4-b4fa-2734b1eda8ae,,40,30,Bash,golangci-lint run ./pkg/sys/,other,False,9,0
+generation-2026-02-25-08-44-27-tyr,slug,2026-02-25-08-44-27,67b50bca-6f65-43a4-b4fa-2734b1eda8ae,,40,30,Bash,golangci-lint run ./pkg/sys/,lint,False,9,0
 generation-2026-02-25-08-44-27-tyr,slug,2026-02-25-08-44-27,67b50bca-6f65-43a4-b4fa-2734b1eda8ae,,42,31,Bash,go test ./...,go_test,False,363,0
-generation-2026-02-25-08-44-27-tyr,slug,2026-02-25-08-44-27,67b50bca-6f65-43a4-b4fa-2734b1eda8ae,,44,32,Bash,golangci-lint run ./...,other,True,4746,0
+generation-2026-02-25-08-44-27-tyr,slug,2026-02-25-08-44-27,67b50bca-6f65-43a4-b4fa-2734b1eda8ae,,44,32,Bash,golangci-lint run ./...,lint,True,4746,0
 generation-2026-02-25-08-44-27-tyr,slug,2026-02-25-08-44-27,67b50bca-6f65-43a4-b4fa-2734b1eda8ae,,46,33,TodoWrite,"{""todos"": [{""content"": ""Review go.mod and existing pkg/sys files"", ""status"": ""completed"", ""activeForm"": ""Reviewing go.mod and existing pkg/sys files""}, {""content"": ""Create pkg/sys/terminal.go (Termina",,False,160,0
 generation-2026-02-25-08-44-27-6qn,slug,2026-02-25-08-44-27,05532645-8295-4f34-aa1c-4e59efe54fa8,,2,1,TodoWrite,"{""todos"": [{""content"": ""Review existing code and plan approach"", ""status"": ""in_progress"", ""activeForm"": ""Reviewing existing code and planning approach""}, {""content"": ""Implement pkg/format/columns.go (",,False,160,0
 generation-2026-02-25-08-44-27-6qn,slug,2026-02-25-08-44-27,05532645-8295-4f34-aa1c-4e59efe54fa8,,4,2,Bash,"ls /var/folders/k1/vt4zxn952wv_8xjqtntq1ycr0000gn/T/go-unix-utils-worktrees/generation-2026-02-25-08-44-27-6qn/pkg/format/ 2>/dev/null || echo ""directory does not exist""",ls,False,24,0
@@ -269,10 +269,10 @@ generation-2026-02-25-08-44-27-6qn,slug,2026-02-25-08-44-27,05532645-8295-4f34-a
 generation-2026-02-25-08-44-27-6qn,slug,2026-02-25-08-44-27,05532645-8295-4f34-aa1c-4e59efe54fa8,,32,21,TodoWrite,"{""todos"": [{""content"": ""Review existing code and plan approach"", ""status"": ""completed"", ""activeForm"": ""Reviewing existing code and planning approach""}, {""content"": ""Implement pkg/format/columns.go (R1",,False,160,0
 generation-2026-02-25-08-44-27-6qn,slug,2026-02-25-08-44-27,05532645-8295-4f34-aa1c-4e59efe54fa8,,33,22,Bash,go vet ./pkg/format/... 2>&1,go_vet,False,0,0
 generation-2026-02-25-08-44-27-6qn,slug,2026-02-25-08-44-27,05532645-8295-4f34-aa1c-4e59efe54fa8,,34,23,Bash,go build ./pkg/format/... 2>&1,go_build,False,0,0
-generation-2026-02-25-08-44-27-6qn,slug,2026-02-25-08-44-27,05532645-8295-4f34-aa1c-4e59efe54fa8,,36,24,Bash,"which golangci-lint 2>/dev/null || echo ""not installed""",other,False,33,0
-generation-2026-02-25-08-44-27-6qn,slug,2026-02-25-08-44-27,05532645-8295-4f34-aa1c-4e59efe54fa8,,37,25,Bash,golangci-lint run ./pkg/format/... 2>&1,other,True,552,0
+generation-2026-02-25-08-44-27-6qn,slug,2026-02-25-08-44-27,05532645-8295-4f34-aa1c-4e59efe54fa8,,36,24,Bash,"which golangci-lint 2>/dev/null || echo ""not installed""",env_check,False,33,0
+generation-2026-02-25-08-44-27-6qn,slug,2026-02-25-08-44-27,05532645-8295-4f34-aa1c-4e59efe54fa8,,37,25,Bash,golangci-lint run ./pkg/format/... 2>&1,lint,True,552,0
 generation-2026-02-25-08-44-27-6qn,slug,2026-02-25-08-44-27,05532645-8295-4f34-aa1c-4e59efe54fa8,,39,26,Edit,/var/folders/k1/vt4zxn952wv_8xjqtntq1ycr0000gn/T/go-unix-utils-worktrees/generation-2026-02-25-08-44-27-6qn/pkg/format/color_test.go,,False,172,0
-generation-2026-02-25-08-44-27-6qn,slug,2026-02-25-08-44-27,05532645-8295-4f34-aa1c-4e59efe54fa8,,40,27,Bash,golangci-lint run ./pkg/format/... 2>&1,other,False,9,0
+generation-2026-02-25-08-44-27-6qn,slug,2026-02-25-08-44-27,05532645-8295-4f34-aa1c-4e59efe54fa8,,40,27,Bash,golangci-lint run ./pkg/format/... 2>&1,lint,False,9,0
 generation-2026-02-25-08-44-27-6qn,slug,2026-02-25-08-44-27,05532645-8295-4f34-aa1c-4e59efe54fa8,,42,28,Bash,go test ./pkg/format/... -v 2>&1,go_test,False,4551,0
 generation-2026-02-25-08-44-27-6qn,slug,2026-02-25-08-44-27,05532645-8295-4f34-aa1c-4e59efe54fa8,,44,29,TodoWrite,"{""todos"": [{""content"": ""Review existing code and plan approach"", ""status"": ""completed"", ""activeForm"": ""Reviewing existing code and planning approach""}, {""content"": ""Implement pkg/format/columns.go (R1",,False,160,0
 generation-2026-02-26-21-54-45-tol,slug,2026-02-26-21-54-45,8361d910-c473-4003-aada-1c9cc5a758e9,,3,1,Read,/var/folders/k1/vt4zxn952wv_8xjqtntq1ycr0000gn/T/go-unix-utils-worktrees/generation-2026-02-26-21-54-45-tol/pkg/testutils/difftest.go,,True,169,0
@@ -362,13 +362,13 @@ generation-2026-02-28-11-56-07-5w2,slug,2026-02-28-11-56-07,fa920512-b38b-4398-a
 89,numeric,2026-03-02-08-43-36,369e9c99-d09c-4bcc-8912-e8e3588777e1,,10,7,TodoWrite,"{""todos"": [{""content"": ""Read required PRD and spec documents"", ""status"": ""completed"", ""activeForm"": ""Reading required PRD and spec documents""}, {""content"": ""Implement pkg/format/align.go with R1 colum",,False,160,0
 89,numeric,2026-03-02-08-43-36,369e9c99-d09c-4bcc-8912-e8e3588777e1,,12,8,Bash,go build ./pkg/format/,go_build,False,0,0
 89,numeric,2026-03-02-08-43-36,369e9c99-d09c-4bcc-8912-e8e3588777e1,,13,9,Bash,go vet ./pkg/format/,go_vet,False,0,0
-89,numeric,2026-03-02-08-43-36,369e9c99-d09c-4bcc-8912-e8e3588777e1,,14,10,Bash,"which golangci-lint 2>/dev/null && golangci-lint run ./pkg/format/ || echo ""golangci-lint not found, skipping""",other,False,43,0
+89,numeric,2026-03-02-08-43-36,369e9c99-d09c-4bcc-8912-e8e3588777e1,,14,10,Bash,"which golangci-lint 2>/dev/null && golangci-lint run ./pkg/format/ || echo ""golangci-lint not found, skipping""",env_check,False,43,0
 89,numeric,2026-03-02-08-43-36,369e9c99-d09c-4bcc-8912-e8e3588777e1,,16,11,Bash,"go test ./pkg/format/ -v -count=1 2>&1 || echo ""(no test files is expected — tests are not in scope for this task)""",go_test,False,69,0
 89,numeric,2026-03-02-08-43-36,369e9c99-d09c-4bcc-8912-e8e3588777e1,,17,12,TodoWrite,"{""todos"": [{""content"": ""Read required PRD and spec documents"", ""status"": ""completed"", ""activeForm"": ""Reading required PRD and spec documents""}, {""content"": ""Implement pkg/format/align.go with R1 colum",,False,160,0
 90,numeric,2026-03-02-08-43-36,56d4d091-4f59-48ae-9241-88e71e65067c,,2,1,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/90/docs/specs/product-requirements/prd002-sys.yaml,,False,8217,0
 90,numeric,2026-03-02-08-43-36,56d4d091-4f59-48ae-9241-88e71e65067c,,5,2,Write,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/90/pkg/sys/terminal.go,,False,125,0
 90,numeric,2026-03-02-08-43-36,56d4d091-4f59-48ae-9241-88e71e65067c,,7,3,Bash,go build ./pkg/sys/,go_build,False,0,0
-90,numeric,2026-03-02-08-43-36,56d4d091-4f59-48ae-9241-88e71e65067c,,9,4,Bash,GOOS=darwin GOARCH=arm64 go build ./pkg/sys/,other,False,0,0
+90,numeric,2026-03-02-08-43-36,56d4d091-4f59-48ae-9241-88e71e65067c,,9,4,Bash,GOOS=darwin GOARCH=arm64 go build ./pkg/sys/,go_build,False,0,0
 91,numeric,2026-03-02-08-43-36,7b30a63d-c030-4034-a5d1-c65c1813eda0,,2,1,TodoWrite,"{""todos"": [{""content"": ""Read prd001-testutils.yaml for requirements R2-R5"", ""status"": ""in_progress"", ""activeForm"": ""Reading PRD requirements""}, {""content"": ""Create pkg/testutils/runner_test.go with te",,False,160,0
 91,numeric,2026-03-02-08-43-36,7b30a63d-c030-4034-a5d1-c65c1813eda0,,3,2,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/91/docs/specs/product-requirements/prd001-testutils.yaml,,False,12033,0
 91,numeric,2026-03-02-08-43-36,7b30a63d-c030-4034-a5d1-c65c1813eda0,,4,3,TodoWrite,"{""todos"": [{""content"": ""Read prd001-testutils.yaml for requirements R2-R5"", ""status"": ""completed"", ""activeForm"": ""Reading PRD requirements""}, {""content"": ""Create pkg/testutils/runner_test.go with test",,False,160,0
@@ -453,12 +453,12 @@ import (
 
 func main() {
 	fmt.Printf(""HumanSize(1536, bi",mkdir,True,632,0
-98,numeric,2026-03-02-10-55-24,402cfa1d-2bef-44ce-b198-92d20df4fac4,,29,23,Bash,cd /tmp/format-check && go mod tidy 2>&1 && go run main.go 2>&1,other,False,150,99
+98,numeric,2026-03-02-10-55-24,402cfa1d-2bef-44ce-b198-92d20df4fac4,,29,23,Bash,cd /tmp/format-check && go mod tidy 2>&1 && go run main.go 2>&1,env_inspect,False,150,99
 98,numeric,2026-03-02-10-55-24,402cfa1d-2bef-44ce-b198-92d20df4fac4,,32,24,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/98/pkg/format/size.go,,False,1926,0
 98,numeric,2026-03-02-10-55-24,402cfa1d-2bef-44ce-b198-92d20df4fac4,,33,25,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/98/pkg/format/size.go,,False,134,0
 98,numeric,2026-03-02-10-55-24,402cfa1d-2bef-44ce-b198-92d20df4fac4,,34,26,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/98/pkg/format/size.go,,False,134,0
 98,numeric,2026-03-02-10-55-24,402cfa1d-2bef-44ce-b198-92d20df4fac4,,35,27,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/98/pkg/format/size.go,,False,134,0
-98,numeric,2026-03-02-10-55-24,402cfa1d-2bef-44ce-b198-92d20df4fac4,,37,28,Bash,cd /tmp/format-check && go run main.go 2>&1,other,False,156,99
+98,numeric,2026-03-02-10-55-24,402cfa1d-2bef-44ce-b198-92d20df4fac4,,37,28,Bash,cd /tmp/format-check && go run main.go 2>&1,env_inspect,False,156,99
 98,numeric,2026-03-02-10-55-24,402cfa1d-2bef-44ce-b198-92d20df4fac4,,39,29,Bash,"go build ./pkg/format/... 2>&1 && echo ""BUILD OK""",go_build,False,8,0
 98,numeric,2026-03-02-10-55-24,402cfa1d-2bef-44ce-b198-92d20df4fac4,,40,30,Bash,"go vet ./pkg/format/... 2>&1 && echo ""VET OK""",go_vet,False,6,0
 98,numeric,2026-03-02-10-55-24,402cfa1d-2bef-44ce-b198-92d20df4fac4,,41,31,TodoWrite,"{""todos"": [{""content"": ""Read required PRD and spec documents"", ""status"": ""completed"", ""activeForm"": ""Reading required PRD and spec documents""}, {""content"": ""Implement pkg/format/size.go"", ""status"": ""c",,False,160,0
@@ -549,7 +549,7 @@ cat > ""$tmpdir/testprog/go.mod"" << 'E",other,True,420,0
 104,numeric,2026-03-02-10-55-24,55d946ae-dfe8-486f-8a89-44582e2a8d3b,,15,12,Bash,"/tmp/version-test-bin --bogus 2>&1; echo ""exit: $?""",other,False,39,0
 104,numeric,2026-03-02-10-55-24,55d946ae-dfe8-486f-8a89-44582e2a8d3b,,17,13,Bash,"go build -ldflags ""-X main.version=v0.20260302.0"" -o /tmp/version-test-bin ./cmd/version/ && /tmp/version-test-bin; echo ""exit: $?""",go_build,False,21,0
 104,numeric,2026-03-02-10-55-24,55d946ae-dfe8-486f-8a89-44582e2a8d3b,,18,14,Bash,go vet ./cmd/version/,go_vet,False,0,0
-104,numeric,2026-03-02-10-55-24,55d946ae-dfe8-486f-8a89-44582e2a8d3b,,19,15,Bash,"which golangci-lint 2>/dev/null && golangci-lint run ./cmd/version/ || echo ""golangci-lint not installed, skipping (go vet passed)""",other,False,43,0
+104,numeric,2026-03-02-10-55-24,55d946ae-dfe8-486f-8a89-44582e2a8d3b,,19,15,Bash,"which golangci-lint 2>/dev/null && golangci-lint run ./cmd/version/ || echo ""golangci-lint not installed, skipping (go vet passed)""",env_check,False,43,0
 104,numeric,2026-03-02-10-55-24,55d946ae-dfe8-486f-8a89-44582e2a8d3b,,21,16,Bash,rm -f /tmp/version-test-bin,rm,False,0,0
 104,numeric,2026-03-02-10-55-24,55d946ae-dfe8-486f-8a89-44582e2a8d3b,,22,17,TodoWrite,"{""todos"": [{""content"": ""Read required PRD and use case files"", ""status"": ""completed"", ""activeForm"": ""Reading required PRD and use case files""}, {""content"": ""Implement cmd/version/main.go per prd011-ma",,False,160,0
 105,numeric,2026-03-02-10-55-24,51c1bdc4-3982-4ec7-82b7-bc8d63e68421,,2,1,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/105/docs/specs/product-requirements/prd011-magefiles.yaml,,False,8292,0
@@ -568,11 +568,11 @@ cat > ""$tmpdir/testprog/go.mod"" << 'E",other,True,420,0
 115,numeric,2026-03-02-10-55-24,99be3374-9d46-4b9e-9096-dd7e107a70c8,,14,10,Bash,go build ./cmd/wc/,go_build,False,0,0
 115,numeric,2026-03-02-10-55-24,99be3374-9d46-4b9e-9096-dd7e107a70c8,,15,11,Bash,go vet ./cmd/wc/,go_vet,False,0,0
 115,numeric,2026-03-02-10-55-24,99be3374-9d46-4b9e-9096-dd7e107a70c8,,16,12,TodoWrite,"{""todos"": [{""content"": ""Review PRD and use case for wc"", ""status"": ""completed"", ""activeForm"": ""Reviewing wc PRD and use case""}, {""content"": ""Implement cmd/wc/main.go"", ""status"": ""completed"", ""activeFo",,False,160,0
-115,numeric,2026-03-02-10-55-24,99be3374-9d46-4b9e-9096-dd7e107a70c8,,18,13,Bash,echo 'hello world' | go run ./cmd/wc/,echo,False,6,0
-115,numeric,2026-03-02-10-55-24,99be3374-9d46-4b9e-9096-dd7e107a70c8,,19,14,Bash,"go run ./cmd/wc/ /nonexistent 2>&1; echo ""exit code: $?""",go_other,False,70,0
-115,numeric,2026-03-02-10-55-24,99be3374-9d46-4b9e-9096-dd7e107a70c8,,20,15,Bash,printf 'foo\nbar baz\n' | go run ./cmd/wc/,other,False,6,0
-115,numeric,2026-03-02-10-55-24,99be3374-9d46-4b9e-9096-dd7e107a70c8,,22,16,Bash,"printf '' | go run ./cmd/wc/ && echo ""---"" && printf 'foo\nbar baz\n' | go run ./cmd/wc/ -l && echo ""---"" && printf 'foo\nbar baz\n' | go run ./cmd/wc/ -w && echo ""---"" && printf 'foo\nbar baz\n' | go",other,False,38,0
-115,numeric,2026-03-02-10-55-24,99be3374-9d46-4b9e-9096-dd7e107a70c8,,23,17,Bash,"printf 'file1 content\n' > /tmp/wc_test1.txt && printf 'file2 has more content here\n' > /tmp/wc_test2.txt && go run ./cmd/wc/ /tmp/wc_test1.txt /tmp/wc_test2.txt && echo ""---"" && go run ./cmd/wc/ /tm",other,False,212,0
+115,numeric,2026-03-02-10-55-24,99be3374-9d46-4b9e-9096-dd7e107a70c8,,18,13,Bash,echo 'hello world' | go run ./cmd/wc/,binary_exercise,False,6,0
+115,numeric,2026-03-02-10-55-24,99be3374-9d46-4b9e-9096-dd7e107a70c8,,19,14,Bash,"go run ./cmd/wc/ /nonexistent 2>&1; echo ""exit code: $?""",binary_run,False,70,0
+115,numeric,2026-03-02-10-55-24,99be3374-9d46-4b9e-9096-dd7e107a70c8,,20,15,Bash,printf 'foo\nbar baz\n' | go run ./cmd/wc/,binary_exercise,False,6,0
+115,numeric,2026-03-02-10-55-24,99be3374-9d46-4b9e-9096-dd7e107a70c8,,22,16,Bash,"printf '' | go run ./cmd/wc/ && echo ""---"" && printf 'foo\nbar baz\n' | go run ./cmd/wc/ -l && echo ""---"" && printf 'foo\nbar baz\n' | go run ./cmd/wc/ -w && echo ""---"" && printf 'foo\nbar baz\n' | go",binary_exercise,False,38,0
+115,numeric,2026-03-02-10-55-24,99be3374-9d46-4b9e-9096-dd7e107a70c8,,23,17,Bash,"printf 'file1 content\n' > /tmp/wc_test1.txt && printf 'file2 has more content here\n' > /tmp/wc_test2.txt && go run ./cmd/wc/ /tmp/wc_test1.txt /tmp/wc_test2.txt && echo ""---"" && go run ./cmd/wc/ /tm",binary_exercise,False,212,0
 115,numeric,2026-03-02-10-55-24,99be3374-9d46-4b9e-9096-dd7e107a70c8,,25,18,TodoWrite,"{""todos"": [{""content"": ""Review PRD and use case for wc"", ""status"": ""completed"", ""activeForm"": ""Reviewing wc PRD and use case""}, {""content"": ""Implement cmd/wc/main.go"", ""status"": ""completed"", ""activeFo",,False,160,0
 117,numeric,2026-03-02-10-55-24,4599da91-9db4-45ae-a570-33d5df5dd41e,,2,1,TodoWrite,"{""todos"": [{""content"": ""Read required PRD and test suite specs"", ""status"": ""in_progress"", ""activeForm"": ""Reading required PRD and test suite specs""}, {""content"": ""Plan test structure and cases"", ""stat",,False,160,0
 117,numeric,2026-03-02-10-55-24,4599da91-9db4-45ae-a570-33d5df5dd41e,,3,2,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/117/docs/specs/product-requirements/prd005-wc.yaml,,False,6336,0
@@ -584,9 +584,9 @@ cat > ""$tmpdir/testprog/go.mod"" << 'E",other,True,420,0
 117,numeric,2026-03-02-10-55-24,4599da91-9db4-45ae-a570-33d5df5dd41e,,11,8,TodoWrite,"{""todos"": [{""content"": ""Read required PRD and test suite specs"", ""status"": ""completed"", ""activeForm"": ""Reading required PRD and test suite specs""}, {""content"": ""Plan test structure and cases"", ""status",,False,160,0
 117,numeric,2026-03-02-10-55-24,4599da91-9db4-45ae-a570-33d5df5dd41e,,13,9,Bash,go test -c ./cmd/wc/ -o /dev/null 2>&1,go_test,False,0,0
 117,numeric,2026-03-02-10-55-24,4599da91-9db4-45ae-a570-33d5df5dd41e,,15,10,Bash,go test ./cmd/wc/ -v 2>&1,go_test,False,102,0
-117,numeric,2026-03-02-10-55-24,4599da91-9db4-45ae-a570-33d5df5dd41e,,17,11,Bash,which wc && wc --version 2>&1 | head -3,other,False,105,0
-117,numeric,2026-03-02-10-55-24,4599da91-9db4-45ae-a570-33d5df5dd41e,,18,12,Bash,which gwc 2>&1 || (apt list --installed 2>/dev/null | grep coreutils) || (dnf list installed coreutils 2>/dev/null | head -3),other,False,0,0
-117,numeric,2026-03-02-10-55-24,4599da91-9db4-45ae-a570-33d5df5dd41e,,19,13,Bash,which apt-get dnf brew 2>&1; ls /usr/bin/wc /usr/local/bin/wc /usr/bin/gwc 2>&1,other,True,222,0
+117,numeric,2026-03-02-10-55-24,4599da91-9db4-45ae-a570-33d5df5dd41e,,17,11,Bash,which wc && wc --version 2>&1 | head -3,env_check,False,105,0
+117,numeric,2026-03-02-10-55-24,4599da91-9db4-45ae-a570-33d5df5dd41e,,18,12,Bash,which gwc 2>&1 || (apt list --installed 2>/dev/null | grep coreutils) || (dnf list installed coreutils 2>/dev/null | head -3),env_check,False,0,0
+117,numeric,2026-03-02-10-55-24,4599da91-9db4-45ae-a570-33d5df5dd41e,,19,13,Bash,which apt-get dnf brew 2>&1; ls /usr/bin/wc /usr/local/bin/wc /usr/bin/gwc 2>&1,env_check,True,222,0
 117,numeric,2026-03-02-10-55-24,4599da91-9db4-45ae-a570-33d5df5dd41e,,20,14,Bash,apk --version 2>&1 && apk add --no-cache coreutils 2>&1 | tail -5,other,False,86,0
 117,numeric,2026-03-02-10-55-24,4599da91-9db4-45ae-a570-33d5df5dd41e,,21,15,Bash,sudo apk add --no-cache coreutils 2>&1 | tail -5,other,False,42,0
 117,numeric,2026-03-02-10-55-24,4599da91-9db4-45ae-a570-33d5df5dd41e,,23,16,Bash,go vet ./cmd/wc/ 2>&1,go_vet,False,0,0
@@ -610,7 +610,7 @@ printf 'test\n' | /tmp/test-cat -u
 echo ""exit: $?""
 # Test unknown flag
 /tmp/test-cat --unknown 2>&1
-echo ""exit: $?""",other,False,387,0
+echo ""exit: $?""",setup,False,387,0
 118,numeric,2026-03-02-10-55-24,3f0be86a-d807-483d-8aee-2f0218879a9d,,22,15,Bash,rm -f /tmp/test-cat,rm,False,0,0
 118,numeric,2026-03-02-10-55-24,3f0be86a-d807-483d-8aee-2f0218879a9d,,23,16,TodoWrite,"{""todos"": [{""content"": ""Read required PRD, use case, and test suite docs"", ""status"": ""completed"", ""activeForm"": ""Reading required documentation""}, {""content"": ""Plan implementation approach based on PR",,False,160,0
 120,numeric,2026-03-02-10-55-24,10d5f7be-ed0a-49c8-82cf-011d07f02858,,3,2,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/120/docs/specs/test-suites/test-rel01.1.yaml,,False,7914,0
@@ -650,7 +650,7 @@ echo ""exit: $?""",other,False,387,0
 122,numeric,2026-03-02-10-55-24,0c5e0c7b-820f-41f4-bffe-6ff0c2b25f45,,14,11,TodoWrite,"{""todos"": [{""content"": ""Read required PRD, use case, and test suite docs"", ""status"": ""completed"", ""activeForm"": ""Reading required documentation""}, {""content"": ""Read cmd/cat/main.go for reference patte",,False,160,0
 122,numeric,2026-03-02-10-55-24,0c5e0c7b-820f-41f4-bffe-6ff0c2b25f45,,16,12,Bash,go build ./cmd/sponge/,go_build,False,0,0
 122,numeric,2026-03-02-10-55-24,0c5e0c7b-820f-41f4-bffe-6ff0c2b25f45,,18,13,Bash,"go build -o /tmp/sponge-test-bin ./cmd/sponge/ && echo ""--- AC2: soak-before-write ---"" && echo -e ""line1\nline2\nline3"" > /tmp/sponge-test-data.txt && cat /tmp/sponge-test-data.txt | /tmp/sponge-test",go_build,False,337,0
-122,numeric,2026-03-02-10-55-24,0c5e0c7b-820f-41f4-bffe-6ff0c2b25f45,,20,14,Bash,"echo ""old content"" > /tmp/sponge-perm-test.txt && chmod 0640 /tmp/sponge-perm-test.txt && ls -la /tmp/sponge-perm-test.txt && echo ""new content"" | /tmp/sponge-test-bin /tmp/sponge-perm-test.txt && ls ",echo,False,177,0
+122,numeric,2026-03-02-10-55-24,0c5e0c7b-820f-41f4-bffe-6ff0c2b25f45,,20,14,Bash,"echo ""old content"" > /tmp/sponge-perm-test.txt && chmod 0640 /tmp/sponge-perm-test.txt && ls -la /tmp/sponge-perm-test.txt && echo ""new content"" | /tmp/sponge-test-bin /tmp/sponge-perm-test.txt && ls ",setup,False,177,0
 122,numeric,2026-03-02-10-55-24,0c5e0c7b-820f-41f4-bffe-6ff0c2b25f45,,22,15,Bash,go vet ./cmd/sponge/,go_vet,False,0,0
 122,numeric,2026-03-02-10-55-24,0c5e0c7b-820f-41f4-bffe-6ff0c2b25f45,,23,16,Bash,"rm /tmp/sponge-test-bin /tmp/sponge-test-data.txt /tmp/sponge-append-test.txt /tmp/sponge-empty.txt /tmp/sponge-perm-test.txt 2>/dev/null; echo ""cleaned up""",rm,False,10,0
 122,numeric,2026-03-02-10-55-24,0c5e0c7b-820f-41f4-bffe-6ff0c2b25f45,,24,17,TodoWrite,"{""todos"": [{""content"": ""Read required PRD, use case, and test suite docs"", ""status"": ""completed"", ""activeForm"": ""Reading required documentation""}, {""content"": ""Read cmd/cat/main.go for reference patte",,False,160,0
@@ -730,7 +730,7 @@ echo ""exit: $?""",other,False,387,0
 126,numeric,2026-03-02-10-55-24,06a6dad7-588e-4321-87aa-0af726b7dedc,,8,7,Read,/var/folders/dl/cbns6zkx7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/126/docs/specs/use-cases/rel01.3-uc001-du.yaml,,True,138,0
 126,numeric,2026-03-02-10-55-24,06a6dad7-588e-4321-87aa-0af726b7dedc,,9,8,Bash,ls -la /var/folders/dl/cbns6zkx7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/126/docs/specs/,ls,True,244,0
 126,numeric,2026-03-02-10-55-24,06a6dad7-588e-4321-87aa-0af726b7dedc,,10,9,Bash,ls -la /var/folders/dl/cbns6zkx7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/126/,ls,True,222,0
-126,numeric,2026-03-02-10-55-24,06a6dad7-588e-4321-87aa-0af726b7dedc,,11,10,Bash,pwd && ls -la,other,False,0,0
+126,numeric,2026-03-02-10-55-24,06a6dad7-588e-4321-87aa-0af726b7dedc,,11,10,Bash,pwd && ls -la,env_inspect,False,0,0
 126,numeric,2026-03-02-10-55-24,06a6dad7-588e-4321-87aa-0af726b7dedc,,12,11,Bash,"find /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/126/docs -type f -name ""*.yaml"" 2>/dev/null",find,False,0,0
 126,numeric,2026-03-02-10-55-24,06a6dad7-588e-4321-87aa-0af726b7dedc,,13,12,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/126/docs/specs/product-requirements/prd009-du.yaml,,False,10280,0
 126,numeric,2026-03-02-10-55-24,06a6dad7-588e-4321-87aa-0af726b7dedc,,14,13,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/126/docs/specs/use-cases/rel01.3-uc001-du.yaml,,False,4840,0
@@ -743,7 +743,7 @@ echo ""exit: $?""",other,False,387,0
 126,numeric,2026-03-02-10-55-24,06a6dad7-588e-4321-87aa-0af726b7dedc,,22,19,Bash,go build ./cmd/du/,go_build,False,40,0
 126,numeric,2026-03-02-10-55-24,06a6dad7-588e-4321-87aa-0af726b7dedc,,24,20,TodoWrite,"{""todos"": [{""content"": ""Create cmd/du/main.go with directory traversal, flags, and error handling"", ""status"": ""completed"", ""activeForm"": ""Creating cmd/du/main.go""}, {""content"": ""Verify compilation wit",,False,160,0
 126,numeric,2026-03-02-10-55-24,06a6dad7-588e-4321-87aa-0af726b7dedc,,25,21,Bash,"go build -o /tmp/du-test-bin ./cmd/du/ && mkdir -p /tmp/du-fixture/sub1/sub2 && echo ""hello world"" > /tmp/du-fixture/file1.txt && echo ""test content here"" > /tmp/du-fixture/sub1/file2.txt && echo ""dee",go_build,False,901,0
-126,numeric,2026-03-02-10-55-24,06a6dad7-588e-4321-87aa-0af726b7dedc,,26,22,Bash,"echo ""=== Error: nonexistent path ==="" && /tmp/du-test-bin /tmp/nonexistent-path-12345 2>&1; echo ""exit code: $?"" && echo ""=== Error: permission denied ==="" && chmod 000 /tmp/du-fixture/sub1/sub2 && /",echo,False,498,0
+126,numeric,2026-03-02-10-55-24,06a6dad7-588e-4321-87aa-0af726b7dedc,,26,22,Bash,"echo ""=== Error: nonexistent path ==="" && /tmp/du-test-bin /tmp/nonexistent-path-12345 2>&1; echo ""exit code: $?"" && echo ""=== Error: permission denied ==="" && chmod 000 /tmp/du-fixture/sub1/sub2 && /",setup,False,498,0
 126,numeric,2026-03-02-10-55-24,06a6dad7-588e-4321-87aa-0af726b7dedc,,29,23,Bash,go vet ./cmd/du/,go_vet,False,0,0
 126,numeric,2026-03-02-10-55-24,06a6dad7-588e-4321-87aa-0af726b7dedc,,30,24,Bash,rm -rf /tmp/du-fixture /tmp/du-test-bin,rm,False,0,0
 126,numeric,2026-03-02-10-55-24,06a6dad7-588e-4321-87aa-0af726b7dedc,,31,25,TodoWrite,"{""todos"": [{""content"": ""Create cmd/du/main.go with directory traversal, flags, and error handling"", ""status"": ""completed"", ""activeForm"": ""Creating cmd/du/main.go""}, {""content"": ""Verify compilation wit",,False,160,0
@@ -760,7 +760,7 @@ echo ""exit: $?""",other,False,387,0
 127,numeric,2026-03-02-10-55-24,3fb5a884-dc99-4051-9107-9e94fb33ddd1,,17,11,Bash,go doc golang.org/x/sys/unix Major 2>&1 | head -20,go_other,False,43,0
 127,numeric,2026-03-02-10-55-24,3fb5a884-dc99-4051-9107-9e94fb33ddd1,,18,12,Bash,go mod download golang.org/x/sys 2>&1 && go doc golang.org/x/sys/unix Major 2>&1 | head -10,go_mod,False,141,0
 127,numeric,2026-03-02-10-55-24,3fb5a884-dc99-4051-9107-9e94fb33ddd1,,20,13,Bash,go doc golang.org/x/sys/unix Minor 2>&1 | head -10,go_other,False,141,0
-127,numeric,2026-03-02-10-55-24,3fb5a884-dc99-4051-9107-9e94fb33ddd1,,21,14,Bash,GOOS=darwin go doc golang.org/x/sys/unix Major 2>&1 | head -10,other,False,142,0
+127,numeric,2026-03-02-10-55-24,3fb5a884-dc99-4051-9107-9e94fb33ddd1,,21,14,Bash,GOOS=darwin go doc golang.org/x/sys/unix Major 2>&1 | head -10,go_other,False,142,0
 127,numeric,2026-03-02-10-55-24,3fb5a884-dc99-4051-9107-9e94fb33ddd1,,24,15,TodoWrite,"{""todos"": [{""content"": ""Review existing code against task requirements R1-R4 and AC1-AC5"", ""status"": ""completed"", ""activeForm"": ""Reviewing existing code against requirements""}, {""content"": ""Add DevMaj",,False,160,0
 127,numeric,2026-03-02-10-55-24,3fb5a884-dc99-4051-9107-9e94fb33ddd1,,25,16,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/127/pkg/sys/stat.go,,False,132,0
 127,numeric,2026-03-02-10-55-24,3fb5a884-dc99-4051-9107-9e94fb33ddd1,,27,17,TodoWrite,"{""todos"": [{""content"": ""Review existing code against task requirements R1-R4 and AC1-AC5"", ""status"": ""completed"", ""activeForm"": ""Reviewing existing code against requirements""}, {""content"": ""Add DevMaj",,False,160,0
@@ -938,19 +938,19 @@ echo ""exit: $?""",other,False,387,0
 188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,15,11,TodoWrite,"{""todos"": [{""content"": ""Read required specs (PRD, use case, test suite)"", ""status"": ""completed"", ""activeForm"": ""Reading required specs""}, {""content"": ""Implement cmd/wc/main.go"", ""status"": ""completed"",",,False,160,0
 188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,17,12,Bash,go build -o bin/wc ./cmd/wc/ 2>&1,go_build,False,40,0
 188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,18,13,Bash,go vet ./cmd/wc/ 2>&1,go_vet,False,0,0
-188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,20,14,Bash,printf 'foo\nbar baz\nqux\n' | ./bin/wc 2>&1,other,False,23,0
-188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,21,15,Bash,printf 'hello\n' | ./bin/wc -l 2>&1,other,False,7,0
-188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,22,16,Bash,printf 'hello world\n' | ./bin/wc -w 2>&1,other,False,7,0
-188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,23,17,Bash,printf 'abc\n' | ./bin/wc -c 2>&1,other,False,7,0
-188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,24,18,Bash,printf 'hello\n' | ./bin/wc -m 2>&1,other,False,7,0
-188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,27,19,Bash,printf 'hello\nworld\n' > /tmp/wc_test1.txt && printf 'foo bar baz\n' > /tmp/wc_test2.txt && ./bin/wc /tmp/wc_test1.txt /tmp/wc_test2.txt 2>&1,other,False,68,0
-188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,28,20,Bash,printf 'stdin data here\n' | ./bin/wc 2>&1,other,False,23,0
-188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,29,21,Bash,printf '' | ./bin/wc 2>&1,other,False,23,0
-188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,30,22,Bash,printf 'short\na much longer line here\nmed\n' | ./bin/wc -L 2>&1,other,False,7,0
-188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,33,23,Bash,printf 'a much longer line here' | wc -c,other,False,2,0
-188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,36,24,Bash,printf 'one two\nthree\n' | ./bin/wc -w -l -c 2>&1,other,False,23,0
-188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,37,25,Bash,"./bin/wc /tmp/nonexistent_file.txt /tmp/wc_test1.txt 2>&1; echo ""exit: $?""",other,False,136,0
-188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,38,26,Bash,printf 'stdin content\n' | ./bin/wc - 2>&1,other,False,25,0
+188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,20,14,Bash,printf 'foo\nbar baz\nqux\n' | ./bin/wc 2>&1,binary_exercise,False,23,0
+188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,21,15,Bash,printf 'hello\n' | ./bin/wc -l 2>&1,binary_exercise,False,7,0
+188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,22,16,Bash,printf 'hello world\n' | ./bin/wc -w 2>&1,binary_exercise,False,7,0
+188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,23,17,Bash,printf 'abc\n' | ./bin/wc -c 2>&1,binary_exercise,False,7,0
+188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,24,18,Bash,printf 'hello\n' | ./bin/wc -m 2>&1,binary_exercise,False,7,0
+188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,27,19,Bash,printf 'hello\nworld\n' > /tmp/wc_test1.txt && printf 'foo bar baz\n' > /tmp/wc_test2.txt && ./bin/wc /tmp/wc_test1.txt /tmp/wc_test2.txt 2>&1,binary_exercise,False,68,0
+188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,28,20,Bash,printf 'stdin data here\n' | ./bin/wc 2>&1,binary_exercise,False,23,0
+188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,29,21,Bash,printf '' | ./bin/wc 2>&1,binary_exercise,False,23,0
+188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,30,22,Bash,printf 'short\na much longer line here\nmed\n' | ./bin/wc -L 2>&1,binary_exercise,False,7,0
+188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,33,23,Bash,printf 'a much longer line here' | wc -c,binary_exercise,False,2,0
+188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,36,24,Bash,printf 'one two\nthree\n' | ./bin/wc -w -l -c 2>&1,binary_exercise,False,23,0
+188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,37,25,Bash,"./bin/wc /tmp/nonexistent_file.txt /tmp/wc_test1.txt 2>&1; echo ""exit: $?""",binary_run,False,136,0
+188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,38,26,Bash,printf 'stdin content\n' | ./bin/wc - 2>&1,binary_exercise,False,25,0
 188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,41,27,Bash,rm -f /tmp/wc_test1.txt /tmp/wc_test2.txt,rm,False,0,0
 188,numeric,gh-168-generation-run-12,8a115c45-1bdc-4b94-a522-324914dd00d1,,42,28,TodoWrite,"{""todos"": [{""content"": ""Read required specs (PRD, use case, test suite)"", ""status"": ""completed"", ""activeForm"": ""Reading required specs""}, {""content"": ""Implement cmd/wc/main.go"", ""status"": ""completed"",",,False,160,0
 189,numeric,gh-168-generation-run-12,f7513335-6c80-4376-b5d5-42ab4a6e2bb1,,2,1,TodoWrite,"{""todos"": [{""content"": ""Read required docs not provided inline (prd005-wc, test-rel01.0)"", ""status"": ""in_progress"", ""activeForm"": ""Reading required documentation""}, {""content"": ""Create cmd/wc/wc_test.",,False,160,0
@@ -975,23 +975,23 @@ echo ""exit: $?""",other,False,387,0
 190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,12,8,Write,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/190/cmd/cat/main.go,,False,122,0
 190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,13,9,TodoWrite,"{""todos"": [{""content"": ""Read required PRD and specification documents"", ""status"": ""completed"", ""activeForm"": ""Reading required PRD and specification documents""}, {""content"": ""Implement cmd/cat/main.go",,False,160,0
 190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,15,10,Bash,go build -o bin/cat ./cmd/cat/,go_build,False,40,0
-190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,17,11,Bash,printf 'alpha\n\nbeta\n' | ./bin/cat -n | cat -A,other,False,38,0
-190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,18,12,Bash,printf 'first\n\n\nsecond\n' | ./bin/cat -b,other,False,28,0
-190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,19,13,Bash,printf 'a\n\n\n\nb\n' | ./bin/cat -s,other,False,4,0
-190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,20,14,Bash,printf '\x01\x09\x1b\x7f\x80\xff' | ./bin/cat -v | xxd,other,False,66,0
-190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,22,15,Bash,printf '\x01\thello\n' | ./bin/cat -A,other,False,10,0
-190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,23,16,Bash,printf 'line one\nline two\n' | ./bin/cat -E,other,False,19,0
-190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,24,17,Bash,printf 'col1\tcol2\tcol3\n' | ./bin/cat -T,other,False,16,0
-190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,25,18,Bash,printf 'a\n\n\n\nb\n' | ./bin/cat -n -s,other,False,25,0
-190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,28,19,Bash,printf 'a\n\n\n\nb\n' | ./bin/cat -n -s | xxd,other,False,129,0
-190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,29,20,Bash,"./bin/cat nonexistent.txt 2>&1; echo ""exit: $?""",other,False,55,0
-190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,31,21,Bash,"printf 'data\n' > /tmp/cat_test_real.txt && ./bin/cat nonexistent.txt /tmp/cat_test_real.txt 2>/tmp/cat_test_err.txt; echo ""exit: $?""; echo ""---stdout---""; echo ""---stderr---""; cat /tmp/cat_test_err.t",other,False,86,0
-190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,32,22,Bash,printf 'test\n' | ./bin/cat -u,other,False,4,0
-190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,33,23,Bash,printf 'from stdin\n' | ./bin/cat -,other,False,10,0
-190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,35,24,Bash,printf 'hello\n' | ./bin/cat -vET | xxd,other,False,58,0
-190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,36,25,Bash,printf 'hello\n' | ./bin/cat --show-all | xxd,other,False,58,0
-190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,37,26,Bash,printf '\x01hello\n' | ./bin/cat -e,other,False,8,0
-190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,38,27,Bash,printf '\x01\thello\n' | ./bin/cat -t,other,False,9,0
+190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,17,11,Bash,printf 'alpha\n\nbeta\n' | ./bin/cat -n | cat -A,binary_exercise,False,38,0
+190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,18,12,Bash,printf 'first\n\n\nsecond\n' | ./bin/cat -b,binary_exercise,False,28,0
+190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,19,13,Bash,printf 'a\n\n\n\nb\n' | ./bin/cat -s,binary_exercise,False,4,0
+190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,20,14,Bash,printf '\x01\x09\x1b\x7f\x80\xff' | ./bin/cat -v | xxd,binary_exercise,False,66,0
+190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,22,15,Bash,printf '\x01\thello\n' | ./bin/cat -A,binary_exercise,False,10,0
+190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,23,16,Bash,printf 'line one\nline two\n' | ./bin/cat -E,binary_exercise,False,19,0
+190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,24,17,Bash,printf 'col1\tcol2\tcol3\n' | ./bin/cat -T,binary_exercise,False,16,0
+190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,25,18,Bash,printf 'a\n\n\n\nb\n' | ./bin/cat -n -s,binary_exercise,False,25,0
+190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,28,19,Bash,printf 'a\n\n\n\nb\n' | ./bin/cat -n -s | xxd,binary_exercise,False,129,0
+190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,29,20,Bash,"./bin/cat nonexistent.txt 2>&1; echo ""exit: $?""",binary_run,False,55,0
+190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,31,21,Bash,"printf 'data\n' > /tmp/cat_test_real.txt && ./bin/cat nonexistent.txt /tmp/cat_test_real.txt 2>/tmp/cat_test_err.txt; echo ""exit: $?""; echo ""---stdout---""; echo ""---stderr---""; cat /tmp/cat_test_err.t",binary_exercise,False,86,0
+190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,32,22,Bash,printf 'test\n' | ./bin/cat -u,binary_exercise,False,4,0
+190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,33,23,Bash,printf 'from stdin\n' | ./bin/cat -,binary_exercise,False,10,0
+190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,35,24,Bash,printf 'hello\n' | ./bin/cat -vET | xxd,binary_exercise,False,58,0
+190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,36,25,Bash,printf 'hello\n' | ./bin/cat --show-all | xxd,binary_exercise,False,58,0
+190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,37,26,Bash,printf '\x01hello\n' | ./bin/cat -e,binary_exercise,False,8,0
+190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,38,27,Bash,printf '\x01\thello\n' | ./bin/cat -t,binary_exercise,False,9,0
 190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,40,28,Bash,go build ./...,go_build,False,0,0
 190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,41,29,Bash,go vet ./...,go_vet,False,0,0
 190,numeric,gh-168-generation-run-12,52dc9268-38a9-408c-ad3e-30afddea9623,,42,30,Bash,go test ./...,go_test,False,315,0
@@ -1045,32 +1045,32 @@ echo ""exit: $?""",other,False,387,0
 194,numeric,gh-168-generation-run-12,b76c3fdc-4eec-4396-910f-0ab53d888509,,13,10,Write,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/194/cmd/sponge/main.go,,False,125,0
 194,numeric,gh-168-generation-run-12,b76c3fdc-4eec-4396-910f-0ab53d888509,,14,11,TodoWrite,"{""todos"": [{""content"": ""Read sponge PRD, use case, and test suite"", ""status"": ""completed"", ""activeForm"": ""Reading sponge PRD, use case, and test suite""}, {""content"": ""Implement cmd/sponge/main.go"", ""s",,False,160,0
 194,numeric,gh-168-generation-run-12,b76c3fdc-4eec-4396-910f-0ab53d888509,,16,12,Bash,go build -o bin/sponge ./cmd/sponge/,go_build,False,40,0
-194,numeric,gh-168-generation-run-12,b76c3fdc-4eec-4396-910f-0ab53d888509,,18,13,Bash,printf 'line1\nline2\nline3\n' | ./bin/sponge /tmp/sponge_test_out.txt && cat /tmp/sponge_test_out.txt && rm /tmp/sponge_test_out.txt,other,False,17,0
-194,numeric,gh-168-generation-run-12,b76c3fdc-4eec-4396-910f-0ab53d888509,,19,14,Bash,printf 'hello' | ./bin/sponge,other,False,5,0
-194,numeric,gh-168-generation-run-12,b76c3fdc-4eec-4396-910f-0ab53d888509,,20,15,Bash,printf 'original\n' > /tmp/sponge_append_test.txt && printf 'appended\n' | ./bin/sponge -a /tmp/sponge_append_test.txt && cat /tmp/sponge_append_test.txt && rm /tmp/sponge_append_test.txt,other,False,17,0
-194,numeric,gh-168-generation-run-12,b76c3fdc-4eec-4396-910f-0ab53d888509,,21,16,Bash,"./bin/sponge -z 2>&1; echo ""exit: $?""",other,False,37,0
+194,numeric,gh-168-generation-run-12,b76c3fdc-4eec-4396-910f-0ab53d888509,,18,13,Bash,printf 'line1\nline2\nline3\n' | ./bin/sponge /tmp/sponge_test_out.txt && cat /tmp/sponge_test_out.txt && rm /tmp/sponge_test_out.txt,binary_exercise,False,17,0
+194,numeric,gh-168-generation-run-12,b76c3fdc-4eec-4396-910f-0ab53d888509,,19,14,Bash,printf 'hello' | ./bin/sponge,binary_exercise,False,5,0
+194,numeric,gh-168-generation-run-12,b76c3fdc-4eec-4396-910f-0ab53d888509,,20,15,Bash,printf 'original\n' > /tmp/sponge_append_test.txt && printf 'appended\n' | ./bin/sponge -a /tmp/sponge_append_test.txt && cat /tmp/sponge_append_test.txt && rm /tmp/sponge_append_test.txt,binary_exercise,False,17,0
+194,numeric,gh-168-generation-run-12,b76c3fdc-4eec-4396-910f-0ab53d888509,,21,16,Bash,"./bin/sponge -z 2>&1; echo ""exit: $?""",binary_run,False,37,0
 194,numeric,gh-168-generation-run-12,b76c3fdc-4eec-4396-910f-0ab53d888509,,22,17,Bash,"# Test soak-before-write: cat file | sponge file should preserve content
-printf 'data1\ndata2\ndata3\n' > /tmp/sponge_soak_test.txt && cat /tmp/sponge_soak_test.txt | ./bin/sponge /tmp/sponge_soak_tes",other,False,17,0
+printf 'data1\ndata2\ndata3\n' > /tmp/sponge_soak_test.txt && cat /tmp/sponge_soak_test.txt | ./bin/sponge /tmp/sponge_soak_tes",binary_exercise,False,17,0
 194,numeric,gh-168-generation-run-12,b76c3fdc-4eec-4396-910f-0ab53d888509,,23,18,Bash,"# Test permission preservation
-printf 'old\n' > /tmp/sponge_perm_test.txt && chmod 0640 /tmp/sponge_perm_test.txt && printf 'new\n' | ./bin/sponge /tmp/sponge_perm_test.txt && stat -c '%a' /tmp/sponge",other,False,7,0
+printf 'old\n' > /tmp/sponge_perm_test.txt && chmod 0640 /tmp/sponge_perm_test.txt && printf 'new\n' | ./bin/sponge /tmp/sponge_perm_test.txt && stat -c '%a' /tmp/sponge",binary_exercise,False,7,0
 194,numeric,gh-168-generation-run-12,b76c3fdc-4eec-4396-910f-0ab53d888509,,24,19,Bash,"# Test empty stdin
-printf '' | ./bin/sponge /tmp/sponge_empty_test.txt && wc -c /tmp/sponge_empty_test.txt && rm /tmp/sponge_empty_test.txt",other,False,28,0
+printf '' | ./bin/sponge /tmp/sponge_empty_test.txt && wc -c /tmp/sponge_empty_test.txt && rm /tmp/sponge_empty_test.txt",binary_exercise,False,28,0
 194,numeric,gh-168-generation-run-12,b76c3fdc-4eec-4396-910f-0ab53d888509,,25,20,Bash,"# Test -- flag terminator
-printf 'test\n' | ./bin/sponge -- /tmp/sponge_dash_test.txt && cat /tmp/sponge_dash_test.txt && rm /tmp/sponge_dash_test.txt",other,False,4,0
+printf 'test\n' | ./bin/sponge -- /tmp/sponge_dash_test.txt && cat /tmp/sponge_dash_test.txt && rm /tmp/sponge_dash_test.txt",binary_exercise,False,4,0
 194,numeric,gh-168-generation-run-12,b76c3fdc-4eec-4396-910f-0ab53d888509,,26,21,Bash,"# Test append mode with non-existent file (R3.2)
-printf 'new content\n' | ./bin/sponge -a /tmp/sponge_append_new.txt && cat /tmp/sponge_append_new.txt && rm /tmp/sponge_append_new.txt",other,False,11,0
+printf 'new content\n' | ./bin/sponge -a /tmp/sponge_append_new.txt && cat /tmp/sponge_append_new.txt && rm /tmp/sponge_append_new.txt",binary_exercise,False,11,0
 194,numeric,gh-168-generation-run-12,b76c3fdc-4eec-4396-910f-0ab53d888509,,27,22,Bash,"# Test error on file open failure
-printf 'test' | ./bin/sponge /nonexistent/dir/file.txt 2>&1; echo ""exit: $?""",other,False,100,0
+printf 'test' | ./bin/sponge /nonexistent/dir/file.txt 2>&1; echo ""exit: $?""",binary_exercise,False,100,0
 194,numeric,gh-168-generation-run-12,b76c3fdc-4eec-4396-910f-0ab53d888509,,29,23,TodoWrite,"{""todos"": [{""content"": ""Read sponge PRD, use case, and test suite"", ""status"": ""completed"", ""activeForm"": ""Reading sponge PRD, use case, and test suite""}, {""content"": ""Implement cmd/sponge/main.go"", ""s",,False,160,0
 195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,2,1,TodoWrite,"{""todos"": [{""content"": ""Read required specification files (PRD, use case, test suite)"", ""status"": ""in_progress"", ""activeForm"": ""Reading required specification files""}, {""content"": ""Implement cmd/du/ma",,False,160,0
 195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,4,3,Read,/var/folders/dl/cbns6zkx7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/195/docs/specs/use-cases/rel01.3-uc001-du.yaml,,True,138,0
 195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,5,4,Read,/var/folders/dl/cbns6zkx7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/195/docs/specs/test-suites/test-rel01.3.yaml,,True,58,0
 195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,6,5,Glob,docs/specs/product-requirements/prd009-du.yaml,,True,58,0
 195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,7,6,Bash,"find /var/folders/dl/cbns6zkx7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/195 -type f -name ""*.yaml"" | grep -E ""(rel01|prd|test)"" | head -20",find,False,0,0
-195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,8,7,Bash,pwd && ls -la,other,False,0,0
+195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,8,7,Bash,pwd && ls -la,env_inspect,False,0,0
 195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,9,8,Bash,"find /var/folders/dl/cbns6zkx7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/195/docs -type f -name ""*.yaml"" | sort",find,False,0,0
 195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,10,9,Bash,ls -la /var/folders/dl/cbns6zkx7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/195/,ls,True,222,0
-195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,11,10,Bash,pwd,other,False,0,0
+195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,11,10,Bash,pwd,env_inspect,False,0,0
 195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,12,11,Bash,ls -la docs/,ls,False,0,0
 195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,13,12,Bash,"find docs/specs -type f -name ""*.yaml"" | sort",find,False,0,0
 195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,14,13,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/195/docs/specs/use-cases/rel01.3-uc001-du.yaml,,False,4840,0
@@ -1087,15 +1087,15 @@ printf 'test' | ./bin/sponge /nonexistent/dir/file.txt 2>&1; echo ""exit: $?""",
 195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,29,23,Bash,go build -o bin/du ./cmd/du/ 2>&1,go_build,False,40,0
 195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,30,24,Bash,go vet ./cmd/du/ 2>&1,go_vet,False,0,0
 195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,32,25,Bash,"mkdir -p /tmp/du-test/sub1 /tmp/du-test/sub2 && echo ""hello world"" > /tmp/du-test/sub1/a.txt && echo ""test data"" > /tmp/du-test/sub2/b.txt && echo ""root file"" > /tmp/du-test/c.txt",mkdir,False,0,0
-195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,33,26,Bash,bin/du -k /tmp/du-test/ 2>&1,other,False,56,0
-195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,34,27,Bash,bin/du -sk /tmp/du-test/ 2>&1,other,False,16,0
-195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,35,28,Bash,bin/du -ak /tmp/du-test/ 2>&1,other,False,129,0
-195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,36,29,Bash,bin/du -h /tmp/du-test/ 2>&1,other,False,63,0
-195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,37,30,Bash,bin/du -ck /tmp/du-test/sub1 /tmp/du-test/sub2 2>&1,other,False,47,0
-195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,38,31,Bash,bin/du -k -d 1 /tmp/du-test/ 2>&1,other,False,56,0
-195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,39,32,Bash,"bin/du -k /tmp/du-test/nonexistent 2>&1; echo ""exit: $?""",other,False,79,0
+195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,33,26,Bash,bin/du -k /tmp/du-test/ 2>&1,binary_run,False,56,0
+195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,34,27,Bash,bin/du -sk /tmp/du-test/ 2>&1,binary_run,False,16,0
+195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,35,28,Bash,bin/du -ak /tmp/du-test/ 2>&1,binary_run,False,129,0
+195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,36,29,Bash,bin/du -h /tmp/du-test/ 2>&1,binary_run,False,63,0
+195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,37,30,Bash,bin/du -ck /tmp/du-test/sub1 /tmp/du-test/sub2 2>&1,binary_run,False,47,0
+195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,38,31,Bash,bin/du -k -d 1 /tmp/du-test/ 2>&1,binary_run,False,56,0
+195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,39,32,Bash,"bin/du -k /tmp/du-test/nonexistent 2>&1; echo ""exit: $?""",binary_run,False,79,0
 195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,41,33,Bash,"mkdir -p /tmp/du-hardlink/dir_a /tmp/du-hardlink/dir_b && echo ""shared content"" > /tmp/du-hardlink/dir_a/shared.txt && ln /tmp/du-hardlink/dir_a/shared.txt /tmp/du-hardlink/dir_b/shared.txt && bin/du ",mkdir,False,141,0
-195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,42,34,Bash,bin/du -sh /tmp/du-test/ 2>&1 && bin/du --max-depth=0 -k /tmp/du-test/ 2>&1,other,False,34,0
+195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,42,34,Bash,bin/du -sh /tmp/du-test/ 2>&1 && bin/du --max-depth=0 -k /tmp/du-test/ 2>&1,binary_run,False,34,0
 195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,44,35,Bash,rm -rf /tmp/du-test /tmp/du-hardlink,rm,False,0,0
 195,numeric,gh-168-generation-run-12,ffcf16cc-f1bd-4af0-8cf7-4be580f5f5ef,,45,36,TodoWrite,"{""todos"": [{""content"": ""Read required specification files (PRD, use case, test suite)"", ""status"": ""completed"", ""activeForm"": ""Reading required specification files""}, {""content"": ""Implement cmd/du/main",,False,160,0
 196,numeric,gh-168-generation-run-12,96e7470d-8688-4c8a-b186-6ec683412ab3,,2,1,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/196/docs/specs/product-requirements/prd007-sponge.yaml,,False,8184,0
@@ -1130,12 +1130,12 @@ printf 'test' | ./bin/sponge /nonexistent/dir/file.txt 2>&1; echo ""exit: $?""",
 199,numeric,gh-168-generation-run-12,3ec44b0e-995a-4ca7-b2ad-70942cb22054,,10,7,TodoWrite,"{""todos"": [{""content"": ""Read prd011-magefiles.yaml and use case for cmd/version requirements"", ""status"": ""completed"", ""activeForm"": ""Reading PRD and use case specifications""}, {""content"": ""Implement c",,False,160,0
 199,numeric,gh-168-generation-run-12,3ec44b0e-995a-4ca7-b2ad-70942cb22054,,11,8,Bash,go build -o bin/version ./cmd/version/,go_build,False,40,0
 199,numeric,gh-168-generation-run-12,3ec44b0e-995a-4ca7-b2ad-70942cb22054,,12,9,Bash,go vet ./cmd/version/,go_vet,False,0,0
-199,numeric,gh-168-generation-run-12,3ec44b0e-995a-4ca7-b2ad-70942cb22054,,14,10,Bash,"bin/version ; echo ""exit: $?""",other,False,11,0
-199,numeric,gh-168-generation-run-12,3ec44b0e-995a-4ca7-b2ad-70942cb22054,,15,11,Bash,"bin/version --version ; echo ""exit: $?""",other,False,11,0
-199,numeric,gh-168-generation-run-12,3ec44b0e-995a-4ca7-b2ad-70942cb22054,,16,12,Bash,"bin/version -v ; echo ""exit: $?""",other,False,11,0
-199,numeric,gh-168-generation-run-12,3ec44b0e-995a-4ca7-b2ad-70942cb22054,,17,13,Bash,"bin/version --bogus 2>&1 ; echo ""exit: $?""",other,False,78,0
+199,numeric,gh-168-generation-run-12,3ec44b0e-995a-4ca7-b2ad-70942cb22054,,14,10,Bash,"bin/version ; echo ""exit: $?""",binary_run,False,11,0
+199,numeric,gh-168-generation-run-12,3ec44b0e-995a-4ca7-b2ad-70942cb22054,,15,11,Bash,"bin/version --version ; echo ""exit: $?""",binary_run,False,11,0
+199,numeric,gh-168-generation-run-12,3ec44b0e-995a-4ca7-b2ad-70942cb22054,,16,12,Bash,"bin/version -v ; echo ""exit: $?""",binary_run,False,11,0
+199,numeric,gh-168-generation-run-12,3ec44b0e-995a-4ca7-b2ad-70942cb22054,,17,13,Bash,"bin/version --bogus 2>&1 ; echo ""exit: $?""",binary_run,False,78,0
 199,numeric,gh-168-generation-run-12,3ec44b0e-995a-4ca7-b2ad-70942cb22054,,19,14,Bash,"go build -ldflags ""-X main.version=v0.20260228.0"" -o bin/version ./cmd/version/ && bin/version ; echo ""exit: $?""",go_build,False,21,0
-199,numeric,gh-168-generation-run-12,3ec44b0e-995a-4ca7-b2ad-70942cb22054,,21,15,Bash,"bin/version somearg 2>&1 ; echo ""exit: $?""",other,False,78,0
+199,numeric,gh-168-generation-run-12,3ec44b0e-995a-4ca7-b2ad-70942cb22054,,21,15,Bash,"bin/version somearg 2>&1 ; echo ""exit: $?""",binary_run,False,78,0
 199,numeric,gh-168-generation-run-12,3ec44b0e-995a-4ca7-b2ad-70942cb22054,,22,16,TodoWrite,"{""todos"": [{""content"": ""Read prd011-magefiles.yaml and use case for cmd/version requirements"", ""status"": ""completed"", ""activeForm"": ""Reading PRD and use case specifications""}, {""content"": ""Implement c",,False,160,0
 200,numeric,gh-168-generation-run-12,1336b52e-863e-4709-b077-3d2c0a4a9cd2,,2,1,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/200/docs/specs/product-requirements/prd011-magefiles.yaml,,False,8292,0
 200,numeric,gh-168-generation-run-12,1336b52e-863e-4709-b077-3d2c0a4a9cd2,,5,2,Write,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/200/cmd/version/version_test.go,,False,134,0
@@ -1162,7 +1162,7 @@ import (
 )
 
 func main() {
-	data, err := os.ReadFil",go_other,True,280,0
+	data, err := os.ReadFil",binary_run,True,280,0
 202,numeric,gh-168-generation-run-12,e9dedc78-8323-47af-9bbb-87a2976cb28b,,14,7,Bash,"go run -C . <<'GOEOF' 2>&1 || true
 //go:build ignore
 
@@ -1175,7 +1175,7 @@ import (
 )
 
 func main() {
-	data, err := os.ReadFile(""docs/specs/product-requirements/prd020-true.ya",go_other,False,22,0
+	data, err := os.ReadFile(""docs/specs/product-requirements/prd020-true.ya",binary_run,False,22,0
 202,numeric,gh-168-generation-run-12,e9dedc78-8323-47af-9bbb-87a2976cb28b,,15,8,Bash,"cat > /tmp/yamlcheck.go << 'EOF'
 package main
 
@@ -1195,12 +1195,12 @@ package main
 import (
 	""fmt""
 	""os""
-	""gopkg.in/yaml.",other,False,125,100
+	""gopkg.in/yaml.",env_inspect,False,125,100
 203,numeric,gh-168-generation-run-12,8b8e2752-e0d3-4adb-aeb5-99f03f790516,,3,2,Read,/var/folders/dl/cbns6zkx7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/203/docs/specs/product-requirements/prd020-true.yaml,,True,138,0
 203,numeric,gh-168-generation-run-12,8b8e2752-e0d3-4adb-aeb5-99f03f790516,,4,3,Read,/var/folders/dl/cbns6zkx7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/203/docs/road-map.yaml,,True,58,0
 203,numeric,gh-168-generation-run-12,8b8e2752-e0d3-4adb-aeb5-99f03f790516,,5,4,Read,/var/folders/dl/cbns6zkx7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/203/docs/utilities.yaml,,True,58,0
 203,numeric,gh-168-generation-run-12,8b8e2752-e0d3-4adb-aeb5-99f03f790516,,6,5,Bash,"find /var/folders/dl/cbns6zkx7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/203 -type f -name ""*.yaml"" | head -20",find,False,0,0
-203,numeric,gh-168-generation-run-12,8b8e2752-e0d3-4adb-aeb5-99f03f790516,,7,6,Bash,pwd && ls -la,other,False,0,0
+203,numeric,gh-168-generation-run-12,8b8e2752-e0d3-4adb-aeb5-99f03f790516,,7,6,Bash,pwd && ls -la,env_inspect,False,0,0
 203,numeric,gh-168-generation-run-12,8b8e2752-e0d3-4adb-aeb5-99f03f790516,,8,7,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/203/docs/specs/product-requirements/prd020-true.yaml,,False,4164,0
 203,numeric,gh-168-generation-run-12,8b8e2752-e0d3-4adb-aeb5-99f03f790516,,9,8,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/203/docs/road-map.yaml,,False,6710,0
 203,numeric,gh-168-generation-run-12,8b8e2752-e0d3-4adb-aeb5-99f03f790516,,10,9,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/203/docs/utilities.yaml,,False,2247,0
@@ -1209,7 +1209,7 @@ import (
 203,numeric,gh-168-generation-run-12,8b8e2752-e0d3-4adb-aeb5-99f03f790516,,14,11,Grep,false,,False,2747,0
 203,numeric,gh-168-generation-run-12,8b8e2752-e0d3-4adb-aeb5-99f03f790516,,16,12,Write,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/203/docs/specs/product-requirements/prd021-false.yaml,,False,156,0
 203,numeric,gh-168-generation-run-12,8b8e2752-e0d3-4adb-aeb5-99f03f790516,,18,13,Bash,"python3 -c ""import yaml; yaml.safe_load(open('docs/specs/product-requirements/prd021-false.yaml')); print('Valid YAML')""",other,True,106,0
-203,numeric,gh-168-generation-run-12,8b8e2752-e0d3-4adb-aeb5-99f03f790516,,19,14,Bash,"which go && go run -mod=mod -modfile=/dev/null golang.org/x/tools/cmd/... 2>/dev/null; echo ""---""; cat docs/specs/product-requirements/prd021-false.yaml | head -3",other,False,81,0
+203,numeric,gh-168-generation-run-12,8b8e2752-e0d3-4adb-aeb5-99f03f790516,,19,14,Bash,"which go && go run -mod=mod -modfile=/dev/null golang.org/x/tools/cmd/... 2>/dev/null; echo ""---""; cat docs/specs/product-requirements/prd021-false.yaml | head -3",env_check,False,81,0
 203,numeric,gh-168-generation-run-12,8b8e2752-e0d3-4adb-aeb5-99f03f790516,,20,15,Bash,"cat > /tmp/validate_yaml.go << 'GOEOF'
 package main
 
@@ -1236,52 +1236,52 @@ func main() {
 	data, err := os.ReadFile(os.Args[1])
 	if err != nil {
 		fmt.Fprintf(os.Stderr, ""read: %",cat,True,246,0
-203,numeric,gh-168-generation-run-12,8b8e2752-e0d3-4adb-aeb5-99f03f790516,,22,17,Bash,"go run -C magefiles /tmp/validate_yaml.go ../docs/specs/product-requirements/prd021-false.yaml 2>/dev/null || echo ""trying alternative...""; ruby -e ""require 'yaml'; YAML.load_file('docs/specs/product-",go_other,False,196,0
+203,numeric,gh-168-generation-run-12,8b8e2752-e0d3-4adb-aeb5-99f03f790516,,22,17,Bash,"go run -C magefiles /tmp/validate_yaml.go ../docs/specs/product-requirements/prd021-false.yaml 2>/dev/null || echo ""trying alternative...""; ruby -e ""require 'yaml'; YAML.load_file('docs/specs/product-",binary_run,False,196,0
 203,numeric,gh-168-generation-run-12,8b8e2752-e0d3-4adb-aeb5-99f03f790516,,24,18,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/203/docs/specs/product-requirements/prd021-false.yaml,,False,4272,0
 204,numeric,gh-168-generation-run-12,2419d28b-c119-4265-842d-981c2e5998d5,,3,1,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/204/docs/specs/product-requirements/prd020-true.yaml,,False,4164,0
 204,numeric,gh-168-generation-run-12,2419d28b-c119-4265-842d-981c2e5998d5,,5,2,TodoWrite,"{""todos"": [{""content"": ""Create cmd/true/main.go implementing GNU true"", ""status"": ""in_progress"", ""activeForm"": ""Creating cmd/true/main.go""}, {""content"": ""Verify compilation and behavior"", ""status"": ""p",,False,160,0
 204,numeric,gh-168-generation-run-12,2419d28b-c119-4265-842d-981c2e5998d5,,6,3,Write,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/204/cmd/true/main.go,,False,123,0
 204,numeric,gh-168-generation-run-12,2419d28b-c119-4265-842d-981c2e5998d5,,7,4,TodoWrite,"{""todos"": [{""content"": ""Create cmd/true/main.go implementing GNU true"", ""status"": ""completed"", ""activeForm"": ""Creating cmd/true/main.go""}, {""content"": ""Verify compilation and behavior"", ""status"": ""in_",,False,160,0
 204,numeric,gh-168-generation-run-12,2419d28b-c119-4265-842d-981c2e5998d5,,9,5,Bash,go build -o bin/true ./cmd/true/,go_build,False,40,0
-204,numeric,gh-168-generation-run-12,2419d28b-c119-4265-842d-981c2e5998d5,,10,6,Bash,"bin/true; echo ""exit: $?""",other,False,7,0
-204,numeric,gh-168-generation-run-12,2419d28b-c119-4265-842d-981c2e5998d5,,11,7,Bash,"bin/true foo bar --baz; echo ""exit: $?""",other,False,7,0
-204,numeric,gh-168-generation-run-12,2419d28b-c119-4265-842d-981c2e5998d5,,12,8,Bash,"bin/true --help; echo ""exit: $?""",other,False,213,0
-204,numeric,gh-168-generation-run-12,2419d28b-c119-4265-842d-981c2e5998d5,,13,9,Bash,"bin/true --version; echo ""exit: $?""",other,False,32,0
-204,numeric,gh-168-generation-run-12,2419d28b-c119-4265-842d-981c2e5998d5,,14,10,Bash,"bin/true -- --help; echo ""exit: $?""",other,False,7,0
-204,numeric,gh-168-generation-run-12,2419d28b-c119-4265-842d-981c2e5998d5,,15,11,Bash,"bin/true foo --help; echo ""exit: $?""",other,False,7,0
+204,numeric,gh-168-generation-run-12,2419d28b-c119-4265-842d-981c2e5998d5,,10,6,Bash,"bin/true; echo ""exit: $?""",binary_run,False,7,0
+204,numeric,gh-168-generation-run-12,2419d28b-c119-4265-842d-981c2e5998d5,,11,7,Bash,"bin/true foo bar --baz; echo ""exit: $?""",binary_run,False,7,0
+204,numeric,gh-168-generation-run-12,2419d28b-c119-4265-842d-981c2e5998d5,,12,8,Bash,"bin/true --help; echo ""exit: $?""",binary_run,False,213,0
+204,numeric,gh-168-generation-run-12,2419d28b-c119-4265-842d-981c2e5998d5,,13,9,Bash,"bin/true --version; echo ""exit: $?""",binary_run,False,32,0
+204,numeric,gh-168-generation-run-12,2419d28b-c119-4265-842d-981c2e5998d5,,14,10,Bash,"bin/true -- --help; echo ""exit: $?""",binary_run,False,7,0
+204,numeric,gh-168-generation-run-12,2419d28b-c119-4265-842d-981c2e5998d5,,15,11,Bash,"bin/true foo --help; echo ""exit: $?""",binary_run,False,7,0
 204,numeric,gh-168-generation-run-12,2419d28b-c119-4265-842d-981c2e5998d5,,17,12,Bash,"output=$(bin/true foo 2>&1); echo ""output='$output' exit=$?""",other,False,16,0
 204,numeric,gh-168-generation-run-12,2419d28b-c119-4265-842d-981c2e5998d5,,18,13,Bash,"output=$(bin/true 2>&1); echo ""output='$output' exit=$?""",other,False,16,0
 204,numeric,gh-168-generation-run-12,2419d28b-c119-4265-842d-981c2e5998d5,,20,14,TodoWrite,"{""todos"": [{""content"": ""Create cmd/true/main.go implementing GNU true"", ""status"": ""completed"", ""activeForm"": ""Creating cmd/true/main.go""}, {""content"": ""Verify compilation and behavior"", ""status"": ""com",,False,160,0
 204,numeric,gh-168-generation-run-12,9c1506a9-03c5-4381-b2d8-e6c523aa04b7,,2,1,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/204/docs/specs/product-requirements/prd020-true.yaml,,False,4164,0
 204,numeric,gh-168-generation-run-12,9c1506a9-03c5-4381-b2d8-e6c523aa04b7,,3,2,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/204/cmd/true/main.go,,False,2517,0
 204,numeric,gh-168-generation-run-12,9c1506a9-03c5-4381-b2d8-e6c523aa04b7,,6,3,Bash,go build -o bin/true ./cmd/true/,go_build,False,40,0
-204,numeric,gh-168-generation-run-12,9c1506a9-03c5-4381-b2d8-e6c523aa04b7,,7,4,Bash,"bin/true; echo ""exit: $?""",other,False,7,0
-204,numeric,gh-168-generation-run-12,9c1506a9-03c5-4381-b2d8-e6c523aa04b7,,8,5,Bash,"bin/true foo bar --baz; echo ""exit: $?""",other,False,7,0
-204,numeric,gh-168-generation-run-12,9c1506a9-03c5-4381-b2d8-e6c523aa04b7,,9,6,Bash,"bin/true --help; echo ""exit: $?""",other,False,213,0
-204,numeric,gh-168-generation-run-12,9c1506a9-03c5-4381-b2d8-e6c523aa04b7,,10,7,Bash,"bin/true --version; echo ""exit: $?""",other,False,32,0
+204,numeric,gh-168-generation-run-12,9c1506a9-03c5-4381-b2d8-e6c523aa04b7,,7,4,Bash,"bin/true; echo ""exit: $?""",binary_run,False,7,0
+204,numeric,gh-168-generation-run-12,9c1506a9-03c5-4381-b2d8-e6c523aa04b7,,8,5,Bash,"bin/true foo bar --baz; echo ""exit: $?""",binary_run,False,7,0
+204,numeric,gh-168-generation-run-12,9c1506a9-03c5-4381-b2d8-e6c523aa04b7,,9,6,Bash,"bin/true --help; echo ""exit: $?""",binary_run,False,213,0
+204,numeric,gh-168-generation-run-12,9c1506a9-03c5-4381-b2d8-e6c523aa04b7,,10,7,Bash,"bin/true --version; echo ""exit: $?""",binary_run,False,32,0
 204,numeric,gh-168-generation-run-12,9c1506a9-03c5-4381-b2d8-e6c523aa04b7,,11,8,Bash,"output=$(bin/true foo 2>&1); echo ""stdout+stderr length: ${#output}""; echo ""exit: $?""",other,False,31,0
-204,numeric,gh-168-generation-run-12,9c1506a9-03c5-4381-b2d8-e6c523aa04b7,,12,9,Bash,"bin/true -- --help; echo ""exit: $?""",other,False,7,0
-204,numeric,gh-168-generation-run-12,9c1506a9-03c5-4381-b2d8-e6c523aa04b7,,13,10,Bash,"bin/true foo --help; echo ""exit: $?""",other,False,7,0
+204,numeric,gh-168-generation-run-12,9c1506a9-03c5-4381-b2d8-e6c523aa04b7,,12,9,Bash,"bin/true -- --help; echo ""exit: $?""",binary_run,False,7,0
+204,numeric,gh-168-generation-run-12,9c1506a9-03c5-4381-b2d8-e6c523aa04b7,,13,10,Bash,"bin/true foo --help; echo ""exit: $?""",binary_run,False,7,0
 204,numeric,gh-168-generation-run-12,9c1506a9-03c5-4381-b2d8-e6c523aa04b7,,15,11,Bash,go test ./cmd/true/... 2>&1,go_test,False,67,0
 204,numeric,gh-168-generation-run-12,9c1506a9-03c5-4381-b2d8-e6c523aa04b7,,16,12,Bash,go vet ./cmd/true/... 2>&1,go_vet,False,0,0
 204,numeric,gh-168-generation-run-12,edb79ba3-81b5-4fe7-9491-6774e6bfdb03,,3,2,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/204/cmd/true/main.go,,False,2517,0
 204,numeric,gh-168-generation-run-12,edb79ba3-81b5-4fe7-9491-6774e6bfdb03,,2,1,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/204/docs/specs/product-requirements/prd020-true.yaml,,False,4164,0
 204,numeric,gh-168-generation-run-12,edb79ba3-81b5-4fe7-9491-6774e6bfdb03,,6,3,Bash,go build -o bin/true ./cmd/true/,go_build,False,40,0
-204,numeric,gh-168-generation-run-12,edb79ba3-81b5-4fe7-9491-6774e6bfdb03,,7,4,Bash,"bin/true; echo ""exit: $?""",other,False,7,0
-204,numeric,gh-168-generation-run-12,edb79ba3-81b5-4fe7-9491-6774e6bfdb03,,8,5,Bash,"bin/true foo bar --baz; echo ""exit: $?""",other,False,7,0
-204,numeric,gh-168-generation-run-12,edb79ba3-81b5-4fe7-9491-6774e6bfdb03,,9,6,Bash,"bin/true --help; echo ""exit: $?""",other,False,213,0
-204,numeric,gh-168-generation-run-12,edb79ba3-81b5-4fe7-9491-6774e6bfdb03,,10,7,Bash,"bin/true --version; echo ""exit: $?""",other,False,32,0
-204,numeric,gh-168-generation-run-12,edb79ba3-81b5-4fe7-9491-6774e6bfdb03,,11,8,Bash,"bin/true -- --help; echo ""exit: $?""",other,False,7,0
-204,numeric,gh-168-generation-run-12,edb79ba3-81b5-4fe7-9491-6774e6bfdb03,,12,9,Bash,"bin/true arg1 --version; echo ""exit: $?""",other,False,7,0
+204,numeric,gh-168-generation-run-12,edb79ba3-81b5-4fe7-9491-6774e6bfdb03,,7,4,Bash,"bin/true; echo ""exit: $?""",binary_run,False,7,0
+204,numeric,gh-168-generation-run-12,edb79ba3-81b5-4fe7-9491-6774e6bfdb03,,8,5,Bash,"bin/true foo bar --baz; echo ""exit: $?""",binary_run,False,7,0
+204,numeric,gh-168-generation-run-12,edb79ba3-81b5-4fe7-9491-6774e6bfdb03,,9,6,Bash,"bin/true --help; echo ""exit: $?""",binary_run,False,213,0
+204,numeric,gh-168-generation-run-12,edb79ba3-81b5-4fe7-9491-6774e6bfdb03,,10,7,Bash,"bin/true --version; echo ""exit: $?""",binary_run,False,32,0
+204,numeric,gh-168-generation-run-12,edb79ba3-81b5-4fe7-9491-6774e6bfdb03,,11,8,Bash,"bin/true -- --help; echo ""exit: $?""",binary_run,False,7,0
+204,numeric,gh-168-generation-run-12,edb79ba3-81b5-4fe7-9491-6774e6bfdb03,,12,9,Bash,"bin/true arg1 --version; echo ""exit: $?""",binary_run,False,7,0
 204,numeric,gh-168-generation-run-12,b9ef2e83-cba1-4d2c-a4ad-cb419743d3ba,,2,1,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/204/docs/specs/product-requirements/prd020-true.yaml,,False,4164,0
 204,numeric,gh-168-generation-run-12,b9ef2e83-cba1-4d2c-a4ad-cb419743d3ba,,3,2,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/204/cmd/true/main.go,,False,2517,0
 204,numeric,gh-168-generation-run-12,b9ef2e83-cba1-4d2c-a4ad-cb419743d3ba,,6,3,Bash,go build -o bin/true ./cmd/true/,go_build,False,40,0
-204,numeric,gh-168-generation-run-12,b9ef2e83-cba1-4d2c-a4ad-cb419743d3ba,,7,4,Bash,"bin/true; echo ""exit: $?""",other,False,7,0
-204,numeric,gh-168-generation-run-12,b9ef2e83-cba1-4d2c-a4ad-cb419743d3ba,,8,5,Bash,"bin/true foo bar --baz; echo ""exit: $?""",other,False,7,0
-204,numeric,gh-168-generation-run-12,b9ef2e83-cba1-4d2c-a4ad-cb419743d3ba,,9,6,Bash,"bin/true --help; echo ""exit: $?""",other,False,213,0
-204,numeric,gh-168-generation-run-12,b9ef2e83-cba1-4d2c-a4ad-cb419743d3ba,,10,7,Bash,"bin/true --version; echo ""exit: $?""",other,False,32,0
-204,numeric,gh-168-generation-run-12,b9ef2e83-cba1-4d2c-a4ad-cb419743d3ba,,11,8,Bash,"bin/true foo --help bar; echo ""exit: $?""",other,False,7,0
-204,numeric,gh-168-generation-run-12,b9ef2e83-cba1-4d2c-a4ad-cb419743d3ba,,12,9,Bash,"bin/true -- --help; echo ""exit: $?""",other,False,7,0
+204,numeric,gh-168-generation-run-12,b9ef2e83-cba1-4d2c-a4ad-cb419743d3ba,,7,4,Bash,"bin/true; echo ""exit: $?""",binary_run,False,7,0
+204,numeric,gh-168-generation-run-12,b9ef2e83-cba1-4d2c-a4ad-cb419743d3ba,,8,5,Bash,"bin/true foo bar --baz; echo ""exit: $?""",binary_run,False,7,0
+204,numeric,gh-168-generation-run-12,b9ef2e83-cba1-4d2c-a4ad-cb419743d3ba,,9,6,Bash,"bin/true --help; echo ""exit: $?""",binary_run,False,213,0
+204,numeric,gh-168-generation-run-12,b9ef2e83-cba1-4d2c-a4ad-cb419743d3ba,,10,7,Bash,"bin/true --version; echo ""exit: $?""",binary_run,False,32,0
+204,numeric,gh-168-generation-run-12,b9ef2e83-cba1-4d2c-a4ad-cb419743d3ba,,11,8,Bash,"bin/true foo --help bar; echo ""exit: $?""",binary_run,False,7,0
+204,numeric,gh-168-generation-run-12,b9ef2e83-cba1-4d2c-a4ad-cb419743d3ba,,12,9,Bash,"bin/true -- --help; echo ""exit: $?""",binary_run,False,7,0
 204,numeric,gh-168-generation-run-12,b9ef2e83-cba1-4d2c-a4ad-cb419743d3ba,,13,10,Bash,"output=$(bin/true foo 2>&1); echo ""output='$output'""; echo ""exit: $?""",other,False,17,0
 205,numeric,gh-168-generation-run-12,a44c4f24-2ca8-4291-ac9b-a5aa3817499f,,2,1,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/205/docs/specs/product-requirements/prd020-true.yaml,,False,4164,0
 205,numeric,gh-168-generation-run-12,a44c4f24-2ca8-4291-ac9b-a5aa3817499f,,4,2,Write,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/205/cmd/true/true_test.go,,False,128,0
@@ -1337,7 +1337,7 @@ import (
 func main() {
 	// AC2: Size formatting
 	fmt.Println(""=== Size formatting ==="")
-	fmt.Prin",go_other,True,58,0
+	fmt.Prin",binary_run,True,58,0
 227,numeric,gh-206-generation-run-14,e3a1d410-8e86-4806-834e-e0f0e6346df3,,26,18,Bash,"cat > /tmp/format_verify.go <<'EOF'
 package main
 
@@ -1351,7 +1351,7 @@ import (
 func main() {
 	// AC2: Size formatting
 	fmt.Println(""=== Size formatting",cat,False,762,0
-227,numeric,gh-206-generation-run-14,e3a1d410-8e86-4806-834e-e0f0e6346df3,,29,19,Bash,"which golangci-lint 2>/dev/null && golangci-lint run ./pkg/format/ || echo ""golangci-lint not available, skipping""",other,False,43,0
+227,numeric,gh-206-generation-run-14,e3a1d410-8e86-4806-834e-e0f0e6346df3,,29,19,Bash,"which golangci-lint 2>/dev/null && golangci-lint run ./pkg/format/ || echo ""golangci-lint not available, skipping""",env_check,False,43,0
 227,numeric,gh-206-generation-run-14,e3a1d410-8e86-4806-834e-e0f0e6346df3,,30,20,Bash,rm /tmp/format_verify.go,rm,False,0,0
 227,numeric,gh-206-generation-run-14,e3a1d410-8e86-4806-834e-e0f0e6346df3,,32,21,TodoWrite,"{""todos"": [{""content"": ""Read required PRD and use case documents"", ""status"": ""completed"", ""activeForm"": ""Reading required PRD and use case documents""}, {""content"": ""Implement pkg/format/size.go - huma",,False,160,0
 228,numeric,gh-206-generation-run-14,000ec219-da40-4bd1-a63a-a0be702f3080,,2,1,TodoWrite,"{""todos"": [{""content"": ""Read required docs (prd002-sys.yaml, go.mod)"", ""status"": ""in_progress"", ""activeForm"": ""Reading required documentation""}, {""content"": ""Implement pkg/sys/fileinfo.go"", ""status"": ",,False,160,0
@@ -1404,22 +1404,22 @@ func main() {
 233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,11,8,Write,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/233/cmd/cat/main.go,,False,122,0
 233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,12,9,TodoWrite,"{""todos"": [{""content"": ""Read required PRD, use case, and test suite documents"", ""status"": ""completed"", ""activeForm"": ""Reading required documents""}, {""content"": ""Implement cmd/cat/main.go"", ""status"": """,,False,160,0
 233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,14,10,Bash,go build -o bin/cat ./cmd/cat/,go_build,False,0,0
-233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,16,11,Bash,printf 'hello\nworld\n' > /tmp/cat_test_file1.txt && printf 'foo\nbar\n' > /tmp/cat_test_file2.txt && ./bin/cat /tmp/cat_test_file1.txt /tmp/cat_test_file2.txt,other,False,19,0
-233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,17,12,Bash,printf 'from stdin\n' | ./bin/cat,other,False,10,0
-233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,18,13,Bash,printf 'alpha\n\nbeta\n' | ./bin/cat -n,other,False,32,0
-233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,19,14,Bash,printf 'first\n\n\nsecond\n' | ./bin/cat -b,other,False,28,0
-233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,20,15,Bash,printf 'a\n\n\n\nb\n' | ./bin/cat -s,other,False,4,0
-233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,21,16,Bash,"./bin/cat /tmp/nonexistent_file_12345.txt /tmp/cat_test_file1.txt; echo ""exit code: $?""",other,False,88,0
-233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,23,17,Bash,printf '\x01\x09\x1b\x7f\x80\xff' | ./bin/cat -v | cat -v,other,False,15,0
-233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,24,18,Bash,printf '\x01\thello\n' | ./bin/cat -A,other,False,10,0
-233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,25,19,Bash,printf 'a\n\n\n\nb\n' | ./bin/cat -n -s,other,False,25,0
-233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,28,20,Bash,printf 'a\n\n\n\nb\n' | ./bin/cat -n -s | xxd | head -5,other,False,129,0
-233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,30,21,Bash,printf 'line one\nline two\n' | ./bin/cat -E,other,False,19,0
-233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,31,22,Bash,printf 'col1\tcol2\tcol3\n' | ./bin/cat -T,other,False,16,0
-233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,32,23,Bash,printf 'from stdin\n' | ./bin/cat -,other,False,10,0
-233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,33,24,Bash,printf 'test\n' | ./bin/cat -u,other,False,4,0
-233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,35,25,Bash,printf '\x01hello\n' | ./bin/cat -e,other,False,8,0
-233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,36,26,Bash,printf '\x01\thello\n' | ./bin/cat -t,other,False,9,0
+233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,16,11,Bash,printf 'hello\nworld\n' > /tmp/cat_test_file1.txt && printf 'foo\nbar\n' > /tmp/cat_test_file2.txt && ./bin/cat /tmp/cat_test_file1.txt /tmp/cat_test_file2.txt,binary_exercise,False,19,0
+233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,17,12,Bash,printf 'from stdin\n' | ./bin/cat,binary_exercise,False,10,0
+233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,18,13,Bash,printf 'alpha\n\nbeta\n' | ./bin/cat -n,binary_exercise,False,32,0
+233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,19,14,Bash,printf 'first\n\n\nsecond\n' | ./bin/cat -b,binary_exercise,False,28,0
+233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,20,15,Bash,printf 'a\n\n\n\nb\n' | ./bin/cat -s,binary_exercise,False,4,0
+233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,21,16,Bash,"./bin/cat /tmp/nonexistent_file_12345.txt /tmp/cat_test_file1.txt; echo ""exit code: $?""",binary_run,False,88,0
+233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,23,17,Bash,printf '\x01\x09\x1b\x7f\x80\xff' | ./bin/cat -v | cat -v,binary_exercise,False,15,0
+233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,24,18,Bash,printf '\x01\thello\n' | ./bin/cat -A,binary_exercise,False,10,0
+233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,25,19,Bash,printf 'a\n\n\n\nb\n' | ./bin/cat -n -s,binary_exercise,False,25,0
+233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,28,20,Bash,printf 'a\n\n\n\nb\n' | ./bin/cat -n -s | xxd | head -5,binary_exercise,False,129,0
+233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,30,21,Bash,printf 'line one\nline two\n' | ./bin/cat -E,binary_exercise,False,19,0
+233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,31,22,Bash,printf 'col1\tcol2\tcol3\n' | ./bin/cat -T,binary_exercise,False,16,0
+233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,32,23,Bash,printf 'from stdin\n' | ./bin/cat -,binary_exercise,False,10,0
+233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,33,24,Bash,printf 'test\n' | ./bin/cat -u,binary_exercise,False,4,0
+233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,35,25,Bash,printf '\x01hello\n' | ./bin/cat -e,binary_exercise,False,8,0
+233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,36,26,Bash,printf '\x01\thello\n' | ./bin/cat -t,binary_exercise,False,9,0
 233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,38,27,Bash,go vet ./cmd/cat/,go_vet,False,0,0
 233,numeric,gh-206-generation-run-14,05ba9b6b-2994-4c02-a62b-f2922733d361,,39,28,TodoWrite,"{""todos"": [{""content"": ""Read required PRD, use case, and test suite documents"", ""status"": ""completed"", ""activeForm"": ""Reading required documents""}, {""content"": ""Implement cmd/cat/main.go"", ""status"": """,,False,160,0
 234,numeric,gh-206-generation-run-14,4bed78a5-ce10-4005-a086-7164c95aed1f,,3,2,Glob,docs/specs/product-requirements/*sponge.yaml,,True,250,0
@@ -1438,19 +1438,19 @@ func main() {
 234,numeric,gh-206-generation-run-14,4bed78a5-ce10-4005-a086-7164c95aed1f,,17,14,Bash,go build -o bin/sponge ./cmd/sponge/,go_build,False,0,0
 234,numeric,gh-206-generation-run-14,4bed78a5-ce10-4005-a086-7164c95aed1f,,19,15,Bash,seq 1 100 | ./bin/sponge /tmp/sponge_test_out.txt && wc -l /tmp/sponge_test_out.txt && head -3 /tmp/sponge_test_out.txt && tail -3 /tmp/sponge_test_out.txt && rm /tmp/sponge_test_out.txt,other,False,44,0
 234,numeric,gh-206-generation-run-14,4bed78a5-ce10-4005-a086-7164c95aed1f,,20,16,Bash,"# AC3: verify -a flag appends
-printf 'original line\n' > /tmp/sponge_append_test.txt && printf 'appended line\n' | ./bin/sponge -a /tmp/sponge_append_test.txt && cat /tmp/sponge_append_test.txt && rm ",other,False,27,0
+printf 'original line\n' > /tmp/sponge_append_test.txt && printf 'appended line\n' | ./bin/sponge -a /tmp/sponge_append_test.txt && cat /tmp/sponge_append_test.txt && rm ",binary_exercise,False,27,0
 234,numeric,gh-206-generation-run-14,4bed78a5-ce10-4005-a086-7164c95aed1f,,21,17,Bash,"# AC4: verify error on nonexistent directory and passthrough mode
-./bin/sponge /nonexistent/dir/file 2>&1; echo ""exit: $?"" && printf 'hello' | ./bin/sponge; echo ""exit: $?""",other,False,113,0
+./bin/sponge /nonexistent/dir/file 2>&1; echo ""exit: $?"" && printf 'hello' | ./bin/sponge; echo ""exit: $?""",binary_run,False,113,0
 234,numeric,gh-206-generation-run-14,4bed78a5-ce10-4005-a086-7164c95aed1f,,22,18,Bash,"# Test soak-before-write: cat file | sponge file must not truncate
-printf 'line1\nline2\nline3\n' > /tmp/sponge_soak_test.txt && cat /tmp/sponge_soak_test.txt | ./bin/sponge /tmp/sponge_soak_test.txt ",other,False,17,0
+printf 'line1\nline2\nline3\n' > /tmp/sponge_soak_test.txt && cat /tmp/sponge_soak_test.txt | ./bin/sponge /tmp/sponge_soak_test.txt ",binary_exercise,False,17,0
 234,numeric,gh-206-generation-run-14,4bed78a5-ce10-4005-a086-7164c95aed1f,,23,19,Bash,"# Test permission preservation
 touch /tmp/sponge_perm_test.txt && chmod 640 /tmp/sponge_perm_test.txt && printf 'new content\n' | ./bin/sponge /tmp/sponge_perm_test.txt && stat -c '%a' /tmp/sponge_per",other,False,15,0
 234,numeric,gh-206-generation-run-14,4bed78a5-ce10-4005-a086-7164c95aed1f,,24,20,Bash,"# Test empty stdin
-printf '' | ./bin/sponge /tmp/sponge_empty_test.txt && wc -c /tmp/sponge_empty_test.txt && rm /tmp/sponge_empty_test.txt",other,False,28,0
+printf '' | ./bin/sponge /tmp/sponge_empty_test.txt && wc -c /tmp/sponge_empty_test.txt && rm /tmp/sponge_empty_test.txt",binary_exercise,False,28,0
 234,numeric,gh-206-generation-run-14,4bed78a5-ce10-4005-a086-7164c95aed1f,,25,21,Bash,"# Test -a with non-existent file (R3.2: behaves as default mode)
-printf 'new content\n' | ./bin/sponge -a /tmp/sponge_append_new.txt && cat /tmp/sponge_append_new.txt && rm /tmp/sponge_append_new.txt",other,False,11,0
+printf 'new content\n' | ./bin/sponge -a /tmp/sponge_append_new.txt && cat /tmp/sponge_append_new.txt && rm /tmp/sponge_append_new.txt",binary_exercise,False,11,0
 234,numeric,gh-206-generation-run-14,4bed78a5-ce10-4005-a086-7164c95aed1f,,26,22,Bash,"# Test too many arguments error
-./bin/sponge file1 file2 2>&1; echo ""exit: $?""",other,False,34,0
+./bin/sponge file1 file2 2>&1; echo ""exit: $?""",binary_run,False,34,0
 234,numeric,gh-206-generation-run-14,4bed78a5-ce10-4005-a086-7164c95aed1f,,28,23,TodoWrite,"{""todos"": [{""content"": ""Review PRD, use case, test suite, and cat reference patterns"", ""status"": ""completed"", ""activeForm"": ""Reviewing specifications and reference code""}, {""content"": ""Implement cmd/s",,False,160,0
 235,numeric,gh-206-generation-run-14,286c6e79-e6d7-46b2-94a8-acb16c22699c,,2,1,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/235/docs/specs/product-requirements/prd006-cat.yaml,,False,7605,0
 235,numeric,gh-206-generation-run-14,286c6e79-e6d7-46b2-94a8-acb16c22699c,,3,2,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/235/docs/specs/test-suites/test-rel01.1.yaml,,False,7914,0
@@ -1485,19 +1485,19 @@ printf 'new content\n' | ./bin/sponge -a /tmp/sponge_append_new.txt && cat /tmp/
 237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,20,15,Bash,go build -o bin/du ./cmd/du/ 2>&1,go_build,False,40,0
 237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,21,16,Bash,go vet ./cmd/du/ 2>&1,go_vet,False,0,0
 237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,23,17,Bash,"mkdir -p /tmp/du-test/subdir1/nested && mkdir -p /tmp/du-test/subdir2 && echo ""hello world"" > /tmp/du-test/file1.txt && echo ""test content for subdir1"" > /tmp/du-test/subdir1/a.txt && echo ""nested fil",mkdir,False,0,0
-237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,24,18,Bash,"echo ""=== AC2: Directory traversal ==="" && ./bin/du /tmp/du-test && echo ""=== Reference (gdu) ==="" && gdu -k /tmp/du-test 2>/dev/null || du -k /tmp/du-test",echo,False,240,0
-237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,26,19,Bash,"echo ""=== AC3: Regular file argument ==="" && ./bin/du /tmp/du-test/file1.txt && echo ""=== Reference ==="" && du -k /tmp/du-test/file1.txt",echo,False,102,0
-237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,27,20,Bash,"echo ""=== AC4: No arguments (defaults to '.') ==="" && cd /tmp/du-test && /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/237/bin/du && echo ""=== Reference ==="" && du -k .",echo,False,151,100
-237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,28,21,Bash,"echo ""=== AC5: Nonexistent path ==="" && ./bin/du /tmp/nonexistent_path 2>&1; echo ""exit code: $?""",echo,False,95,0
+237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,24,18,Bash,"echo ""=== AC2: Directory traversal ==="" && ./bin/du /tmp/du-test && echo ""=== Reference (gdu) ==="" && gdu -k /tmp/du-test 2>/dev/null || du -k /tmp/du-test",binary_exercise,False,240,0
+237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,26,19,Bash,"echo ""=== AC3: Regular file argument ==="" && ./bin/du /tmp/du-test/file1.txt && echo ""=== Reference ==="" && du -k /tmp/du-test/file1.txt",binary_exercise,False,102,0
+237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,27,20,Bash,"echo ""=== AC4: No arguments (defaults to '.') ==="" && cd /tmp/du-test && /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/237/bin/du && echo ""=== Reference ==="" && du -k .",setup,False,151,100
+237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,28,21,Bash,"echo ""=== AC5: Nonexistent path ==="" && ./bin/du /tmp/nonexistent_path 2>&1; echo ""exit code: $?""",binary_exercise,False,95,0
 237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,31,22,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/237/cmd/du/main.go,,False,4990,0
 237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,32,23,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/237/cmd/du/main.go,,False,131,0
 237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,33,24,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/237/cmd/du/main.go,,False,131,0
 237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,35,25,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/237/cmd/du/main.go,,False,131,0
 237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,36,26,Bash,go build -o bin/du ./cmd/du/ 2>&1,go_build,False,0,0
-237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,37,27,Bash,"echo ""=== AC2: Directory traversal ==="" && ./bin/du /tmp/du-test && echo ""=== Reference ==="" && du -k /tmp/du-test && echo ""---"" && echo ""=== AC4: No arguments ==="" && cd /tmp/du-test && /var/folders/",echo,False,378,100
-237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,39,28,Bash,"echo ""=== AC3: Regular file ==="" && ./bin/du /tmp/du-test/file1.txt && echo ""=== Reference ==="" && du -k /tmp/du-test/file1.txt && echo ""---"" && echo ""=== AC5: Nonexistent path ==="" && ./bin/du /tmp/n",echo,False,277,0
-237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,42,29,Bash,which golangci-lint 2>&1 && golangci-lint run ./cmd/du/ 2>&1,other,False,43,0
-237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,43,30,Bash,"echo ""=== AC6: Block size calculation test ==="" && echo ""Testing ceiling division: (blocks+1)/2"" && stat -c '%b' /tmp/du-test/file1.txt 2>/dev/null || stat -f '%b' /tmp/du-test/file1.txt",echo,False,81,0
+237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,37,27,Bash,"echo ""=== AC2: Directory traversal ==="" && ./bin/du /tmp/du-test && echo ""=== Reference ==="" && du -k /tmp/du-test && echo ""---"" && echo ""=== AC4: No arguments ==="" && cd /tmp/du-test && /var/folders/",binary_exercise,False,378,100
+237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,39,28,Bash,"echo ""=== AC3: Regular file ==="" && ./bin/du /tmp/du-test/file1.txt && echo ""=== Reference ==="" && du -k /tmp/du-test/file1.txt && echo ""---"" && echo ""=== AC5: Nonexistent path ==="" && ./bin/du /tmp/n",binary_exercise,False,277,0
+237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,42,29,Bash,which golangci-lint 2>&1 && golangci-lint run ./cmd/du/ 2>&1,env_check,False,43,0
+237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,43,30,Bash,"echo ""=== AC6: Block size calculation test ==="" && echo ""Testing ceiling division: (blocks+1)/2"" && stat -c '%b' /tmp/du-test/file1.txt 2>/dev/null || stat -f '%b' /tmp/du-test/file1.txt",setup,False,81,0
 237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,46,31,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/237/cmd/du/main.go,,False,5418,0
 237,numeric,gh-206-generation-run-14,2111581c-5ab1-41cd-b38c-38140798a1e8,,47,32,TodoWrite,"{""todos"": [{""content"": ""Read required PRD, use case, and test suite docs for du"", ""status"": ""completed"", ""activeForm"": ""Reading required documentation for du""}, {""content"": ""Read pkg/sys platform-spec",,False,160,0
 238,numeric,gh-206-generation-run-14,9d51250f-fc99-4604-8e63-1250cbe593d9,,2,1,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/238/docs/specs/product-requirements/prd009-du.yaml,,False,10280,0
@@ -1526,10 +1526,10 @@ printf 'new content\n' | ./bin/sponge -a /tmp/sponge_append_new.txt && cat /tmp/
 240,numeric,gh-206-generation-run-14,9bb5990b-81b5-4517-b072-c738724c2eab,,11,8,Write,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/240/cmd/wc/main.go,,False,121,0
 240,numeric,gh-206-generation-run-14,9bb5990b-81b5-4517-b072-c738724c2eab,,13,9,TodoWrite,"{""todos"": [{""content"": ""Read required PRD, use case, and test suite files for wc"", ""status"": ""completed"", ""activeForm"": ""Reading required specification files""}, {""content"": ""Implement cmd/wc/main.go"",",,False,160,0
 240,numeric,gh-206-generation-run-14,9bb5990b-81b5-4517-b072-c738724c2eab,,14,10,Bash,go build -o bin/wc ./cmd/wc/,go_build,False,0,0
-240,numeric,gh-206-generation-run-14,9bb5990b-81b5-4517-b072-c738724c2eab,,16,11,Bash,printf 'hello\nworld\n' > /tmp/wc_test_file.txt && ./bin/wc /tmp/wc_test_file.txt,other,False,30,0
-240,numeric,gh-206-generation-run-14,9bb5990b-81b5-4517-b072-c738724c2eab,,17,12,Bash,printf 'foo\nbar baz\n' | ./bin/wc,other,False,23,0
-240,numeric,gh-206-generation-run-14,9bb5990b-81b5-4517-b072-c738724c2eab,,18,13,Bash,printf 'stdin content\n' | ./bin/wc -,other,False,25,0
-240,numeric,gh-206-generation-run-14,9bb5990b-81b5-4517-b072-c738724c2eab,,19,14,Bash,printf 'foo\nbar baz\nqux\n' | ./bin/wc,other,False,23,0
+240,numeric,gh-206-generation-run-14,9bb5990b-81b5-4517-b072-c738724c2eab,,16,11,Bash,printf 'hello\nworld\n' > /tmp/wc_test_file.txt && ./bin/wc /tmp/wc_test_file.txt,binary_exercise,False,30,0
+240,numeric,gh-206-generation-run-14,9bb5990b-81b5-4517-b072-c738724c2eab,,17,12,Bash,printf 'foo\nbar baz\n' | ./bin/wc,binary_exercise,False,23,0
+240,numeric,gh-206-generation-run-14,9bb5990b-81b5-4517-b072-c738724c2eab,,18,13,Bash,printf 'stdin content\n' | ./bin/wc -,binary_exercise,False,25,0
+240,numeric,gh-206-generation-run-14,9bb5990b-81b5-4517-b072-c738724c2eab,,19,14,Bash,printf 'foo\nbar baz\nqux\n' | ./bin/wc,binary_exercise,False,23,0
 240,numeric,gh-206-generation-run-14,9bb5990b-81b5-4517-b072-c738724c2eab,,21,15,TodoWrite,"{""todos"": [{""content"": ""Read required PRD, use case, and test suite files for wc"", ""status"": ""completed"", ""activeForm"": ""Reading required specification files""}, {""content"": ""Implement cmd/wc/main.go"",",,False,160,0
 241,numeric,gh-206-generation-run-14,93994a83-5d4b-42ba-9a8f-7c6195384f3d,,2,1,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/241/docs/specs/product-requirements/prd005-wc.yaml,,False,6336,0
 241,numeric,gh-206-generation-run-14,93994a83-5d4b-42ba-9a8f-7c6195384f3d,,3,2,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/241/docs/specs/test-suites/test-rel03.0.yaml,,False,7405,0
@@ -1544,11 +1544,11 @@ printf 'new content\n' | ./bin/sponge -a /tmp/sponge_append_new.txt && cat /tmp/
 242,numeric,gh-206-generation-run-14,4ba7b611-6e9a-4a57-994c-cbdb7a7c6af5,,7,4,Bash,ls /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/242/cmd/,ls,False,16,0
 242,numeric,gh-206-generation-run-14,4ba7b611-6e9a-4a57-994c-cbdb7a7c6af5,,8,5,Write,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/242/cmd/version/main.go,,False,126,0
 242,numeric,gh-206-generation-run-14,4ba7b611-6e9a-4a57-994c-cbdb7a7c6af5,,10,6,Bash,go build -o bin/version ./cmd/version/,go_build,False,0,0
-242,numeric,gh-206-generation-run-14,4ba7b611-6e9a-4a57-994c-cbdb7a7c6af5,,11,7,Bash,"bin/version; echo ""exit: $?""",other,False,11,0
-242,numeric,gh-206-generation-run-14,4ba7b611-6e9a-4a57-994c-cbdb7a7c6af5,,12,8,Bash,"bin/version --version; echo ""exit: $?""",other,False,11,0
+242,numeric,gh-206-generation-run-14,4ba7b611-6e9a-4a57-994c-cbdb7a7c6af5,,11,7,Bash,"bin/version; echo ""exit: $?""",binary_run,False,11,0
+242,numeric,gh-206-generation-run-14,4ba7b611-6e9a-4a57-994c-cbdb7a7c6af5,,12,8,Bash,"bin/version --version; echo ""exit: $?""",binary_run,False,11,0
 242,numeric,gh-206-generation-run-14,4ba7b611-6e9a-4a57-994c-cbdb7a7c6af5,,13,9,Bash,"go build -ldflags ""-X main.version=v1.0.0"" -o bin/version ./cmd/version/ && bin/version; echo ""exit: $?""",go_build,False,14,0
-242,numeric,gh-206-generation-run-14,4ba7b611-6e9a-4a57-994c-cbdb7a7c6af5,,14,10,Bash,"bin/version --bogus 2>&1; echo ""exit: $?""",other,False,77,0
-242,numeric,gh-206-generation-run-14,4ba7b611-6e9a-4a57-994c-cbdb7a7c6af5,,15,11,Bash,"bin/version -v; echo ""exit: $?""",other,False,14,0
+242,numeric,gh-206-generation-run-14,4ba7b611-6e9a-4a57-994c-cbdb7a7c6af5,,14,10,Bash,"bin/version --bogus 2>&1; echo ""exit: $?""",binary_run,False,77,0
+242,numeric,gh-206-generation-run-14,4ba7b611-6e9a-4a57-994c-cbdb7a7c6af5,,15,11,Bash,"bin/version -v; echo ""exit: $?""",binary_run,False,14,0
 243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,2,1,TodoWrite,"{""todos"": [{""content"": ""Read required reading files not in context"", ""status"": ""in_progress"", ""activeForm"": ""Reading required reading files""}, {""content"": ""Implement cmd/ls/main.go"", ""status"": ""pendin",,False,160,0
 243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,3,2,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/243/docs/specs/product-requirements/prd008-ls.yaml,,False,14899,0
 243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,4,3,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/243/docs/specs/test-suites/test-rel04.0.yaml,,False,8256,0
@@ -1561,11 +1561,11 @@ printf 'new content\n' | ./bin/sponge -a /tmp/sponge_append_new.txt && cat /tmp/
 243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,13,10,Bash,go build -o bin/ls ./cmd/ls/ 2>&1,go_build,False,0,0
 243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,15,11,Bash,"mkdir -p /tmp/ls-test-fixture && cd /tmp/ls-test-fixture && rm -rf * .hidden 2>/dev/null; touch alpha.txt bravo.txt charlie.txt .hidden && mkdir subdir && echo ""AC2: default listing (no dotfiles)"" && ",mkdir,True,194,0
 243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,16,12,Bash,mkdir -p /tmp/ls-test-fixture && cd /tmp/ls-test-fixture && rm -rf * .hidden 2>/dev/null; touch alpha.txt bravo.txt charlie.txt .hidden && mkdir -p subdir && cd /var/folders/dl/cbns6zkx7txc7pt64b6cgzp,mkdir,False,67,0
-243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,18,13,Bash,"echo ""=== AC3: -a shows . and .. ==="" && LC_ALL=C bin/ls -a /tmp/ls-test-fixture && echo ""=== AC3: -A shows dotfiles but not . and .. ==="" && LC_ALL=C bin/ls -A /tmp/ls-test-fixture",echo,False,177,0
-243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,20,14,Bash,"echo ""=== AC4: nonexistent path ==="" && LC_ALL=C bin/ls /tmp/does-not-exist-xyz 2>&1; echo ""exit code: $?""",echo,False,97,0
-243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,22,15,Bash,"echo ""=== AC5: two directory args with headers ==="" && LC_ALL=C bin/ls /tmp/ls-test-fixture /tmp/ls-test-fixture/subdir",echo,False,135,0
-243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,24,16,Bash,"echo ""=== AC6: file argument (not directory) ==="" && LC_ALL=C bin/ls /tmp/ls-test-fixture/alpha.txt",echo,False,73,0
-243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,26,17,Bash,"echo ""=== Mixed file + dir args ==="" && LC_ALL=C bin/ls /tmp/ls-test-fixture/alpha.txt /tmp/ls-test-fixture",echo,False,122,0
+243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,18,13,Bash,"echo ""=== AC3: -a shows . and .. ==="" && LC_ALL=C bin/ls -a /tmp/ls-test-fixture && echo ""=== AC3: -A shows dotfiles but not . and .. ==="" && LC_ALL=C bin/ls -A /tmp/ls-test-fixture",setup,False,177,0
+243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,20,14,Bash,"echo ""=== AC4: nonexistent path ==="" && LC_ALL=C bin/ls /tmp/does-not-exist-xyz 2>&1; echo ""exit code: $?""",setup,False,97,0
+243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,22,15,Bash,"echo ""=== AC5: two directory args with headers ==="" && LC_ALL=C bin/ls /tmp/ls-test-fixture /tmp/ls-test-fixture/subdir",setup,False,135,0
+243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,24,16,Bash,"echo ""=== AC6: file argument (not directory) ==="" && LC_ALL=C bin/ls /tmp/ls-test-fixture/alpha.txt",setup,False,73,0
+243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,26,17,Bash,"echo ""=== Mixed file + dir args ==="" && LC_ALL=C bin/ls /tmp/ls-test-fixture/alpha.txt /tmp/ls-test-fixture",setup,False,122,0
 243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,28,18,Bash,go build ./... 2>&1,go_build,False,40,0
 243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,29,19,Bash,go vet ./cmd/ls/ 2>&1,go_vet,False,0,0
 243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,31,20,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/243/cmd/ls/main.go,,False,750,0
@@ -1573,7 +1573,7 @@ printf 'new content\n' | ./bin/sponge -a /tmp/sponge_append_new.txt && cat /tmp/
 243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,34,22,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/243/cmd/ls/main.go,,False,131,0
 243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,36,23,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/243/cmd/ls/main.go,,False,131,0
 243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,37,24,Bash,go build -o bin/ls ./cmd/ls/ 2>&1 && go vet ./cmd/ls/ 2>&1,go_build,False,0,0
-243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,39,25,Bash,"echo ""=== AC2 ==="" && LC_ALL=C bin/ls /tmp/ls-test-fixture && echo ""=== AC3 -a ==="" && LC_ALL=C bin/ls -a /tmp/ls-test-fixture && echo ""=== AC3 -A ==="" && LC_ALL=C bin/ls -A /tmp/ls-test-fixture && ec",echo,False,400,0
+243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,39,25,Bash,"echo ""=== AC2 ==="" && LC_ALL=C bin/ls /tmp/ls-test-fixture && echo ""=== AC3 -a ==="" && LC_ALL=C bin/ls -a /tmp/ls-test-fixture && echo ""=== AC3 -A ==="" && LC_ALL=C bin/ls -A /tmp/ls-test-fixture && ec",setup,False,400,0
 243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,41,26,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/243/cmd/ls/main.go,,False,5971,0
 243,numeric,gh-206-generation-run-14,d435111c-0cb8-4c04-97d5-71917f93f264,,42,27,TodoWrite,"{""todos"": [{""content"": ""Read required reading files not in context"", ""status"": ""completed"", ""activeForm"": ""Reading required reading files""}, {""content"": ""Implement cmd/ls/main.go"", ""status"": ""complete",,False,160,0
 244,numeric,gh-206-generation-run-14,fa1a185f-f542-4dc2-bd9b-cebd102d6c86,,2,1,TodoWrite,"{""todos"": [{""content"": ""Create cmd/ls/ls_test.go with differential tests"", ""status"": ""in_progress"", ""activeForm"": ""Creating ls differential test file""}, {""content"": ""Verify compilation and run tests"",",,False,160,0
@@ -1628,13 +1628,13 @@ printf 'new content\n' | ./bin/sponge -a /tmp/sponge_append_new.txt && cat /tmp/
 247,numeric,gh-206-generation-run-14,5db64dcf-77d9-43f9-86cc-418e9c0d9211,,36,20,Bash,go build ./... 2>&1,go_build,False,0,0
 247,numeric,gh-206-generation-run-14,5db64dcf-77d9-43f9-86cc-418e9c0d9211,,37,21,Bash,go test ./pkg/... -count=1 2>&1,go_test,False,182,0
 247,numeric,gh-206-generation-run-14,5db64dcf-77d9-43f9-86cc-418e9c0d9211,,39,22,Bash,"mkdir -p /tmp/ls-color-test && mkdir -p /tmp/ls-color-test/subdir && echo ""test"" > /tmp/ls-color-test/file.txt && echo ""test"" > /tmp/ls-color-test/subdir/nested.txt 2>&1",mkdir,False,0,0
-247,numeric,gh-206-generation-run-14,5db64dcf-77d9-43f9-86cc-418e9c0d9211,,40,23,Bash,bin/ls --color=always /tmp/ls-color-test 2>&1 | cat -v,other,False,36,0
-247,numeric,gh-206-generation-run-14,5db64dcf-77d9-43f9-86cc-418e9c0d9211,,42,24,Bash,bin/ls --color=never /tmp/ls-color-test 2>&1 | cat -v,other,False,15,0
-247,numeric,gh-206-generation-run-14,5db64dcf-77d9-43f9-86cc-418e9c0d9211,,44,25,Bash,bin/ls --color=auto /tmp/ls-color-test 2>&1 | cat -v,other,False,15,0
-247,numeric,gh-206-generation-run-14,5db64dcf-77d9-43f9-86cc-418e9c0d9211,,46,26,Bash,bin/ls /tmp/ls-color-test 2>&1 | cat -v,other,False,15,0
+247,numeric,gh-206-generation-run-14,5db64dcf-77d9-43f9-86cc-418e9c0d9211,,40,23,Bash,bin/ls --color=always /tmp/ls-color-test 2>&1 | cat -v,binary_run,False,36,0
+247,numeric,gh-206-generation-run-14,5db64dcf-77d9-43f9-86cc-418e9c0d9211,,42,24,Bash,bin/ls --color=never /tmp/ls-color-test 2>&1 | cat -v,binary_run,False,15,0
+247,numeric,gh-206-generation-run-14,5db64dcf-77d9-43f9-86cc-418e9c0d9211,,44,25,Bash,bin/ls --color=auto /tmp/ls-color-test 2>&1 | cat -v,binary_run,False,15,0
+247,numeric,gh-206-generation-run-14,5db64dcf-77d9-43f9-86cc-418e9c0d9211,,46,26,Bash,bin/ls /tmp/ls-color-test 2>&1 | cat -v,binary_run,False,15,0
 247,numeric,gh-206-generation-run-14,5db64dcf-77d9-43f9-86cc-418e9c0d9211,,48,27,Bash,"mkdir -p /tmp/ls-multi-test && for f in alpha bravo charlie delta echo foxtrot; do echo ""x"" > ""/tmp/ls-multi-test/$f""; done && mkdir -p /tmp/ls-multi-test/golf && bin/ls -C --color=always /tmp/ls-mult",mkdir,False,120,0
-247,numeric,gh-206-generation-run-14,5db64dcf-77d9-43f9-86cc-418e9c0d9211,,49,28,Bash,bin/ls -C --color=never /tmp/ls-multi-test 2>&1,other,False,49,0
-247,numeric,gh-206-generation-run-14,5db64dcf-77d9-43f9-86cc-418e9c0d9211,,51,29,Bash,bin/ls --color=always /tmp/ls-color-test/file.txt /tmp/ls-color-test/subdir 2>&1 | cat -v,other,False,86,0
+247,numeric,gh-206-generation-run-14,5db64dcf-77d9-43f9-86cc-418e9c0d9211,,49,28,Bash,bin/ls -C --color=never /tmp/ls-multi-test 2>&1,binary_run,False,49,0
+247,numeric,gh-206-generation-run-14,5db64dcf-77d9-43f9-86cc-418e9c0d9211,,51,29,Bash,bin/ls --color=always /tmp/ls-color-test/file.txt /tmp/ls-color-test/subdir 2>&1 | cat -v,binary_run,False,86,0
 247,numeric,gh-206-generation-run-14,5db64dcf-77d9-43f9-86cc-418e9c0d9211,,53,30,Bash,rm -rf /tmp/ls-color-test /tmp/ls-multi-test bin/ls,rm,False,0,0
 247,numeric,gh-206-generation-run-14,5db64dcf-77d9-43f9-86cc-418e9c0d9211,,54,31,TodoWrite,"{""todos"": [{""content"": ""Add lsEntry struct type to cmd/ls/main.go"", ""status"": ""completed"", ""activeForm"": ""Adding lsEntry struct type""}, {""content"": ""Add --color flag parsing and handling"", ""status"": """,,False,160,0
 248,numeric,gh-206-generation-run-14,64c2bce3-b259-4057-adc4-4205f4f13414,,2,1,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/248/docs/specs/product-requirements/prd006-cat.yaml,,False,7605,0
@@ -1689,14 +1689,14 @@ printf 'new content\n' | ./bin/sponge -a /tmp/sponge_append_new.txt && cat /tmp/
 255,numeric,gh-206-generation-run-14,3ad970d4-648f-4b6b-893e-07e6492ea4fc,,11,8,TodoWrite,"{""todos"": [{""content"": ""Create cmd/true/main.go per prd012-true"", ""status"": ""completed"", ""activeForm"": ""Creating cmd/true/main.go""}, {""content"": ""Create cmd/false/main.go per prd013-false"", ""status"": ",,False,160,0
 255,numeric,gh-206-generation-run-14,3ad970d4-648f-4b6b-893e-07e6492ea4fc,,13,9,Bash,"go build -o bin/true ./cmd/true/ && echo ""true: build OK""",go_build,False,14,0
 255,numeric,gh-206-generation-run-14,3ad970d4-648f-4b6b-893e-07e6492ea4fc,,14,10,Bash,"go build -o bin/false ./cmd/false/ && echo ""false: build OK""",go_build,False,15,0
-255,numeric,gh-206-generation-run-14,3ad970d4-648f-4b6b-893e-07e6492ea4fc,,15,11,Bash,"bin/true; echo ""exit code: $?""",other,False,12,0
-255,numeric,gh-206-generation-run-14,3ad970d4-648f-4b6b-893e-07e6492ea4fc,,16,12,Bash,"bin/false; echo ""exit code: $?""",other,False,12,0
-255,numeric,gh-206-generation-run-14,3ad970d4-648f-4b6b-893e-07e6492ea4fc,,17,13,Bash,"bin/true foo bar --unknown; echo ""exit code: $?""",other,False,12,0
-255,numeric,gh-206-generation-run-14,3ad970d4-648f-4b6b-893e-07e6492ea4fc,,18,14,Bash,"bin/false foo bar --unknown; echo ""exit code: $?""",other,False,12,0
-255,numeric,gh-206-generation-run-14,3ad970d4-648f-4b6b-893e-07e6492ea4fc,,20,15,Bash,"bin/true --help; echo ""exit code: $?""",other,False,218,0
-255,numeric,gh-206-generation-run-14,3ad970d4-648f-4b6b-893e-07e6492ea4fc,,21,16,Bash,"bin/false --help; echo ""exit code: $?""",other,False,220,0
-255,numeric,gh-206-generation-run-14,3ad970d4-648f-4b6b-893e-07e6492ea4fc,,22,17,Bash,"bin/true --version; echo ""exit code: $?""",other,False,16,0
-255,numeric,gh-206-generation-run-14,3ad970d4-648f-4b6b-893e-07e6492ea4fc,,23,18,Bash,"bin/false --version; echo ""exit code: $?""",other,False,16,0
+255,numeric,gh-206-generation-run-14,3ad970d4-648f-4b6b-893e-07e6492ea4fc,,15,11,Bash,"bin/true; echo ""exit code: $?""",binary_run,False,12,0
+255,numeric,gh-206-generation-run-14,3ad970d4-648f-4b6b-893e-07e6492ea4fc,,16,12,Bash,"bin/false; echo ""exit code: $?""",binary_run,False,12,0
+255,numeric,gh-206-generation-run-14,3ad970d4-648f-4b6b-893e-07e6492ea4fc,,17,13,Bash,"bin/true foo bar --unknown; echo ""exit code: $?""",binary_run,False,12,0
+255,numeric,gh-206-generation-run-14,3ad970d4-648f-4b6b-893e-07e6492ea4fc,,18,14,Bash,"bin/false foo bar --unknown; echo ""exit code: $?""",binary_run,False,12,0
+255,numeric,gh-206-generation-run-14,3ad970d4-648f-4b6b-893e-07e6492ea4fc,,20,15,Bash,"bin/true --help; echo ""exit code: $?""",binary_run,False,218,0
+255,numeric,gh-206-generation-run-14,3ad970d4-648f-4b6b-893e-07e6492ea4fc,,21,16,Bash,"bin/false --help; echo ""exit code: $?""",binary_run,False,220,0
+255,numeric,gh-206-generation-run-14,3ad970d4-648f-4b6b-893e-07e6492ea4fc,,22,17,Bash,"bin/true --version; echo ""exit code: $?""",binary_run,False,16,0
+255,numeric,gh-206-generation-run-14,3ad970d4-648f-4b6b-893e-07e6492ea4fc,,23,18,Bash,"bin/false --version; echo ""exit code: $?""",binary_run,False,16,0
 255,numeric,gh-206-generation-run-14,3ad970d4-648f-4b6b-893e-07e6492ea4fc,,25,19,TodoWrite,"{""todos"": [{""content"": ""Create cmd/true/main.go per prd012-true"", ""status"": ""completed"", ""activeForm"": ""Creating cmd/true/main.go""}, {""content"": ""Create cmd/false/main.go per prd013-false"", ""status"": ",,False,160,0
 256,numeric,gh-206-generation-run-14,2b6493b5-44ef-4116-82c3-7bf161174670,,3,1,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/256/docs/specs/product-requirements/prd013-false.yaml,,False,4292,0
 256,numeric,gh-206-generation-run-14,2b6493b5-44ef-4116-82c3-7bf161174670,,5,2,Write,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/256/cmd/false/false_test.go,,False,130,0
@@ -1753,9 +1753,9 @@ printf 'new content\n' | ./bin/sponge -a /tmp/sponge_append_new.txt && cat /tmp/
 280,numeric,gh-262-codegen,278ea2bf-8175-4107-871d-11b3bb989640,,28,18,TodoWrite,"{""todos"": [{""content"": ""Create pkg/format/columns.go (Columns, PadRight, PadLeft)"", ""status"": ""completed"", ""activeForm"": ""Creating pkg/format/columns.go""}, {""content"": ""Create pkg/format/color.go (Fil",,False,160,0
 280,numeric,gh-262-codegen,278ea2bf-8175-4107-871d-11b3bb989640,,29,19,Bash,go test ./pkg/format/... -v 2>&1,go_test,False,6477,0
 280,numeric,gh-262-codegen,278ea2bf-8175-4107-871d-11b3bb989640,,32,20,TodoWrite,"{""todos"": [{""content"": ""Create pkg/format/columns.go (Columns, PadRight, PadLeft)"", ""status"": ""completed"", ""activeForm"": ""Creating pkg/format/columns.go""}, {""content"": ""Create pkg/format/color.go (Fil",,False,160,0
-280,numeric,gh-262-codegen,278ea2bf-8175-4107-871d-11b3bb989640,,33,21,Bash,golangci-lint run ./pkg/format/... 2>&1,other,True,384,0
+280,numeric,gh-262-codegen,278ea2bf-8175-4107-871d-11b3bb989640,,33,21,Bash,golangci-lint run ./pkg/format/... 2>&1,lint,True,384,0
 280,numeric,gh-262-codegen,278ea2bf-8175-4107-871d-11b3bb989640,,36,22,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/280/pkg/format/color_test.go,,False,141,0
-280,numeric,gh-262-codegen,278ea2bf-8175-4107-871d-11b3bb989640,,37,23,Bash,golangci-lint run ./pkg/format/... 2>&1,other,False,9,0
+280,numeric,gh-262-codegen,278ea2bf-8175-4107-871d-11b3bb989640,,37,23,Bash,golangci-lint run ./pkg/format/... 2>&1,lint,False,9,0
 280,numeric,gh-262-codegen,278ea2bf-8175-4107-871d-11b3bb989640,,38,24,Bash,go test ./pkg/format/... 2>&1,go_test,False,60,0
 280,numeric,gh-262-codegen,278ea2bf-8175-4107-871d-11b3bb989640,,39,25,TodoWrite,"{""todos"": [{""content"": ""Create pkg/format/columns.go (Columns, PadRight, PadLeft)"", ""status"": ""completed"", ""activeForm"": ""Creating pkg/format/columns.go""}, {""content"": ""Create pkg/format/color.go (Fil",,False,160,0
 282,numeric,gh-262-codegen,8182f0d5-ce13-4695-a0f7-0019cb776689,,2,1,Read,/home/crumbs/.claude/projects/-var-folders-dl-cbns6zkx7txc7pt64b6cgzp40000gn-T-go-unix-utils-worktrees-282/memory/MEMORY.md,,True,138,0
@@ -1781,7 +1781,7 @@ printf 'new content\n' | ./bin/sponge -a /tmp/sponge_append_new.txt && cat /tmp/
 287,numeric,gh-262-codegen,d9efc00c-de85-4587-a818-7b80ecd56cee,,6,3,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/287/pkg/testutils/difftest_test.go,,False,5318,0
 287,numeric,gh-262-codegen,d9efc00c-de85-4587-a818-7b80ecd56cee,,9,4,Bash,go build ./pkg/testutils/...,go_build,False,0,0
 287,numeric,gh-262-codegen,d9efc00c-de85-4587-a818-7b80ecd56cee,,10,5,Bash,go test ./pkg/testutils/... -v 2>&1,go_test,False,456,0
-287,numeric,gh-262-codegen,d9efc00c-de85-4587-a818-7b80ecd56cee,,13,6,Bash,"which golangci-lint && golangci-lint run ./pkg/testutils/... 2>&1 || echo ""golangci-lint not in PATH""",other,False,43,0
+287,numeric,gh-262-codegen,d9efc00c-de85-4587-a818-7b80ecd56cee,,13,6,Bash,"which golangci-lint && golangci-lint run ./pkg/testutils/... 2>&1 || echo ""golangci-lint not in PATH""",env_check,False,43,0
 289,numeric,gh-262-codegen,8b24164a-b953-4d71-be3c-fb712decc881,,2,1,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/289/docs/specs/product-requirements/prd002-sys.yaml,,False,8460,0
 289,numeric,gh-262-codegen,8b24164a-b953-4d71-be3c-fb712decc881,,3,2,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/289/docs/specs/use-cases/rel00.0-uc003-sys.yaml,,False,4137,0
 289,numeric,gh-262-codegen,8b24164a-b953-4d71-be3c-fb712decc881,,4,3,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/289/go.mod,,False,491,0
@@ -1798,35 +1798,35 @@ printf 'new content\n' | ./bin/sponge -a /tmp/sponge_append_new.txt && cat /tmp/
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,16,11,Write,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/290/.golangci.yml,,False,120,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,17,12,TodoWrite,"{""todos"": [{""content"": ""Create cmd/version/main.go"", ""status"": ""completed"", ""activeForm"": ""Creating cmd/version/main.go""}, {""content"": ""Create .golangci.yml"", ""status"": ""completed"", ""activeForm"": ""Cre",,False,160,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,19,13,Bash,go build -o bin/version ./cmd/version/ 2>&1,go_build,False,0,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,20,14,Bash,"echo ""=== AC2: no args ==="" && ./bin/version; echo ""exit: $?"" && echo ""=== AC3: --version ==="" && ./bin/version --version; echo ""exit: $?"" && echo ""=== AC3: -v ==="" && ./bin/version -v; echo ""exit: $?",echo,False,95,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,21,15,Bash,"echo ""=== AC4: unknown flag ==="" && ./bin/version --bogus 2>&1; echo ""exit: $?"" && ./bin/version --bogus 2>/dev/null; echo ""exit (stdout suppressed): $?""",echo,False,93,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,22,16,Bash,"echo ""=== ldflags injection (S7 / dev build) ==="" && ./bin/version && echo ""=== Build with injected tag ==="" && go build -ldflags ""-X main.version=v0.20260305.0"" -o bin/version ./cmd/version/ && ./bin",echo,False,100,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,20,14,Bash,"echo ""=== AC2: no args ==="" && ./bin/version; echo ""exit: $?"" && echo ""=== AC3: --version ==="" && ./bin/version --version; echo ""exit: $?"" && echo ""=== AC3: -v ==="" && ./bin/version -v; echo ""exit: $?",binary_exercise,False,95,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,21,15,Bash,"echo ""=== AC4: unknown flag ==="" && ./bin/version --bogus 2>&1; echo ""exit: $?"" && ./bin/version --bogus 2>/dev/null; echo ""exit (stdout suppressed): $?""",binary_exercise,False,93,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,22,16,Bash,"echo ""=== ldflags injection (S7 / dev build) ==="" && ./bin/version && echo ""=== Build with injected tag ==="" && go build -ldflags ""-X main.version=v0.20260305.0"" -o bin/version ./cmd/version/ && ./bin",binary_exercise,False,100,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,24,17,Bash,"go build ./cmd/version/... 2>&1; echo ""exit: $?""",go_build,False,7,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,25,18,Bash,"go vet ./cmd/version/... 2>&1; echo ""exit: $?""",go_vet,False,7,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,26,19,Bash,"which golangci-lint 2>/dev/null && golangci-lint --version 2>&1 || echo ""golangci-lint not in PATH""",other,False,187,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,29,20,Bash,"golangci-lint run ./cmd/... ./pkg/... 2>&1; echo ""exit: $?""",other,False,341,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,26,19,Bash,"which golangci-lint 2>/dev/null && golangci-lint --version 2>&1 || echo ""golangci-lint not in PATH""",env_check,False,187,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,29,20,Bash,"golangci-lint run ./cmd/... ./pkg/... 2>&1; echo ""exit: $?""",lint,False,341,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,31,21,WebFetch,"{""url"": ""https://golangci-lint.run/product/migration-guide"", ""prompt"": ""What are the key configuration format changes in golangci-lint v2? Specifically, what replaced disable-all: true, how do you ena",,False,700,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,32,22,Bash,golangci-lint config path 2>&1 | head -5; golangci-lint help linters 2>&1 | head -30,other,False,2668,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,33,23,Bash,"golangci-lint help linters 2>&1 | grep -E ""gochecknoglobals|gofmt|revive|misspell|gosimple""",other,False,244,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,34,24,Bash,"golangci-lint help linters 2>&1 | grep -E ""gofmt|goimports|gosimple""",other,False,0,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,36,25,Bash,"golangci-lint help linters 2>&1 | grep -E ""^(errcheck|govet|staticcheck|ineffassign|unused|gofmt|gosimple|revive|gochecknoglobals|misspell|goimports)""",other,False,740,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,38,26,Bash,golangci-lint run --no-config ./cmd/... 2>&1 | head -20,other,False,9,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,32,22,Bash,golangci-lint config path 2>&1 | head -5; golangci-lint help linters 2>&1 | head -30,lint,False,2668,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,33,23,Bash,"golangci-lint help linters 2>&1 | grep -E ""gochecknoglobals|gofmt|revive|misspell|gosimple""",lint,False,244,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,34,24,Bash,"golangci-lint help linters 2>&1 | grep -E ""gofmt|goimports|gosimple""",lint,False,0,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,36,25,Bash,"golangci-lint help linters 2>&1 | grep -E ""^(errcheck|govet|staticcheck|ineffassign|unused|gofmt|gosimple|revive|gochecknoglobals|misspell|goimports)""",lint,False,740,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,38,26,Bash,golangci-lint run --no-config ./cmd/... 2>&1 | head -20,lint,False,9,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,40,27,Write,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/290/.golangci.yml,,False,130,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,41,28,Bash,"golangci-lint run ./cmd/... ./pkg/... 2>&1; echo ""exit: $?""",other,False,272,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,41,28,Bash,"golangci-lint run ./cmd/... ./pkg/... 2>&1; echo ""exit: $?""",lint,False,272,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,44,29,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/290/.golangci.yml,,False,130,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,45,30,Bash,"golangci-lint run ./cmd/... ./pkg/... 2>&1; echo ""exit: $?""",other,False,272,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,47,31,Bash,golangci-lint run --no-config --disable-all --enable gochecknoglobals ./pkg/format/... 2>&1,other,True,212,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,48,32,Bash,golangci-lint run --no-config --enable gochecknoglobals ./pkg/format/... 2>&1,other,True,542,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,45,30,Bash,"golangci-lint run ./cmd/... ./pkg/... 2>&1; echo ""exit: $?""",lint,False,272,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,47,31,Bash,golangci-lint run --no-config --disable-all --enable gochecknoglobals ./pkg/format/... 2>&1,lint,True,212,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,48,32,Bash,golangci-lint run --no-config --enable gochecknoglobals ./pkg/format/... 2>&1,lint,True,542,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,51,33,Bash,"cat -A /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/290/.golangci.yml | grep -A2 ""test""",cat,False,149,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,52,34,Bash,golangci-lint config verify 2>&1 | head -20,other,False,333,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,54,35,Bash,golangci-lint config --help 2>&1,other,False,594,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,55,36,Bash,golangci-lint run --dump-config 2>/dev/null | head -80,other,False,0,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,56,37,Bash,golangci-lint run --print-issued-lines --print-linter-name --no-config ./cmd/... 2>&1 | head -20,other,False,113,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,52,34,Bash,golangci-lint config verify 2>&1 | head -20,lint,False,333,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,54,35,Bash,golangci-lint config --help 2>&1,lint,False,594,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,55,36,Bash,golangci-lint run --dump-config 2>/dev/null | head -80,lint,False,0,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,56,37,Bash,golangci-lint run --print-issued-lines --print-linter-name --no-config ./cmd/... 2>&1 | head -20,lint,False,113,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,57,38,WebFetch,"{""url"": ""https://raw.githubusercontent.com/golangci/golangci-lint/v2.1.6/pkg/config/config.go"", ""prompt"": ""What are the top-level struct fields for the golangci-lint v2 Config struct? Specifically wha",,False,754,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,58,39,Bash,"golangci-lint run --no-config ./cmd/... ./pkg/... 2>&1 && echo ""PASS: no issues with default linters""",other,False,46,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,58,39,Bash,"golangci-lint run --no-config ./cmd/... ./pkg/... 2>&1 && echo ""PASS: no issues with default linters""",lint,False,46,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,60,40,Bash,"find /home/crumbs/go -name ""*.go"" -path ""*/golangci-lint/pkg/config/*"" 2>/dev/null | head -10",find,False,0,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,61,41,Bash,"find / -name ""golangci-lint"" -type f 2>/dev/null | head -5; ls $(which golangci-lint 2>/dev/null | xargs dirname 2>/dev/null) 2>/dev/null",find,False,52,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,62,42,Bash,"golangci-lint run --no-config 2>&1 | head -5; echo ""---""; golangci-lint version 2>&1",other,False,167,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,62,42,Bash,"golangci-lint run --no-config 2>&1 | head -5; echo ""---""; golangci-lint version 2>&1",lint,False,167,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,63,43,WebFetch,"{""url"": ""https://golangci-lint.run/usage/configuration/"", ""prompt"": ""What is the correct YAML configuration format for golangci-lint v2? Specifically: what replaced 'linters-settings' and 'issues.excl",,False,897,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,64,44,Bash,"cat > /tmp/test-golangci.yml << 'EOF'
 version: ""2""
@@ -1839,7 +1839,7 @@ issues:
     - path: ""_test\\.go""
       linters:
         - gochecknoglobals",cat,True,858,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,66,45,Bash,golangci-lint run --config /tmp/test-golangci.yml ./pkg/... 2>&1,other,True,858,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,66,45,Bash,golangci-lint run --config /tmp/test-golangci.yml ./pkg/... 2>&1,lint,True,858,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,68,46,Bash,"cat > /tmp/test-golangci2.yml << 'EOF'
 version: ""2""
 linters:
@@ -1852,7 +1852,7 @@ issues:
       - path: ""_test\\.go""
         linters:
           - g",cat,True,696,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,70,47,Bash,"golangci-lint run --config /tmp/test-golangci2.yml ./pkg/... 2>&1; echo ""exit: $?""",other,False,430,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,70,47,Bash,"golangci-lint run --config /tmp/test-golangci2.yml ./pkg/... 2>&1; echo ""exit: $?""",lint,False,430,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,72,48,Bash,"cat > /tmp/test-golangci3.yml << 'EOF'
 version: ""2""
 linters:
@@ -1876,13 +1876,13 @@ issues:
     - ""is a global variable""
 EOF
 golangci-lint run --config /tmp/test-g",cat,False,430,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,76,50,Bash,golangci-lint run --config /tmp/test-golangci4.yml config verify 2>&1,other,True,696,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,77,51,Bash,golangci-lint config verify --config /tmp/test-golangci4.yml 2>&1,other,True,436,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,76,50,Bash,golangci-lint run --config /tmp/test-golangci4.yml config verify 2>&1,lint,True,696,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,77,51,Bash,golangci-lint config verify --config /tmp/test-golangci4.yml 2>&1,lint,True,436,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,79,52,Bash,"find / -name ""*.json"" -path ""*golangci*schema*"" 2>/dev/null | head -5; find / -name ""config.go"" -path ""*golangci*config*"" 2>/dev/null | head -5",find,False,0,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,80,53,Bash,"golangci-lint config verify --config /dev/null 2>&1; echo ""---""; cat > /tmp/empty-v2.yml << 'EOF'
 version: ""2""
 EOF
-golangci-lint config verify --config /tmp/empty-v2.yml 2>&1",other,False,185,0
+golangci-lint config verify --config /tmp/empty-v2.yml 2>&1",lint,False,185,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,81,54,Bash,"cat > /tmp/test-issues.yml << 'EOF'
 version: ""2""
 linters:
@@ -1955,7 +1955,7 @@ linters:
       - path: ""_test\\.go""
         linters:
           - gochec",cat,False,0,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,93,61,Bash,"golangci-lint run --config /tmp/test-linters-excl.yml ./pkg/... 2>&1; echo ""exit: $?""",other,False,17,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,93,61,Bash,"golangci-lint run --config /tmp/test-linters-excl.yml ./pkg/... 2>&1; echo ""exit: $?""",lint,False,17,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,95,62,Bash,"cat > /tmp/test-settings.yml << 'EOF'
 version: ""2""
 linters:
@@ -1971,23 +1971,23 @@ golangci-lint config v",cat,False,0,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,97,63,Write,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/290/.golangci.yml,,True,96,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,98,64,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/290/.golangci.yml,,False,2813,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,99,65,Write,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/290/.golangci.yml,,False,130,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,100,66,Bash,"golangci-lint config verify --config /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/290/.golangci.yml 2>&1; echo ""verify exit: $?""",other,False,14,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,102,67,Bash,"golangci-lint run ./cmd/... ./pkg/... 2>&1; echo ""exit: $?""",other,False,17,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,104,68,Bash,"cd magefiles && golangci-lint run --config ../.golangci.yml ./... 2>&1; echo ""exit: $?""",other,False,17,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,106,69,Bash,"echo ""=== AC7: go build ./cmd/version/... ==="" && go build ./cmd/version/... && echo ""PASS"" && echo """" && echo ""=== AC1: Build to bin/version ==="" && go build -o bin/version ./cmd/version/ && ls -la b",echo,True,534,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,108,70,Bash,pwd,other,False,86,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,109,71,Bash,"cd /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/290 && echo ""=== AC7: go build ./cmd/version/... ==="" && go build ./cmd/version/... && echo ""PASS"" && echo """" && echo ""=== A",other,False,413,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,110,72,Bash,"echo ""=== AC2 with ldflags injection ==="" && go build -ldflags ""-X main.version=v0.20260305.0"" -o bin/version ./cmd/version/ && ./bin/version && ./bin/version --version && echo """" && echo ""=== AC5: go",echo,False,122,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,111,73,Bash,"echo ""=== AC6: mage clean test (remove bin/) ==="" && ls bin/ && rm -rf bin/ && ls bin/ 2>&1; echo ""bin/ removed, exit: $?"" && echo """" && echo ""=== AC6: mage clean when bin/ doesn't exist ==="" && ls bi",echo,False,225,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,113,74,Bash,"echo ""=== AC6: rm -rf bin/ when bin/ does not exist ==="" && rm -rf bin/; echo ""exit: $?"" && echo ""=== bin/ still absent ==="" && test ! -d bin/ && echo ""confirmed: bin/ does not exist""",echo,False,114,0
-290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,115,75,Bash,"echo ""--- AC7: go build ./cmd/version/... ---"" && go build ./cmd/version/... && echo ""PASS"" && echo ""--- AC1: bin/version exists after build ---"" && go build -o bin/version ./cmd/version/ && test -f b",echo,False,358,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,100,66,Bash,"golangci-lint config verify --config /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/290/.golangci.yml 2>&1; echo ""verify exit: $?""",lint,False,14,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,102,67,Bash,"golangci-lint run ./cmd/... ./pkg/... 2>&1; echo ""exit: $?""",lint,False,17,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,104,68,Bash,"cd magefiles && golangci-lint run --config ../.golangci.yml ./... 2>&1; echo ""exit: $?""",env_inspect,False,17,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,106,69,Bash,"echo ""=== AC7: go build ./cmd/version/... ==="" && go build ./cmd/version/... && echo ""PASS"" && echo """" && echo ""=== AC1: Build to bin/version ==="" && go build -o bin/version ./cmd/version/ && ls -la b",binary_exercise,True,534,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,108,70,Bash,pwd,env_inspect,False,86,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,109,71,Bash,"cd /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/290 && echo ""=== AC7: go build ./cmd/version/... ==="" && go build ./cmd/version/... && echo ""PASS"" && echo """" && echo ""=== A",env_inspect,False,413,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,110,72,Bash,"echo ""=== AC2 with ldflags injection ==="" && go build -ldflags ""-X main.version=v0.20260305.0"" -o bin/version ./cmd/version/ && ./bin/version && ./bin/version --version && echo """" && echo ""=== AC5: go",binary_exercise,False,122,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,111,73,Bash,"echo ""=== AC6: mage clean test (remove bin/) ==="" && ls bin/ && rm -rf bin/ && ls bin/ 2>&1; echo ""bin/ removed, exit: $?"" && echo """" && echo ""=== AC6: mage clean when bin/ doesn't exist ==="" && ls bi",setup,False,225,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,113,74,Bash,"echo ""=== AC6: rm -rf bin/ when bin/ does not exist ==="" && rm -rf bin/; echo ""exit: $?"" && echo ""=== bin/ still absent ==="" && test ! -d bin/ && echo ""confirmed: bin/ does not exist""",setup,False,114,0
+290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,115,75,Bash,"echo ""--- AC7: go build ./cmd/version/... ---"" && go build ./cmd/version/... && echo ""PASS"" && echo ""--- AC1: bin/version exists after build ---"" && go build -o bin/version ./cmd/version/ && test -f b",binary_exercise,False,358,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,117,76,Bash,"go vet ./... 2>&1; echo ""go vet exit: $?""",go_vet,False,14,0
 290,numeric,gh-262-codegen,d1e27269-084c-48a0-81f5-e7539000574e,,118,77,TodoWrite,"{""todos"": [{""content"": ""Create cmd/version/main.go"", ""status"": ""completed"", ""activeForm"": ""Creating cmd/version/main.go""}, {""content"": ""Create .golangci.yml"", ""status"": ""completed"", ""activeForm"": ""Cre",,False,160,0
 291,numeric,gh-262-codegen,3d47fb82-0e76-4eac-81b0-180fd01d344c,,4,2,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/291/docs/specs/use-cases/rel00.0-uc002-format.yaml,,False,4720,0
 291,numeric,gh-262-codegen,3d47fb82-0e76-4eac-81b0-180fd01d344c,,3,1,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/291/docs/specs/product-requirements/prd003-format.yaml,,False,7918,0
 291,numeric,gh-262-codegen,3d47fb82-0e76-4eac-81b0-180fd01d344c,,7,3,Bash,go build ./pkg/format/... 2>&1,go_build,False,0,0
 291,numeric,gh-262-codegen,3d47fb82-0e76-4eac-81b0-180fd01d344c,,8,4,Bash,go test ./pkg/format/... -v 2>&1,go_test,False,6477,0
-291,numeric,gh-262-codegen,3d47fb82-0e76-4eac-81b0-180fd01d344c,,11,5,Bash,golangci-lint run ./pkg/format/... 2>&1,other,False,9,0
+291,numeric,gh-262-codegen,3d47fb82-0e76-4eac-81b0-180fd01d344c,,11,5,Bash,golangci-lint run ./pkg/format/... 2>&1,lint,False,9,0
 293,numeric,gh-262-codegen,3b50d39a-4f8d-491b-8cca-855d1c6eefbf,,4,2,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/293/go.mod,,False,491,0
 293,numeric,gh-262-codegen,3b50d39a-4f8d-491b-8cca-855d1c6eefbf,,3,1,Glob,docs/specs/product-requirements/prd*cat*.yaml,,False,124,0
 293,numeric,gh-262-codegen,3b50d39a-4f8d-491b-8cca-855d1c6eefbf,,5,3,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/293/docs/specs/product-requirements/prd006-cat.yaml,,False,7945,0
@@ -2003,10 +2003,10 @@ golangci-lint config v",cat,False,0,0
 293,numeric,gh-262-codegen,90933c7d-200f-445e-a73a-ef96b1a7a41e,,10,6,Write,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/293/cmd/cat/main.go,,False,122,0
 293,numeric,gh-262-codegen,90933c7d-200f-445e-a73a-ef96b1a7a41e,,12,7,Bash,go build -o bin/cat ./cmd/cat/ 2>&1,go_build,False,0,0
 293,numeric,gh-262-codegen,90933c7d-200f-445e-a73a-ef96b1a7a41e,,13,8,Bash,go vet ./cmd/cat/ 2>&1,go_vet,False,0,0
-293,numeric,gh-262-codegen,90933c7d-200f-445e-a73a-ef96b1a7a41e,,15,9,Bash,printf 'hello\nworld\n' | ./bin/cat | xxd | head,other,False,63,0
-293,numeric,gh-262-codegen,90933c7d-200f-445e-a73a-ef96b1a7a41e,,16,10,Bash,printf 'alpha\n\nbeta\n' | ./bin/cat -n,other,False,32,0
-293,numeric,gh-262-codegen,90933c7d-200f-445e-a73a-ef96b1a7a41e,,17,11,Bash,printf 'first\n\n\nsecond\n' | ./bin/cat -b,other,False,28,0
-293,numeric,gh-262-codegen,90933c7d-200f-445e-a73a-ef96b1a7a41e,,18,12,Bash,"./bin/cat nonexistent.txt /dev/null 2>&1; echo ""exit: $?""",other,False,77,0
+293,numeric,gh-262-codegen,90933c7d-200f-445e-a73a-ef96b1a7a41e,,15,9,Bash,printf 'hello\nworld\n' | ./bin/cat | xxd | head,binary_exercise,False,63,0
+293,numeric,gh-262-codegen,90933c7d-200f-445e-a73a-ef96b1a7a41e,,16,10,Bash,printf 'alpha\n\nbeta\n' | ./bin/cat -n,binary_exercise,False,32,0
+293,numeric,gh-262-codegen,90933c7d-200f-445e-a73a-ef96b1a7a41e,,17,11,Bash,printf 'first\n\n\nsecond\n' | ./bin/cat -b,binary_exercise,False,28,0
+293,numeric,gh-262-codegen,90933c7d-200f-445e-a73a-ef96b1a7a41e,,18,12,Bash,"./bin/cat nonexistent.txt /dev/null 2>&1; echo ""exit: $?""",binary_run,False,77,0
 293,numeric,gh-262-codegen,90933c7d-200f-445e-a73a-ef96b1a7a41e,,19,13,Bash,"# AC7: verify all flags are accepted without ""flag provided but not defined""
 for flag in n b s E T v A e t u; do
   result=$(printf 'x\n' | ./bin/cat -$flag 2>&1)
@@ -2018,24 +2018,24 @@ printf 'hello\nworld\n' | ./bin/cat | od -c | head
 printf '\x01\x09\x1b\x7f\x80\xff' | ./bin/cat -v | od -c
 
 # Verify -E
-printf 'line one\nline",other,False,212,0
+printf 'line one\nline",binary_exercise,False,212,0
 293,numeric,gh-262-codegen,90933c7d-200f-445e-a73a-ef96b1a7a41e,,23,15,Bash,"# AC6: nonexistent file — error to stderr, exit nonzero, no panic
 # Also verifies that processing continues for other operands
 echo ""data"" > /tmp/real_cat_test.txt
-result_stdout=$(./bin/cat nonexisten",other,False,106,0
+result_stdout=$(./bin/cat nonexisten",setup,False,106,0
 293,numeric,gh-262-codegen,90933c7d-200f-445e-a73a-ef96b1a7a41e,,24,16,Bash,"# Binary passthrough: send all 256 byte values, verify round-trip
 python3 -c ""import sys; sys.stdout.buffer.write(bytes(range(256)))"" | ./bin/cat | wc -c",other,False,47,0
 293,numeric,gh-262-codegen,90933c7d-200f-445e-a73a-ef96b1a7a41e,,25,17,Bash,"# Binary passthrough using printf
 printf '%b' ""$(printf '\\x%02x' $(seq 0 255))"" | ./bin/cat | wc -c 2>/dev/null || \
 # Alternative: use od to create binary data
-dd if=/dev/urandom bs=1 count=256 2>/d",other,False,3,0
+dd if=/dev/urandom bs=1 count=256 2>/d",binary_exercise,False,3,0
 293,numeric,gh-262-codegen,90933c7d-200f-445e-a73a-ef96b1a7a41e,,26,18,Bash,"# Stdin dash operand
-printf 'from stdin\n' | ./bin/cat -",other,False,10,0
+printf 'from stdin\n' | ./bin/cat -",binary_exercise,False,10,0
 293,numeric,gh-262-codegen,90933c7d-200f-445e-a73a-ef96b1a7a41e,,27,19,Bash,"# -u flag: accepted with no effect
-printf 'test\n' | ./bin/cat -u",other,False,4,0
+printf 'test\n' | ./bin/cat -u",binary_exercise,False,4,0
 293,numeric,gh-262-codegen,90933c7d-200f-445e-a73a-ef96b1a7a41e,,28,20,Bash,"# -e and -t aliases
 printf '\x01hello\n' | ./bin/cat -e
-printf '\x01\thello\n' | ./bin/cat -t",other,False,18,0
+printf '\x01\thello\n' | ./bin/cat -t",binary_exercise,False,18,0
 293,numeric,gh-262-codegen,90933c7d-200f-445e-a73a-ef96b1a7a41e,,30,21,TodoWrite,"{""todos"": [{""content"": ""Implement cmd/cat/main.go"", ""status"": ""completed"", ""activeForm"": ""Implementing cmd/cat/main.go""}]}",,False,160,0
 295,numeric,gh-262-codegen,1a95a5d2-6a7e-4f46-be9a-8dc65ffccd7e,,2,1,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/295/docs/specs/product-requirements/prd002-sys.yaml,,False,8460,0
 295,numeric,gh-262-codegen,1a95a5d2-6a7e-4f46-be9a-8dc65ffccd7e,,3,2,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/295/docs/specs/use-cases/rel00.0-uc003-sys.yaml,,False,4137,0
@@ -2055,9 +2055,9 @@ printf '\x01\thello\n' | ./bin/cat -t",other,False,18,0
 295,numeric,gh-262-codegen,1a95a5d2-6a7e-4f46-be9a-8dc65ffccd7e,,23,16,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/295/pkg/sys/sys_linux.go,,False,137,0
 295,numeric,gh-262-codegen,1a95a5d2-6a7e-4f46-be9a-8dc65ffccd7e,,24,17,Bash,go build ./pkg/sys/... 2>&1,go_build,False,0,0
 295,numeric,gh-262-codegen,1a95a5d2-6a7e-4f46-be9a-8dc65ffccd7e,,25,18,Bash,go test ./pkg/sys/... -v 2>&1,go_test,False,1126,0
-295,numeric,gh-262-codegen,1a95a5d2-6a7e-4f46-be9a-8dc65ffccd7e,,28,19,Bash,golangci-lint run ./pkg/sys/... 2>&1,other,True,232,0
+295,numeric,gh-262-codegen,1a95a5d2-6a7e-4f46-be9a-8dc65ffccd7e,,28,19,Bash,golangci-lint run ./pkg/sys/... 2>&1,lint,True,232,0
 295,numeric,gh-262-codegen,1a95a5d2-6a7e-4f46-be9a-8dc65ffccd7e,,31,20,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/295/pkg/sys/sys.go,,False,131,0
-295,numeric,gh-262-codegen,1a95a5d2-6a7e-4f46-be9a-8dc65ffccd7e,,32,21,Bash,golangci-lint run ./pkg/sys/... 2>&1,other,False,9,0
+295,numeric,gh-262-codegen,1a95a5d2-6a7e-4f46-be9a-8dc65ffccd7e,,32,21,Bash,golangci-lint run ./pkg/sys/... 2>&1,lint,False,9,0
 295,numeric,gh-262-codegen,1a95a5d2-6a7e-4f46-be9a-8dc65ffccd7e,,34,22,Bash,"go build ./pkg/sys/... && echo ""AC1: build OK"" && go test ./pkg/sys/... -count=1 2>&1 | tail -3",go_build,False,71,0
 295,numeric,gh-262-codegen,1a95a5d2-6a7e-4f46-be9a-8dc65ffccd7e,,35,23,TodoWrite,"{""todos"": [{""content"": ""Write pkg/sys/sys.go (portable interface)"", ""status"": ""completed"", ""activeForm"": ""Writing pkg/sys/sys.go""}, {""content"": ""Write pkg/sys/sys_darwin.go (Darwin fillFromStat)"", ""st",,False,160,0
 297,numeric,gh-262-codegen,a37955b4-bb6b-4f86-bd5e-f3601e429336,,2,1,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/297/docs/specs/product-requirements/prd006-cat.yaml,,False,7945,0
@@ -2069,7 +2069,7 @@ printf '\x01\thello\n' | ./bin/cat -t",other,False,18,0
 297,numeric,gh-262-codegen,a37955b4-bb6b-4f86-bd5e-f3601e429336,,13,7,TodoWrite,"{""todos"": [{""content"": ""Write cmd/cat/cat_test.go with differential tests"", ""status"": ""in_progress"", ""activeForm"": ""Writing cmd/cat/cat_test.go""}]}",,False,160,0
 297,numeric,gh-262-codegen,a37955b4-bb6b-4f86-bd5e-f3601e429336,,14,8,Write,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/297/cmd/cat/cat_test.go,,False,126,0
 297,numeric,gh-262-codegen,a37955b4-bb6b-4f86-bd5e-f3601e429336,,16,9,Bash,go test ./cmd/cat/... -v -timeout 60s 2>&1,go_test,False,2702,0
-297,numeric,gh-262-codegen,a37955b4-bb6b-4f86-bd5e-f3601e429336,,19,10,Bash,golangci-lint run ./cmd/cat/... 2>&1,other,False,9,0
+297,numeric,gh-262-codegen,a37955b4-bb6b-4f86-bd5e-f3601e429336,,19,10,Bash,golangci-lint run ./cmd/cat/... 2>&1,lint,False,9,0
 297,numeric,gh-262-codegen,a37955b4-bb6b-4f86-bd5e-f3601e429336,,20,11,TodoWrite,"{""todos"": [{""content"": ""Write cmd/cat/cat_test.go with differential tests"", ""status"": ""completed"", ""activeForm"": ""Writing cmd/cat/cat_test.go""}]}",,False,160,0
 299,numeric,gh-262-codegen,3c153ef2-0d9c-4f2c-8d00-f7e3c10fc7d9,,2,1,Read,/home/crumbs/.claude/projects/-var-folders-dl-cbns6zkx7txc7pt64b6cgzp40000gn-T-go-unix-utils-worktrees-299/memory/MEMORY.md,,True,138,0
 299,numeric,gh-262-codegen,d8266a09-e27e-462d-af56-a4235225edc7,,2,1,TodoWrite,"{""todos"": [{""content"": ""Read required PRD, use case, and test suite specs"", ""status"": ""in_progress"", ""activeForm"": ""Reading required specifications""}, {""content"": ""Implement cmd/sponge/main.go"", ""stat",,False,160,0
@@ -2086,9 +2086,9 @@ printf '\x01\thello\n' | ./bin/cat -t",other,False,18,0
 299,numeric,gh-262-codegen,ba08a93c-fe73-45cd-8a2a-5e1c0ea1eb8e,,14,11,TodoWrite,"{""todos"": [{""content"": ""Read PRD and use case specs for sponge"", ""status"": ""completed"", ""activeForm"": ""Reading PRD and use case specs for sponge""}, {""content"": ""Implement cmd/sponge/main.go"", ""status""",,False,160,0
 299,numeric,gh-262-codegen,ba08a93c-fe73-45cd-8a2a-5e1c0ea1eb8e,,16,12,Bash,go build -o bin/sponge ./cmd/sponge/,go_build,False,0,0
 299,numeric,gh-262-codegen,ba08a93c-fe73-45cd-8a2a-5e1c0ea1eb8e,,18,13,Bash,go test -v ./cmd/sponge/ 2>&1,go_test,False,1972,0
-299,numeric,gh-262-codegen,ba08a93c-fe73-45cd-8a2a-5e1c0ea1eb8e,,20,14,Bash,golangci-lint run ./cmd/sponge/ 2>&1,other,True,450,0
+299,numeric,gh-262-codegen,ba08a93c-fe73-45cd-8a2a-5e1c0ea1eb8e,,20,14,Bash,golangci-lint run ./cmd/sponge/ 2>&1,lint,True,450,0
 299,numeric,gh-262-codegen,ba08a93c-fe73-45cd-8a2a-5e1c0ea1eb8e,,22,15,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/299/cmd/sponge/main.go,,False,135,0
-299,numeric,gh-262-codegen,ba08a93c-fe73-45cd-8a2a-5e1c0ea1eb8e,,23,16,Bash,golangci-lint run ./cmd/sponge/ 2>&1,other,False,9,0
+299,numeric,gh-262-codegen,ba08a93c-fe73-45cd-8a2a-5e1c0ea1eb8e,,23,16,Bash,golangci-lint run ./cmd/sponge/ 2>&1,lint,False,9,0
 299,numeric,gh-262-codegen,ba08a93c-fe73-45cd-8a2a-5e1c0ea1eb8e,,25,17,Bash,go test ./cmd/sponge/ 2>&1,go_test,False,60,0
 299,numeric,gh-262-codegen,ba08a93c-fe73-45cd-8a2a-5e1c0ea1eb8e,,27,18,TodoWrite,"{""todos"": [{""content"": ""Read PRD and use case specs for sponge"", ""status"": ""completed"", ""activeForm"": ""Reading PRD and use case specs for sponge""}, {""content"": ""Implement cmd/sponge/main.go"", ""status""",,False,160,0
 304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,3,2,Glob,docs/specs/product-requirements/prd*du*.yaml,,False,123,0
@@ -2096,7 +2096,7 @@ printf '\x01\thello\n' | ./bin/cat -t",other,False,18,0
 304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,5,4,Read,/var/folders/dl/cbns6zkx7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/304/docs/specs/test-suites/test-rel01.3.yaml,,True,58,0
 304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,6,5,Bash,"find /var/folders/dl/cbns6zkx7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/304 -name ""*rel01.3-uc001-du.yaml"" -o -name ""*test-rel01.3.yaml""",find,False,0,0
 304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,7,6,Read,/var/folders/dl/cbns6zkx7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/304/docs/specs/product-requirements/prd009-du.yaml,,True,138,0
-304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,8,7,Bash,pwd && ls -la,other,False,0,0
+304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,8,7,Bash,pwd && ls -la,env_inspect,False,0,0
 304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,9,8,Bash,"find /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/304/docs -type f -name ""*rel01.3-uc001-du.yaml"" -o -name ""*test-rel01.3.yaml"" 2>/dev/null",find,False,0,0
 304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,10,9,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/304/docs/specs/product-requirements/prd009-du.yaml,,False,10280,0
 304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,11,10,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/304/docs/specs/use-cases/rel01.3-uc001-du.yaml,,False,4840,0
@@ -2111,11 +2111,11 @@ printf '\x01\thello\n' | ./bin/cat -t",other,False,18,0
 304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,21,18,Bash,go build -o bin/du ./cmd/du/ 2>&1,go_build,False,0,0
 304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,23,19,TodoWrite,"{""todos"": [{""content"": ""Create cmd/du/main.go with full du implementation"", ""status"": ""completed"", ""activeForm"": ""Creating cmd/du/main.go""}, {""content"": ""Verify compilation with go build ./cmd/du/"", """,,False,160,0
 304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,24,20,Bash,"mkdir -p /tmp/du-test/subdir1/deep && mkdir -p /tmp/du-test/subdir2 && echo ""hello world this is a test file with some content"" > /tmp/du-test/file1.txt && echo ""another file"" > /tmp/du-test/subdir1/f",mkdir,False,0,0
-304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,25,21,Bash,"echo ""=== AC2: Default recursive output ==="" && ./bin/du -k /tmp/du-test/ && echo """" && echo ""=== AC3: -s flag ==="" && ./bin/du -sk /tmp/du-test/ && echo """" && echo ""=== AC4: -c flag ==="" && ./bin/du ",echo,True,1786,0
-304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,28,22,Bash,"echo ""=== AC2: Default recursive output ==="" && ./bin/du -k /tmp/du-test/ && echo """" && echo ""=== AC3: -s flag ==="" && ./bin/du -s -k /tmp/du-test/ && echo """" && echo ""=== AC4: -c flag ==="" && ./bin/d",echo,False,397,0
-304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,30,23,Bash,"echo ""=== AC6: Hard-link deduplication ==="" && mkdir -p /tmp/du-hardlink/dir_a /tmp/du-hardlink/dir_b && dd if=/dev/zero of=/tmp/du-hardlink/dir_a/shared.txt bs=1024 count=8 2>/dev/null && ln /tmp/du-",echo,False,390,0
-304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,33,24,Bash,"echo ""=== Depth limiting -d 1 ==="" && ./bin/du -k -d 1 /tmp/du-test/ && echo """" && echo ""=== Depth limiting -d 0 (like -s) ==="" && ./bin/du -k -d 0 /tmp/du-test/ && echo """" && echo ""=== All files -a =",echo,False,718,0
-304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,34,25,Bash,"echo ""=== Default (no args, current dir) ==="" && cd /tmp/du-test && /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/304/bin/du -k .",echo,False,84,100
+304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,25,21,Bash,"echo ""=== AC2: Default recursive output ==="" && ./bin/du -k /tmp/du-test/ && echo """" && echo ""=== AC3: -s flag ==="" && ./bin/du -sk /tmp/du-test/ && echo """" && echo ""=== AC4: -c flag ==="" && ./bin/du ",binary_exercise,True,1786,0
+304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,28,22,Bash,"echo ""=== AC2: Default recursive output ==="" && ./bin/du -k /tmp/du-test/ && echo """" && echo ""=== AC3: -s flag ==="" && ./bin/du -s -k /tmp/du-test/ && echo """" && echo ""=== AC4: -c flag ==="" && ./bin/d",binary_exercise,False,397,0
+304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,30,23,Bash,"echo ""=== AC6: Hard-link deduplication ==="" && mkdir -p /tmp/du-hardlink/dir_a /tmp/du-hardlink/dir_b && dd if=/dev/zero of=/tmp/du-hardlink/dir_a/shared.txt bs=1024 count=8 2>/dev/null && ln /tmp/du-",binary_exercise,False,390,0
+304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,33,24,Bash,"echo ""=== Depth limiting -d 1 ==="" && ./bin/du -k -d 1 /tmp/du-test/ && echo """" && echo ""=== Depth limiting -d 0 (like -s) ==="" && ./bin/du -k -d 0 /tmp/du-test/ && echo """" && echo ""=== All files -a =",binary_exercise,False,718,0
+304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,34,25,Bash,"echo ""=== Default (no args, current dir) ==="" && cd /tmp/du-test && /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/304/bin/du -k .",setup,False,84,100
 304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,36,26,Bash,go vet ./cmd/du/ 2>&1,go_vet,False,0,0
 304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,37,27,Bash,go test ./pkg/... 2>&1,go_test,False,223,0
 304,numeric,gh-262-codegen,d1a3404a-fe8d-4c89-a953-5162131c8ddc,,39,28,Bash,rm -rf /tmp/du-test /tmp/du-hardlink /tmp/du-perm,rm,False,0,0
@@ -2128,44 +2128,44 @@ printf '\x01\thello\n' | ./bin/cat -t",other,False,18,0
 306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,8,6,Bash,mkdir -p /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/306/cmd/wc,mkdir,False,0,0
 306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,9,7,Write,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/306/cmd/wc/main.go,,False,121,0
 306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,11,8,Bash,go build -o bin/wc ./cmd/wc/ 2>&1,go_build,False,0,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,13,9,Bash,which wc && printf 'foo\nbar baz\nqux\n' | wc 2>&1,other,False,41,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,14,10,Bash,printf 'foo\nbar baz\nqux\n' | ./bin/wc 2>&1,other,False,8,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,16,11,Bash,printf 'foo\nbar baz\nqux\n' | wc | cat -A 2>&1,other,False,30,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,17,12,Bash,printf 'foo\nbar baz\nqux\n' | wc | wc -c 2>&1,other,False,2,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,18,13,Bash,printf 'foo\nbar baz\nqux\n' | ./bin/wc | cat -A 2>&1,other,False,9,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,13,9,Bash,which wc && printf 'foo\nbar baz\nqux\n' | wc 2>&1,env_check,False,41,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,14,10,Bash,printf 'foo\nbar baz\nqux\n' | ./bin/wc 2>&1,binary_exercise,False,8,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,16,11,Bash,printf 'foo\nbar baz\nqux\n' | wc | cat -A 2>&1,binary_exercise,False,30,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,17,12,Bash,printf 'foo\nbar baz\nqux\n' | wc | wc -c 2>&1,binary_exercise,False,2,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,18,13,Bash,printf 'foo\nbar baz\nqux\n' | ./bin/wc | cat -A 2>&1,binary_exercise,False,9,0
 306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,20,14,Bash,wc --version 2>&1 | head -1,wc,False,32,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,21,15,Bash,which gwc 2>&1; gwc --version 2>&1 | head -1; printf 'foo\nbar baz\nqux\n' | gwc 2>&1 | cat -A,other,False,84,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,21,15,Bash,which gwc 2>&1; gwc --version 2>&1 | head -1; printf 'foo\nbar baz\nqux\n' | gwc 2>&1 | cat -A,env_check,False,84,0
 306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,23,16,Bash,file $(which wc) 2>&1; ls -la $(which wc) 2>&1,other,False,127,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,25,17,Bash,printf 'foo\nbar baz\nqux\n' > /tmp/testfile.txt && ./bin/wc /tmp/testfile.txt | cat -A,other,False,27,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,26,18,Bash,"printf 'foo\nbar baz\nqux\n' | ./bin/wc | cat -A && echo ""---"" && printf '' | ./bin/wc | cat -A && echo ""---"" && printf 'abc\n' | ./bin/wc -c | cat -A && echo ""---"" && printf 'abc\n' | ./bin/wc -l | c",other,False,41,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,27,19,Bash,printf 'hello\nworld\n' > /tmp/f1.txt && printf 'foo bar baz\n' > /tmp/f2.txt && ./bin/wc /tmp/f1.txt /tmp/f2.txt | cat -A,other,False,59,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,28,20,Bash,"./bin/wc /tmp/nonexistent.txt /tmp/f1.txt 2>&1 | cat -A; echo ""EXIT: $?""",other,False,127,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,25,17,Bash,printf 'foo\nbar baz\nqux\n' > /tmp/testfile.txt && ./bin/wc /tmp/testfile.txt | cat -A,binary_exercise,False,27,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,26,18,Bash,"printf 'foo\nbar baz\nqux\n' | ./bin/wc | cat -A && echo ""---"" && printf '' | ./bin/wc | cat -A && echo ""---"" && printf 'abc\n' | ./bin/wc -c | cat -A && echo ""---"" && printf 'abc\n' | ./bin/wc -l | c",binary_exercise,False,41,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,27,19,Bash,printf 'hello\nworld\n' > /tmp/f1.txt && printf 'foo bar baz\n' > /tmp/f2.txt && ./bin/wc /tmp/f1.txt /tmp/f2.txt | cat -A,binary_exercise,False,59,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,28,20,Bash,"./bin/wc /tmp/nonexistent.txt /tmp/f1.txt 2>&1 | cat -A; echo ""EXIT: $?""",binary_run,False,127,0
 306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,31,21,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/306/cmd/wc/main.go,,False,13955,0
 306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,33,22,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/306/cmd/wc/main.go,,False,131,0
 306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,34,23,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/306/cmd/wc/main.go,,False,131,0
 306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,36,24,Bash,go build -o bin/wc ./cmd/wc/ && ./bin/wc /tmp/nonexistent.txt /tmp/f1.txt 2>&1 | cat -A,go_build,False,90,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,38,25,Bash,printf 'hello\n' | ./bin/wc - 2>&1 | cat -A,other,False,6,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,38,25,Bash,printf 'hello\n' | ./bin/wc - 2>&1 | cat -A,binary_exercise,False,6,0
 306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,41,26,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/306/cmd/wc/main.go,,False,131,0
 306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,43,27,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/306/cmd/wc/main.go,,False,131,0
 306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,45,28,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/306/cmd/wc/main.go,,False,131,0
 306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,46,29,Bash,"go build -o bin/wc ./cmd/wc/ && printf 'hello\n' | ./bin/wc | cat -A && echo ""---"" && printf 'hello\n' | ./bin/wc - | cat -A",go_build,False,19,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,48,30,Bash,"printf '' | ./bin/wc | cat -A && echo ""---"" && printf 'foo\nbar baz\nqux\n' | ./bin/wc | cat -A && echo ""---"" && printf 'one\ntwo\nthree\n' | ./bin/wc -l | cat -A && echo ""---"" && printf 'hello world\",other,False,56,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,50,31,Bash,printf 'short\na much longer line here\nmed\n' | wc -L 2>&1; printf 'a much longer line here' | wc -c 2>&1,other,False,5,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,52,32,Bash,printf 'one two\nthree\n' | ./bin/wc -w -l -c | cat -A,other,False,9,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,54,33,Bash,"printf 'a\n' > /tmp/wc_t1.txt && printf 'b\nc\n' > /tmp/wc_t2.txt && ./bin/wc --total=only /tmp/wc_t1.txt /tmp/wc_t2.txt | cat -A && echo ""---"" && ./bin/wc --total=never /tmp/wc_t1.txt /tmp/wc_t2.txt ",other,False,60,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,55,34,Bash,printf 'stdin content\n' | ./bin/wc - | cat -A,other,False,11,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,57,35,Bash,printf 'stdin content\n' | ./bin/wc - 2>&1 | xxd | head -5,other,False,62,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,48,30,Bash,"printf '' | ./bin/wc | cat -A && echo ""---"" && printf 'foo\nbar baz\nqux\n' | ./bin/wc | cat -A && echo ""---"" && printf 'one\ntwo\nthree\n' | ./bin/wc -l | cat -A && echo ""---"" && printf 'hello world\",binary_exercise,False,56,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,50,31,Bash,printf 'short\na much longer line here\nmed\n' | wc -L 2>&1; printf 'a much longer line here' | wc -c 2>&1,binary_exercise,False,5,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,52,32,Bash,printf 'one two\nthree\n' | ./bin/wc -w -l -c | cat -A,binary_exercise,False,9,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,54,33,Bash,"printf 'a\n' > /tmp/wc_t1.txt && printf 'b\nc\n' > /tmp/wc_t2.txt && ./bin/wc --total=only /tmp/wc_t1.txt /tmp/wc_t2.txt | cat -A && echo ""---"" && ./bin/wc --total=never /tmp/wc_t1.txt /tmp/wc_t2.txt ",binary_exercise,False,60,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,55,34,Bash,printf 'stdin content\n' | ./bin/wc - | cat -A,binary_exercise,False,11,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,57,35,Bash,printf 'stdin content\n' | ./bin/wc - 2>&1 | xxd | head -5,binary_exercise,False,62,0
 306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,59,36,TodoWrite,"{""todos"": [{""content"": ""Read wc PRD, use case, and test suite specs"", ""status"": ""completed"", ""activeForm"": ""Reading wc specifications""}, {""content"": ""Implement cmd/wc/main.go"", ""status"": ""completed"", ",,False,160,0
 306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,60,37,Bash,"go build ./cmd/wc/ 2>&1; echo ""AC1 exit: $?""",go_build,False,11,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,61,38,Bash,"printf 'hello\nworld\n' > /tmp/ac2.txt && ./bin/wc /tmp/ac2.txt && echo ""AC2 exit: $?""",other,False,33,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,62,39,Bash,"printf 'hello world\n' | ./bin/wc && echo ""AC3 exit: $?""",other,False,18,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,64,40,Bash,"printf 'hello world\n' | ./bin/wc; echo ""AC3 exit: $?""",other,False,18,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,66,41,Bash,"printf 'hello world\n' | ./bin/wc; RET=$?; echo ""Exit code: $RET""",other,False,19,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,68,42,Bash,printf 'hello world\n' | ./bin/wc > /dev/null 2>&1; echo $?,other,False,0,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,69,43,Bash,"./bin/wc /tmp/nonexistent_file_xyz 2>/dev/null; echo ""exit=$?""",other,False,6,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,71,44,Bash,printf 'hello\nworld\n' > /tmp/ac4_f1.txt && printf 'foo bar baz\n' > /tmp/ac4_f2.txt && ./bin/wc /tmp/ac4_f1.txt /tmp/ac4_f2.txt | cat -A,other,False,67,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,73,45,Bash,./bin/wc /tmp/nonexistent_xyz.txt /tmp/ac4_f1.txt 2>&1 | cat -A,other,False,98,0
-306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,75,46,Bash,"./bin/wc /tmp/nonexistent_xyz.txt /tmp/ac4_f1.txt > /dev/null 2>/dev/null; echo ""exit=$?""",other,False,6,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,61,38,Bash,"printf 'hello\nworld\n' > /tmp/ac2.txt && ./bin/wc /tmp/ac2.txt && echo ""AC2 exit: $?""",binary_exercise,False,33,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,62,39,Bash,"printf 'hello world\n' | ./bin/wc && echo ""AC3 exit: $?""",binary_exercise,False,18,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,64,40,Bash,"printf 'hello world\n' | ./bin/wc; echo ""AC3 exit: $?""",binary_exercise,False,18,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,66,41,Bash,"printf 'hello world\n' | ./bin/wc; RET=$?; echo ""Exit code: $RET""",binary_exercise,False,19,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,68,42,Bash,printf 'hello world\n' | ./bin/wc > /dev/null 2>&1; echo $?,binary_exercise,False,0,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,69,43,Bash,"./bin/wc /tmp/nonexistent_file_xyz 2>/dev/null; echo ""exit=$?""",binary_run,False,6,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,71,44,Bash,printf 'hello\nworld\n' > /tmp/ac4_f1.txt && printf 'foo bar baz\n' > /tmp/ac4_f2.txt && ./bin/wc /tmp/ac4_f1.txt /tmp/ac4_f2.txt | cat -A,binary_exercise,False,67,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,73,45,Bash,./bin/wc /tmp/nonexistent_xyz.txt /tmp/ac4_f1.txt 2>&1 | cat -A,binary_run,False,98,0
+306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,75,46,Bash,"./bin/wc /tmp/nonexistent_xyz.txt /tmp/ac4_f1.txt > /dev/null 2>/dev/null; echo ""exit=$?""",binary_run,False,6,0
 306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,77,47,Bash,"go build -o bin/wc ./cmd/wc/ 2>&1; echo ""Build exit: $?""",go_build,False,13,0
 306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,79,48,Bash,go test ./pkg/... 2>&1,go_test,False,223,0
 306,numeric,gh-262-codegen,343fd1c1-e462-4614-a39e-fffa4b487ce0,,81,49,Bash,go vet ./cmd/wc/ 2>&1,go_vet,False,0,0
@@ -2181,13 +2181,13 @@ printf '\x01\thello\n' | ./bin/cat -t",other,False,18,0
 308,numeric,gh-262-codegen,4ec5f9a0-75f0-4bb6-b3e8-4454c4b170d0,,13,9,TodoWrite,"{""todos"": [{""content"": ""Read required specification files (PRD, use case, test suite)"", ""status"": ""completed"", ""activeForm"": ""Reading required specification files""}, {""content"": ""Implement cmd/ls/main",,False,160,0
 308,numeric,gh-262-codegen,4ec5f9a0-75f0-4bb6-b3e8-4454c4b170d0,,14,10,Bash,go build -o bin/ls ./cmd/ls/ 2>&1,go_build,False,40,0
 308,numeric,gh-262-codegen,4ec5f9a0-75f0-4bb6-b3e8-4454c4b170d0,,15,11,Bash,"mkdir -p /tmp/ls-test-fixture && cd /tmp/ls-test-fixture && rm -rf * .hidden && touch alpha.txt beta.txt gamma.txt && touch .hidden && mkdir subdir && echo ""hello"" > alpha.txt && echo ""world of text"" ",mkdir,False,0,100
-308,numeric,gh-262-codegen,4ec5f9a0-75f0-4bb6-b3e8-4454c4b170d0,,16,12,Bash,LC_ALL=C bin/ls /tmp/ls-test-fixture 2>&1,other,False,35,0
-308,numeric,gh-262-codegen,4ec5f9a0-75f0-4bb6-b3e8-4454c4b170d0,,18,13,Bash,"LC_ALL=C bin/ls -a /tmp/ls-test-fixture 2>&1 && echo ""---"" && LC_ALL=C bin/ls -A /tmp/ls-test-fixture 2>&1",other,False,96,0
-308,numeric,gh-262-codegen,4ec5f9a0-75f0-4bb6-b3e8-4454c4b170d0,,20,14,Bash,"LC_ALL=C bin/ls -r /tmp/ls-test-fixture 2>&1 && echo ""---"" && LC_ALL=C bin/ls -S /tmp/ls-test-fixture 2>&1 && echo ""---"" && LC_ALL=C bin/ls -t /tmp/ls-test-fixture 2>&1",other,False,115,0
-308,numeric,gh-262-codegen,4ec5f9a0-75f0-4bb6-b3e8-4454c4b170d0,,23,15,Bash,cd /tmp/ls-test-fixture && touch -t 202501010000 gamma.txt && touch -t 202503010000 alpha.txt && touch -t 202502010000 beta.txt && LC_ALL=C /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-uti,other,False,35,100
-308,numeric,gh-262-codegen,4ec5f9a0-75f0-4bb6-b3e8-4454c4b170d0,,25,16,Bash,"LC_ALL=C bin/ls -C /tmp/ls-test-fixture 2>&1 && echo ""---"" && LC_ALL=C bin/ls -1 /tmp/ls-test-fixture 2>&1",other,False,78,0
-308,numeric,gh-262-codegen,4ec5f9a0-75f0-4bb6-b3e8-4454c4b170d0,,27,17,Bash,"LC_ALL=C bin/ls /tmp/nonexistent /tmp/ls-test-fixture 2>&1; echo ""exit: $?""",other,False,129,0
-308,numeric,gh-262-codegen,4ec5f9a0-75f0-4bb6-b3e8-4454c4b170d0,,29,18,Bash,"LC_ALL=C bin/ls --invalid-flag 2>&1; echo ""exit: $?""",other,False,48,0
+308,numeric,gh-262-codegen,4ec5f9a0-75f0-4bb6-b3e8-4454c4b170d0,,16,12,Bash,LC_ALL=C bin/ls /tmp/ls-test-fixture 2>&1,binary_run,False,35,0
+308,numeric,gh-262-codegen,4ec5f9a0-75f0-4bb6-b3e8-4454c4b170d0,,18,13,Bash,"LC_ALL=C bin/ls -a /tmp/ls-test-fixture 2>&1 && echo ""---"" && LC_ALL=C bin/ls -A /tmp/ls-test-fixture 2>&1",binary_run,False,96,0
+308,numeric,gh-262-codegen,4ec5f9a0-75f0-4bb6-b3e8-4454c4b170d0,,20,14,Bash,"LC_ALL=C bin/ls -r /tmp/ls-test-fixture 2>&1 && echo ""---"" && LC_ALL=C bin/ls -S /tmp/ls-test-fixture 2>&1 && echo ""---"" && LC_ALL=C bin/ls -t /tmp/ls-test-fixture 2>&1",binary_run,False,115,0
+308,numeric,gh-262-codegen,4ec5f9a0-75f0-4bb6-b3e8-4454c4b170d0,,23,15,Bash,cd /tmp/ls-test-fixture && touch -t 202501010000 gamma.txt && touch -t 202503010000 alpha.txt && touch -t 202502010000 beta.txt && LC_ALL=C /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-uti,env_inspect,False,35,100
+308,numeric,gh-262-codegen,4ec5f9a0-75f0-4bb6-b3e8-4454c4b170d0,,25,16,Bash,"LC_ALL=C bin/ls -C /tmp/ls-test-fixture 2>&1 && echo ""---"" && LC_ALL=C bin/ls -1 /tmp/ls-test-fixture 2>&1",binary_run,False,78,0
+308,numeric,gh-262-codegen,4ec5f9a0-75f0-4bb6-b3e8-4454c4b170d0,,27,17,Bash,"LC_ALL=C bin/ls /tmp/nonexistent /tmp/ls-test-fixture 2>&1; echo ""exit: $?""",binary_run,False,129,0
+308,numeric,gh-262-codegen,4ec5f9a0-75f0-4bb6-b3e8-4454c4b170d0,,29,18,Bash,"LC_ALL=C bin/ls --invalid-flag 2>&1; echo ""exit: $?""",binary_run,False,48,0
 308,numeric,gh-262-codegen,4ec5f9a0-75f0-4bb6-b3e8-4454c4b170d0,,31,19,Bash,go build ./... 2>&1,go_build,False,0,0
 308,numeric,gh-262-codegen,4ec5f9a0-75f0-4bb6-b3e8-4454c4b170d0,,32,20,Bash,go vet ./cmd/ls/ 2>&1,go_vet,False,0,0
 308,numeric,gh-262-codegen,4ec5f9a0-75f0-4bb6-b3e8-4454c4b170d0,,33,21,TodoWrite,"{""todos"": [{""content"": ""Read required specification files (PRD, use case, test suite)"", ""status"": ""completed"", ""activeForm"": ""Reading required specification files""}, {""content"": ""Implement cmd/ls/main",,False,160,0
@@ -2257,7 +2257,7 @@ printf '\x01\thello\n' | ./bin/cat -t",other,False,18,0
 331,numeric,gh-313-generate-code,ea57d0f1-7494-40c3-b9dd-04669af0d596,,45,31,TodoWrite,"{""todos"": [{""content"": ""Create pkg/sys/sys.go with InstallSIGPIPEHandler"", ""status"": ""completed"", ""activeForm"": ""Creating pkg/sys/sys.go""}, {""content"": ""Create pkg/testutils/testutils.go with DiffTest",,False,160,0
 331,numeric,gh-313-generate-code,ea57d0f1-7494-40c3-b9dd-04669af0d596,,47,32,Bash,go build -o bin/true ./cmd/true/ && go build -o bin/false ./cmd/false/,go_build,False,0,0
 331,numeric,gh-313-generate-code,ea57d0f1-7494-40c3-b9dd-04669af0d596,,48,33,Bash,go vet ./cmd/true/ ./cmd/false/ ./pkg/sys/ ./pkg/testutils/,go_vet,False,0,0
-331,numeric,gh-313-generate-code,ea57d0f1-7494-40c3-b9dd-04669af0d596,,49,34,Bash,"./bin/true; echo ""true exit: $?"" && ./bin/false; echo ""false exit: $?""",other,False,26,0
+331,numeric,gh-313-generate-code,ea57d0f1-7494-40c3-b9dd-04669af0d596,,49,34,Bash,"./bin/true; echo ""true exit: $?"" && ./bin/false; echo ""false exit: $?""",binary_run,False,26,0
 331,numeric,gh-313-generate-code,ea57d0f1-7494-40c3-b9dd-04669af0d596,,50,35,Bash,go test ./cmd/true/ ./cmd/false/ -v -count=1 2>&1,go_test,False,911,0
 331,numeric,gh-313-generate-code,ea57d0f1-7494-40c3-b9dd-04669af0d596,,52,36,TodoWrite,"{""todos"": [{""content"": ""Create pkg/sys/sys.go with InstallSIGPIPEHandler"", ""status"": ""completed"", ""activeForm"": ""Creating pkg/sys/sys.go""}, {""content"": ""Create pkg/testutils/testutils.go with DiffTest",,False,160,0
 332,numeric,gh-313-generate-code,4ecf39f2-e3af-4bf5-864a-659ffb740ed4,,2,1,ToolSearch,"{""query"": ""select:Read,Write,Bash,TodoWrite"", ""max_results"": 4}",,False,202,0
@@ -2275,7 +2275,7 @@ printf '\x01\thello\n' | ./bin/cat -t",other,False,18,0
 332,numeric,gh-313-generate-code,4ecf39f2-e3af-4bf5-864a-659ffb740ed4,,20,13,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/332/cmd/yes/yes_test.go,,False,144,0
 332,numeric,gh-313-generate-code,4ecf39f2-e3af-4bf5-864a-659ffb740ed4,,22,14,Bash,go build -o bin/yes ./cmd/yes/,go_build,False,0,0
 332,numeric,gh-313-generate-code,4ecf39f2-e3af-4bf5-864a-659ffb740ed4,,23,15,Bash,go test ./cmd/yes/ -v -timeout 30s,go_test,False,449,0
-332,numeric,gh-313-generate-code,4ecf39f2-e3af-4bf5-864a-659ffb740ed4,,25,16,Bash,"./bin/yes | head -n 5 && echo ""---"" && ./bin/yes hello world | head -n 3 && echo ""---"" && ./bin/yes -- --help | head -n 1",other,False,60,0
+332,numeric,gh-313-generate-code,4ecf39f2-e3af-4bf5-864a-659ffb740ed4,,25,16,Bash,"./bin/yes | head -n 5 && echo ""---"" && ./bin/yes hello world | head -n 3 && echo ""---"" && ./bin/yes -- --help | head -n 1",binary_run,False,60,0
 332,numeric,gh-313-generate-code,4ecf39f2-e3af-4bf5-864a-659ffb740ed4,,27,17,Bash,go test ./... -timeout 30s,go_test,False,316,0
 332,numeric,gh-313-generate-code,4ecf39f2-e3af-4bf5-864a-659ffb740ed4,,28,18,Bash,go vet ./cmd/yes/,go_vet,False,0,0
 332,numeric,gh-313-generate-code,4ecf39f2-e3af-4bf5-864a-659ffb740ed4,,29,19,TodoWrite,"{""todos"": [{""content"": ""Create cmd/yes/main.go"", ""status"": ""completed"", ""activeForm"": ""Creating cmd/yes/main.go""}, {""content"": ""Create cmd/yes/yes_test.go"", ""status"": ""completed"", ""activeForm"": ""Creat",,False,160,0
@@ -2301,9 +2301,9 @@ printf '\x01\thello\n' | ./bin/cat -t",other,False,18,0
 333,numeric,gh-313-generate-code,3a9d5fb3-6be8-4467-833b-a377d2483dda,,24,20,Bash,go build -o bin/basename ./cmd/basename/ && go build -o bin/dirname ./cmd/dirname/,go_build,False,0,0
 333,numeric,gh-313-generate-code,3a9d5fb3-6be8-4467-833b-a377d2483dda,,26,21,Bash,go test ./cmd/basename/ -v 2>&1 | head -80,go_test,False,270,0
 333,numeric,gh-313-generate-code,3a9d5fb3-6be8-4467-833b-a377d2483dda,,27,22,Bash,go test ./cmd/dirname/ -v 2>&1 | head -80,go_test,False,266,0
-333,numeric,gh-313-generate-code,3a9d5fb3-6be8-4467-833b-a377d2483dda,,29,23,Bash,./bin/basename /usr/bin/sort && ./bin/basename include/stdio.h .h && ./bin/basename -a /usr/bin/sort /usr/bin/cat && ./bin/basename -s .h include/stdio.h include/stdlib.h && ./bin/basename / && ./bin/,other,False,40,0
-333,numeric,gh-313-generate-code,3a9d5fb3-6be8-4467-833b-a377d2483dda,,30,24,Bash,./bin/dirname /usr/bin/sort && ./bin/dirname stdio.h && ./bin/dirname /usr/bin/ && ./bin/dirname / && ./bin/dirname dir1/file dir2/file && ./bin/dirname . && ./bin/dirname ..,other,False,31,0
-333,numeric,gh-313-generate-code,3a9d5fb3-6be8-4467-833b-a377d2483dda,,32,25,Bash,"./bin/basename -z /usr/bin/sort | xxd | head -3 && echo ""---"" && ./bin/dirname -z /usr/bin/sort | xxd | head -3",other,False,121,0
+333,numeric,gh-313-generate-code,3a9d5fb3-6be8-4467-833b-a377d2483dda,,29,23,Bash,./bin/basename /usr/bin/sort && ./bin/basename include/stdio.h .h && ./bin/basename -a /usr/bin/sort /usr/bin/cat && ./bin/basename -s .h include/stdio.h include/stdlib.h && ./bin/basename / && ./bin/,binary_run,False,40,0
+333,numeric,gh-313-generate-code,3a9d5fb3-6be8-4467-833b-a377d2483dda,,30,24,Bash,./bin/dirname /usr/bin/sort && ./bin/dirname stdio.h && ./bin/dirname /usr/bin/ && ./bin/dirname / && ./bin/dirname dir1/file dir2/file && ./bin/dirname . && ./bin/dirname ..,binary_run,False,31,0
+333,numeric,gh-313-generate-code,3a9d5fb3-6be8-4467-833b-a377d2483dda,,32,25,Bash,"./bin/basename -z /usr/bin/sort | xxd | head -3 && echo ""---"" && ./bin/dirname -z /usr/bin/sort | xxd | head -3",binary_run,False,121,0
 333,numeric,gh-313-generate-code,3a9d5fb3-6be8-4467-833b-a377d2483dda,,34,26,Bash,go test ./... 2>&1,go_test,False,441,0
 333,numeric,gh-313-generate-code,3a9d5fb3-6be8-4467-833b-a377d2483dda,,36,27,TodoWrite,"{""todos"": [{""content"": ""Read PRDs, use cases, and test suite for basename and dirname"", ""status"": ""completed"", ""activeForm"": ""Reading PRDs, use cases, and test suite""}, {""content"": ""Read pkg/sys and p",,False,160,0
 340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,3,1,ToolSearch,"{""query"": ""select:Read,Bash,Write,Glob"", ""max_results"": 4}",,False,197,0
@@ -2317,33 +2317,33 @@ printf '\x01\thello\n' | ./bin/cat -t",other,False,18,0
 340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,13,8,Glob,cmd/*/main.go,,False,14,0
 340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,17,10,Write,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/340/cmd/tee/main.go,,False,130,0
 340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,19,11,Bash,go build -o bin/tee ./cmd/tee/,go_build,False,0,0
-340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,20,12,Bash,"echo ""hello"" | ./bin/tee",echo,False,5,0
-340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,21,13,Bash,"echo ""hello"" | ./bin/tee /tmp/tee_test.txt && cat /tmp/tee_test.txt",echo,False,11,0
-340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,22,14,Bash,printf 'old\n' > /tmp/tee_append.txt && printf 'new\n' | ./bin/tee -a /tmp/tee_append.txt > /dev/null && cat /tmp/tee_append.txt,other,False,7,0
-340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,23,15,Bash,"printf 'data\n' | ./bin/tee /nonexistent-dir/file.txt /tmp/tee_good.txt; echo ""exit: $?""",other,False,68,0
+340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,20,12,Bash,"echo ""hello"" | ./bin/tee",binary_exercise,False,5,0
+340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,21,13,Bash,"echo ""hello"" | ./bin/tee /tmp/tee_test.txt && cat /tmp/tee_test.txt",binary_exercise,False,11,0
+340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,22,14,Bash,printf 'old\n' > /tmp/tee_append.txt && printf 'new\n' | ./bin/tee -a /tmp/tee_append.txt > /dev/null && cat /tmp/tee_append.txt,binary_exercise,False,7,0
+340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,23,15,Bash,"printf 'data\n' | ./bin/tee /nonexistent-dir/file.txt /tmp/tee_good.txt; echo ""exit: $?""",binary_exercise,False,68,0
 340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,24,16,Bash,cat /tmp/tee_good.txt,cat,False,4,0
-340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,26,17,Bash,printf 'data\n' | ./bin/tee /nonexistent-dir/file.txt > /dev/null 2>/dev/null; echo $?,other,False,0,0
-340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,27,18,Bash,"printf 'x' | ./bin/tee /nonexistent-dir/f 2>/dev/null >/dev/null; echo ""EXIT=$?""",other,False,5,0
-340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,29,19,Bash,"printf 'x' | ./bin/tee /nonexistent-dir/f >/dev/null 2>&1; RC=$?; echo ""rc=${RC}""",other,False,3,0
-340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,30,20,Bash,"printf 'x\n' | ./bin/tee /nonexistent-dir/f 1>/tmp/tee_stdout 2>/tmp/tee_stderr; echo ""$?"" > /tmp/tee_rc && cat /tmp/tee_rc",other,False,50,0
+340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,26,17,Bash,printf 'data\n' | ./bin/tee /nonexistent-dir/file.txt > /dev/null 2>/dev/null; echo $?,binary_exercise,False,0,0
+340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,27,18,Bash,"printf 'x' | ./bin/tee /nonexistent-dir/f 2>/dev/null >/dev/null; echo ""EXIT=$?""",binary_exercise,False,5,0
+340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,29,19,Bash,"printf 'x' | ./bin/tee /nonexistent-dir/f >/dev/null 2>&1; RC=$?; echo ""rc=${RC}""",binary_exercise,False,3,0
+340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,30,20,Bash,"printf 'x\n' | ./bin/tee /nonexistent-dir/f 1>/tmp/tee_stdout 2>/tmp/tee_stderr; echo ""$?"" > /tmp/tee_rc && cat /tmp/tee_rc",binary_exercise,False,50,0
 340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,31,21,Bash,cat /tmp/tee_rc,cat,False,0,0
 340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,32,22,Bash,cat -A /tmp/tee_rc,cat,True,130,0
 340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,33,23,Read,/tmp/tee_rc,,False,15,0
-340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,34,24,Bash,"printf 'test' | ./bin/tee /no/dir 2>/dev/null 1>/dev/null ; echo ""the_rc_is:$?""",other,False,10,0
-340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,36,25,Bash,"printf 'test' | ./bin/tee /no/dir 2>/dev/null 1>/dev/null && echo ""SUCCESS"" || echo ""FAILED_WITH_NONZERO""",other,False,19,0
+340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,34,24,Bash,"printf 'test' | ./bin/tee /no/dir 2>/dev/null 1>/dev/null ; echo ""the_rc_is:$?""",binary_exercise,False,10,0
+340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,36,25,Bash,"printf 'test' | ./bin/tee /no/dir 2>/dev/null 1>/dev/null && echo ""SUCCESS"" || echo ""FAILED_WITH_NONZERO""",binary_exercise,False,19,0
 340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,38,26,ToolSearch,"{""query"": ""select:Edit"", ""max_results"": 1}",,False,49,0
 340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,39,27,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/340/cmd/tee/main.go,,False,140,0
 340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,41,28,Bash,go build -o bin/tee ./cmd/tee/,go_build,False,0,0
-340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,43,29,Bash,which golangci-lint && golangci-lint run ./cmd/tee/,other,True,1804,0
+340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,43,29,Bash,which golangci-lint && golangci-lint run ./cmd/tee/,env_check,True,1804,0
 340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,44,30,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/340/cmd/tee/main.go,,False,1132,0
 340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,45,31,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/340/cmd/tee/main.go,,False,140,0
 340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,46,32,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/340/cmd/tee/main.go,,False,140,0
-340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,47,33,Bash,golangci-lint run ./cmd/tee/,other,False,9,0
+340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,47,33,Bash,golangci-lint run ./cmd/tee/,lint,False,9,0
 340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,49,34,Bash,"go build -o bin/tee ./cmd/tee/ && echo ""BUILD OK""",go_build,False,8,0
-340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,50,35,Bash,"echo ""hello"" | ./bin/tee && echo ""---PASS AC2""",echo,False,17,0
-340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,51,36,Bash,"echo ""hello"" | ./bin/tee /tmp/tee_ac3.txt && diff <(echo ""hello"") /tmp/tee_ac3.txt && echo ""---PASS AC3""",echo,False,17,0
-340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,52,37,Bash,"printf 'old\n' > /tmp/tee_ac4.txt && printf 'new\n' | ./bin/tee -a /tmp/tee_ac4.txt > /dev/null && diff <(printf 'old\nnew\n') /tmp/tee_ac4.txt && echo ""---PASS AC4""",other,False,11,0
-340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,53,38,Bash,"./bin/tee --version && echo ""---VERSION OK""",other,False,39,0
+340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,50,35,Bash,"echo ""hello"" | ./bin/tee && echo ""---PASS AC2""",binary_exercise,False,17,0
+340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,51,36,Bash,"echo ""hello"" | ./bin/tee /tmp/tee_ac3.txt && diff <(echo ""hello"") /tmp/tee_ac3.txt && echo ""---PASS AC3""",binary_exercise,False,17,0
+340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,52,37,Bash,"printf 'old\n' > /tmp/tee_ac4.txt && printf 'new\n' | ./bin/tee -a /tmp/tee_ac4.txt > /dev/null && diff <(printf 'old\nnew\n') /tmp/tee_ac4.txt && echo ""---PASS AC4""",binary_exercise,False,11,0
+340,numeric,gh-336-generate-code,6a9684d5-9b1c-4463-9a15-9766df9bd4ee,,53,38,Bash,"./bin/tee --version && echo ""---VERSION OK""",binary_run,False,39,0
 341,numeric,gh-336-generate-code,57d4a27a-e6c5-4554-b927-6d245f0b249e,,3,1,ToolSearch,"{""query"": ""select:Read,Bash,Write,TodoWrite"", ""max_results"": 4}",,False,202,0
 341,numeric,gh-336-generate-code,57d4a27a-e6c5-4554-b927-6d245f0b249e,,5,2,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/341/docs/specs/test-suites/test-rel02.1.yaml,,False,6011,0
 341,numeric,gh-336-generate-code,57d4a27a-e6c5-4554-b927-6d245f0b249e,,6,3,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/341/docs/specs/use-cases/rel02.1-uc001-tee.yaml,,False,3614,0
@@ -2361,7 +2361,7 @@ printf '\x01\thello\n' | ./bin/cat -t",other,False,18,0
 341,numeric,gh-336-generate-code,57d4a27a-e6c5-4554-b927-6d245f0b249e,,22,15,TodoWrite,"{""todos"": [{""content"": ""Write cmd/tee/tee_test.go with differential tests"", ""status"": ""completed"", ""activeForm"": ""Writing differential tests for cmd/tee""}, {""content"": ""Verify go vet and go test pass""",,False,160,0
 341,numeric,gh-336-generate-code,57d4a27a-e6c5-4554-b927-6d245f0b249e,,23,16,Bash,go vet ./cmd/tee/ 2>&1,go_vet,False,0,0
 341,numeric,gh-336-generate-code,57d4a27a-e6c5-4554-b927-6d245f0b249e,,24,17,Bash,go test ./cmd/tee/ -v -count=1 2>&1,go_test,False,212,0
-341,numeric,gh-336-generate-code,57d4a27a-e6c5-4554-b927-6d245f0b249e,,25,18,Bash,which gtee 2>&1 || brew --prefix coreutils 2>&1,other,False,42,0
+341,numeric,gh-336-generate-code,57d4a27a-e6c5-4554-b927-6d245f0b249e,,25,18,Bash,which gtee 2>&1 || brew --prefix coreutils 2>&1,env_check,False,42,0
 341,numeric,gh-336-generate-code,57d4a27a-e6c5-4554-b927-6d245f0b249e,,26,19,Bash,"ls /opt/homebrew/opt/coreutils/libexec/gnubin/tee 2>&1 && PATH=""/opt/homebrew/opt/coreutils/libexec/gnubin:$PATH"" go test ./cmd/tee/ -v -count=1 2>&1",ls,True,168,0
 341,numeric,gh-336-generate-code,57d4a27a-e6c5-4554-b927-6d245f0b249e,,27,20,Bash,"ls /opt/homebrew/bin/gtee 2>&1; find /opt/homebrew/opt/coreutils -name ""*tee*"" 2>&1 | head -5",ls,False,114,0
 341,numeric,gh-336-generate-code,57d4a27a-e6c5-4554-b927-6d245f0b249e,,30,21,Bash,"go build -o bin/tee ./cmd/tee/ 2>&1 && echo ""hello"" | ./bin/tee 2>&1",go_build,False,5,0
@@ -2392,10 +2392,10 @@ printf '\x01\thello\n' | ./bin/cat -t",other,False,18,0
 343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,36,24,Bash,go build -o bin/head ./cmd/head/ 2>&1,go_build,False,0,0
 343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,37,25,Bash,go vet ./cmd/head/... 2>&1,go_vet,False,0,0
 343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,39,26,Bash,go test ./cmd/head/... -v -count=1 2>&1,go_test,False,254,0
-343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,41,27,Bash,printf '1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n' | ./bin/head 2>&1,other,False,20,0
-343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,42,28,Bash,printf '1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n' | ./bin/head -n -5 2>&1,other,False,9,0
-343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,43,29,Bash,printf 'abcdefghij' | ./bin/head -c 5 2>&1,other,False,5,0
-343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,44,30,Bash,"cd /tmp && mkdir -p headtest && echo ""1"" > headtest/f1.txt && echo ""2"" > headtest/f2.txt && /private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/343/bin/head headtest/f1.tx",other,False,176,108
+343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,41,27,Bash,printf '1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n' | ./bin/head 2>&1,binary_exercise,False,20,0
+343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,42,28,Bash,printf '1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n' | ./bin/head -n -5 2>&1,binary_exercise,False,9,0
+343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,43,29,Bash,printf 'abcdefghij' | ./bin/head -c 5 2>&1,binary_exercise,False,5,0
+343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,44,30,Bash,"cd /tmp && mkdir -p headtest && echo ""1"" > headtest/f1.txt && echo ""2"" > headtest/f2.txt && /private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/343/bin/head headtest/f1.tx",env_inspect,False,176,108
 343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,46,31,Bash,wc -l cmd/head/main.go,wc,False,25,0
 343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,49,32,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/343/cmd/head/main.go,,False,9824,0
 343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,52,33,Write,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/343/cmd/head/main.go,,False,141,0
@@ -2410,8 +2410,8 @@ printf '\x01\thello\n' | ./bin/cat -t",other,False,18,0
 343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,66,42,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/343/cmd/head/main.go,,False,141,0
 343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,67,43,Bash,wc -l cmd/head/main.go && go build -o bin/head ./cmd/head/ 2>&1 && go vet ./cmd/head/... 2>&1,wc,False,25,0
 343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,68,44,Bash,go test ./cmd/head/... -v -count=1 2>&1,go_test,False,254,0
-343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,70,45,Bash,"printf '1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n' | ./bin/head && echo ""---"" && printf '1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n' | ./bin/head -n -5 && echo ""---"" && printf 'abcdefghij' | ./bin/head -c 5 && ech",other,False,144,0
-343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,72,46,Bash,"./bin/head /nonexistent 2>/dev/null; echo ""exit=$?""",other,False,6,0
+343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,70,45,Bash,"printf '1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n12\n' | ./bin/head && echo ""---"" && printf '1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n' | ./bin/head -n -5 && echo ""---"" && printf 'abcdefghij' | ./bin/head -c 5 && ech",binary_exercise,False,144,0
+343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,72,46,Bash,"./bin/head /nonexistent 2>/dev/null; echo ""exit=$?""",binary_run,False,6,0
 343,numeric,gh-336-generate-code-r02.2,6d4c178c-c666-4b39-b0d2-ff47d37e3168,,74,47,TodoWrite,"{""todos"": [{""content"": ""Read required specs and source files"", ""status"": ""completed"", ""activeForm"": ""Reading required specs and source files""}, {""content"": ""Create pkg/sys/sigpipe.go (minimal, needed ",,False,160,0
 344,numeric,gh-336-generate-code-r02.2,930bb9c0-57e2-4c3f-8188-10a0cdccbab8,,2,1,ToolSearch,"{""query"": ""select:Read,Write,Bash,Glob,TodoWrite"", ""max_results"": 5}",,False,251,0
 344,numeric,gh-336-generate-code-r02.2,930bb9c0-57e2-4c3f-8188-10a0cdccbab8,,4,2,TodoWrite,"{""todos"": [{""content"": ""Read required specs (PRD, use case, test suite, testutils contract)"", ""status"": ""in_progress"", ""activeForm"": ""Reading required specification files""}, {""content"": ""Implement cmd",,False,160,0
@@ -2431,7 +2431,7 @@ printf '\x01\thello\n' | ./bin/cat -t",other,False,18,0
 344,numeric,gh-336-generate-code-r02.2,930bb9c0-57e2-4c3f-8188-10a0cdccbab8,,22,16,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/344/cmd/seq/main.go,,False,714,0
 344,numeric,gh-336-generate-code-r02.2,930bb9c0-57e2-4c3f-8188-10a0cdccbab8,,24,17,Bash,go build -o bin/seq ./cmd/seq/ && go vet ./cmd/seq/,go_build,False,0,0
 344,numeric,gh-336-generate-code-r02.2,930bb9c0-57e2-4c3f-8188-10a0cdccbab8,,26,18,Bash,go test ./cmd/seq/ -v -count=1 2>&1 | head -100,go_test,False,250,0
-344,numeric,gh-336-generate-code-r02.2,930bb9c0-57e2-4c3f-8188-10a0cdccbab8,,28,19,Bash,"which gseq 2>/dev/null || brew --prefix coreutils 2>/dev/null || echo ""not found""",other,False,42,0
+344,numeric,gh-336-generate-code-r02.2,930bb9c0-57e2-4c3f-8188-10a0cdccbab8,,28,19,Bash,"which gseq 2>/dev/null || brew --prefix coreutils 2>/dev/null || echo ""not found""",env_check,False,42,0
 344,numeric,gh-336-generate-code-r02.2,930bb9c0-57e2-4c3f-8188-10a0cdccbab8,,29,20,Bash,"ls /opt/homebrew/opt/coreutils/libexec/gnubin/seq 2>/dev/null && echo ""found""",ls,True,11,0
 344,numeric,gh-336-generate-code-r02.2,930bb9c0-57e2-4c3f-8188-10a0cdccbab8,,30,21,Bash,"ls /opt/homebrew/opt/coreutils/bin/gseq 2>/dev/null && echo ""found"" || ls /opt/homebrew/bin/gseq 2>/dev/null && echo ""found2""",ls,True,11,0
 344,numeric,gh-336-generate-code-r02.2,930bb9c0-57e2-4c3f-8188-10a0cdccbab8,,31,22,Bash,"find /opt/homebrew -name ""gseq"" -type f 2>/dev/null; find /opt/homebrew -name ""seq"" -path ""*/coreutils/*"" -type f 2>/dev/null",find,False,0,0
@@ -2481,9 +2481,9 @@ echo ""=== seq -w 1 10 ==="" && ./bin/seq -w 1 ",other,False,284,0
 346,numeric,gh-336-generate-code-r05.0,697b6b51-98ac-429a-8c87-1d8bb215b693,,25,17,Write,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/346/pkg/testutils/testutils.go,,False,141,0
 346,numeric,gh-336-generate-code-r05.0,697b6b51-98ac-429a-8c87-1d8bb215b693,,26,18,Bash,go build -o bin/echo ./cmd/echo/ 2>&1,go_build,False,0,0
 346,numeric,gh-336-generate-code-r05.0,697b6b51-98ac-429a-8c87-1d8bb215b693,,28,19,Bash,go test ./cmd/echo/ -v -count=1 2>&1,go_test,False,254,0
-346,numeric,gh-336-generate-code-r05.0,697b6b51-98ac-429a-8c87-1d8bb215b693,,29,20,Bash,"which gecho 2>&1 || echo ""gecho not found; trying to find it...""  && ls /opt/homebrew/bin/gecho /usr/local/bin/gecho 2>&1 || true",other,False,160,0
-346,numeric,gh-336-generate-code-r05.0,697b6b51-98ac-429a-8c87-1d8bb215b693,,31,21,Bash,"./bin/echo hello world | xxd | head -3 && echo ""---"" && ./bin/echo -n hello | xxd | head -3 && echo ""---"" && ./bin/echo -e 'col1\tcol2' | xxd | head -3 && echo ""---"" && ./bin/echo -e 'before\cafter' |",other,False,372,0
-346,numeric,gh-336-generate-code-r05.0,697b6b51-98ac-429a-8c87-1d8bb215b693,,33,22,Bash,"./bin/echo | xxd && echo ""---"" && ./bin/echo -e '\0101' | xxd && echo ""---"" && ./bin/echo -e '\x41' | xxd && echo ""---"" && ./bin/echo -z hello | xxd && echo ""---"" && ./bin/echo hello -n world | xxd",other,False,304,0
+346,numeric,gh-336-generate-code-r05.0,697b6b51-98ac-429a-8c87-1d8bb215b693,,29,20,Bash,"which gecho 2>&1 || echo ""gecho not found; trying to find it...""  && ls /opt/homebrew/bin/gecho /usr/local/bin/gecho 2>&1 || true",env_check,False,160,0
+346,numeric,gh-336-generate-code-r05.0,697b6b51-98ac-429a-8c87-1d8bb215b693,,31,21,Bash,"./bin/echo hello world | xxd | head -3 && echo ""---"" && ./bin/echo -n hello | xxd | head -3 && echo ""---"" && ./bin/echo -e 'col1\tcol2' | xxd | head -3 && echo ""---"" && ./bin/echo -e 'before\cafter' |",binary_run,False,372,0
+346,numeric,gh-336-generate-code-r05.0,697b6b51-98ac-429a-8c87-1d8bb215b693,,33,22,Bash,"./bin/echo | xxd && echo ""---"" && ./bin/echo -e '\0101' | xxd && echo ""---"" && ./bin/echo -e '\x41' | xxd && echo ""---"" && ./bin/echo -z hello | xxd && echo ""---"" && ./bin/echo hello -n world | xxd",binary_run,False,304,0
 346,numeric,gh-336-generate-code-r05.0,697b6b51-98ac-429a-8c87-1d8bb215b693,,35,23,Bash,rm /private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/346/pkg/sys/sigpipe.go /private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/346/pkg/test,rm,False,0,0
 346,numeric,gh-336-generate-code-r05.0,697b6b51-98ac-429a-8c87-1d8bb215b693,,36,24,TodoWrite,"{""todos"": [{""content"": ""Create cmd/echo/main.go"", ""status"": ""completed"", ""activeForm"": ""Creating cmd/echo/main.go""}, {""content"": ""Create cmd/echo/echo_test.go"", ""status"": ""completed"", ""activeForm"": ""C",,False,160,0
 347,numeric,gh-336-generate-code-r05.0,abb2040a-f7c9-438c-b4c3-2eddab19244e,,2,1,ToolSearch,"{""query"": ""select:Read,Write,Bash,TodoWrite,Glob"", ""max_results"": 5}",,False,251,0
@@ -2498,8 +2498,8 @@ echo ""=== seq -w 1 10 ==="" && ./bin/seq -w 1 ",other,False,284,0
 347,numeric,gh-336-generate-code-r05.0,abb2040a-f7c9-438c-b4c3-2eddab19244e,,15,10,Glob,pkg/**/*.go,,False,14,0
 347,numeric,gh-336-generate-code-r05.0,abb2040a-f7c9-438c-b4c3-2eddab19244e,,18,11,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/347/go.mod,,False,151,0
 347,numeric,gh-336-generate-code-r05.0,abb2040a-f7c9-438c-b4c3-2eddab19244e,,19,12,Bash,go build -o bin/echo ./cmd/echo/ 2>&1 | head -20,go_build,False,170,0
-347,numeric,gh-336-generate-code-r05.0,abb2040a-f7c9-438c-b4c3-2eddab19244e,,22,13,Bash,"gofmt -e cmd/tac/main.go > /dev/null 2>&1 && echo ""main.go: syntax OK"" || echo ""main.go: syntax error""; gofmt -e cmd/tac/tac_test.go > /dev/null 2>&1 && echo ""tac_test.go: syntax OK"" || echo ""tac_test",other,False,41,0
-347,numeric,gh-336-generate-code-r05.0,abb2040a-f7c9-438c-b4c3-2eddab19244e,,23,14,Bash,"diff <(gofmt cmd/tac/main.go) cmd/tac/main.go && echo ""main.go: properly formatted""; diff <(gofmt cmd/tac/tac_test.go) cmd/tac/tac_test.go && echo ""tac_test.go: properly formatted""",other,False,59,0
+347,numeric,gh-336-generate-code-r05.0,abb2040a-f7c9-438c-b4c3-2eddab19244e,,22,13,Bash,"gofmt -e cmd/tac/main.go > /dev/null 2>&1 && echo ""main.go: syntax OK"" || echo ""main.go: syntax error""; gofmt -e cmd/tac/tac_test.go > /dev/null 2>&1 && echo ""tac_test.go: syntax OK"" || echo ""tac_test",format,False,41,0
+347,numeric,gh-336-generate-code-r05.0,abb2040a-f7c9-438c-b4c3-2eddab19244e,,23,14,Bash,"diff <(gofmt cmd/tac/main.go) cmd/tac/main.go && echo ""main.go: properly formatted""; diff <(gofmt cmd/tac/tac_test.go) cmd/tac/tac_test.go && echo ""tac_test.go: properly formatted""",diff,False,59,0
 347,numeric,gh-336-generate-code-r05.0,abb2040a-f7c9-438c-b4c3-2eddab19244e,,24,15,TodoWrite,"{""todos"": [{""content"": ""Implement cmd/tac/main.go"", ""status"": ""completed"", ""activeForm"": ""Implementing cmd/tac/main.go""}, {""content"": ""Implement cmd/tac/tac_test.go"", ""status"": ""completed"", ""activeFor",,False,160,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,2,1,ToolSearch,"{""query"": ""select:Read,Bash,Write,Glob,TodoWrite"", ""max_results"": 5}",,False,251,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,4,2,TodoWrite,"{""todos"": [{""content"": ""Read required specs (PRD, use case, test suite, testutils, sys)"", ""status"": ""in_progress"", ""activeForm"": ""Reading required specifications""}, {""content"": ""Implement cmd/nl/main.",,False,160,0
@@ -2517,14 +2517,14 @@ echo ""=== seq -w 1 10 ==="" && ./bin/seq -w 1 ",other,False,284,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,20,14,TodoWrite,"{""todos"": [{""content"": ""Read required specs (PRD, use case, test suite, testutils, sys)"", ""status"": ""completed"", ""activeForm"": ""Reading required specifications""}, {""content"": ""Implement cmd/nl/main.go",,False,160,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,22,15,Bash,go build ./cmd/nl/ 2>&1 || true,go_build,False,168,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,23,16,Bash,go build ./cmd/echo/ 2>&1 || true,go_build,False,170,0
-348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,25,17,Bash,"gofmt -e cmd/nl/main.go > /dev/null 2>&1 && echo ""main.go: syntax OK"" || echo ""main.go: syntax errors""; gofmt -e cmd/nl/nl_test.go > /dev/null 2>&1 && echo ""nl_test.go: syntax OK"" || echo ""nl_test.go:",other,False,40,0
-348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,26,18,Bash,"diff <(gofmt cmd/nl/main.go) cmd/nl/main.go && echo ""main.go: properly formatted"" || echo ""main.go: needs formatting""; diff <(gofmt cmd/nl/nl_test.go) cmd/nl/nl_test.go && echo ""nl_test.go: properly f",other,False,367,0
-348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,27,19,Bash,"gofmt -w cmd/nl/main.go && echo ""Formatted successfully""",other,False,22,0
+348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,25,17,Bash,"gofmt -e cmd/nl/main.go > /dev/null 2>&1 && echo ""main.go: syntax OK"" || echo ""main.go: syntax errors""; gofmt -e cmd/nl/nl_test.go > /dev/null 2>&1 && echo ""nl_test.go: syntax OK"" || echo ""nl_test.go:",format,False,40,0
+348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,26,18,Bash,"diff <(gofmt cmd/nl/main.go) cmd/nl/main.go && echo ""main.go: properly formatted"" || echo ""main.go: needs formatting""; diff <(gofmt cmd/nl/nl_test.go) cmd/nl/nl_test.go && echo ""nl_test.go: properly f",diff,False,367,0
+348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,27,19,Bash,"gofmt -w cmd/nl/main.go && echo ""Formatted successfully""",format,False,22,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,29,20,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/348/cmd/nl/main.go,,False,671,0
-348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,32,21,Bash,"which gnl 2>/dev/null && printf '\\:\\:\\:\nheader line\n\\:\\:\nbody line\n' | gnl -h a 2>&1 | cat -A || echo ""gnl not found""",other,False,27,0
-348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,33,22,Bash,"which nl && printf '\\:\\:\\:\nheader line\n\\:\\:\nbody line\n' | nl -h a 2>&1 | cat -A || echo ""nl not found either""",other,False,90,0
-348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,34,23,Bash,printf '\\:\\:\\:\nheader line\n\\:\\:\nbody line\n' | /usr/bin/nl -h a 2>&1 | od -c | head -20,other,False,226,0
-348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,36,24,Bash,printf '\\:\\:\\:\nheader line\n\\:\\:\nbody line\n' | /usr/bin/nl -h a 2>&1 | xxd | head -10,other,False,191,0
+348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,32,21,Bash,"which gnl 2>/dev/null && printf '\\:\\:\\:\nheader line\n\\:\\:\nbody line\n' | gnl -h a 2>&1 | cat -A || echo ""gnl not found""",env_check,False,27,0
+348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,33,22,Bash,"which nl && printf '\\:\\:\\:\nheader line\n\\:\\:\nbody line\n' | nl -h a 2>&1 | cat -A || echo ""nl not found either""",env_check,False,90,0
+348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,34,23,Bash,printf '\\:\\:\\:\nheader line\n\\:\\:\nbody line\n' | /usr/bin/nl -h a 2>&1 | od -c | head -20,binary_exercise,False,226,0
+348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,36,24,Bash,printf '\\:\\:\\:\nheader line\n\\:\\:\nbody line\n' | /usr/bin/nl -h a 2>&1 | xxd | head -10,binary_exercise,False,191,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,39,25,ToolSearch,"{""query"": ""select:Edit"", ""max_results"": 1}",,False,49,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,40,26,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/348/cmd/nl/main.go,,True,217,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,41,27,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/348/cmd/nl/main.go,,False,568,0
@@ -2533,19 +2533,19 @@ echo ""=== seq -w 1 10 ==="" && ./bin/seq -w 1 ",other,False,284,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,45,30,Bash,"sed -n '110,112p' cmd/nl/main.go | xxd",other,False,460,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,47,31,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/348/cmd/nl/main.go,,False,139,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,49,32,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/348/cmd/nl/main.go,,False,782,0
-348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,52,33,Bash,printf 'a\nb\nc\n' | /usr/bin/nl -b n 2>&1 | xxd,other,False,130,0
-348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,54,34,Bash,printf 'first\n\nsecond\n' | /usr/bin/nl 2>&1 | xxd,other,False,190,0
+348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,52,33,Bash,printf 'a\nb\nc\n' | /usr/bin/nl -b n 2>&1 | xxd,binary_exercise,False,130,0
+348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,54,34,Bash,printf 'first\n\nsecond\n' | /usr/bin/nl 2>&1 | xxd,binary_exercise,False,190,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,56,35,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/348/cmd/nl/nl_test.go,,False,315,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,57,36,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/348/cmd/nl/nl_test.go,,False,324,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,59,37,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/348/cmd/nl/nl_test.go,,False,142,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,61,38,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/348/cmd/nl/nl_test.go,,False,142,0
-348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,63,39,Bash,"gofmt -e cmd/nl/main.go > /dev/null 2>&1 && echo ""main.go: syntax OK""; gofmt -e cmd/nl/nl_test.go > /dev/null 2>&1 && echo ""nl_test.go: syntax OK""; diff <(gofmt cmd/nl/main.go) cmd/nl/main.go > /dev/n",other,False,87,0
+348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,63,39,Bash,"gofmt -e cmd/nl/main.go > /dev/null 2>&1 && echo ""main.go: syntax OK""; gofmt -e cmd/nl/nl_test.go > /dev/null 2>&1 && echo ""nl_test.go: syntax OK""; diff <(gofmt cmd/nl/main.go) cmd/nl/main.go > /dev/n",format,False,87,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,65,40,Bash,grep -c 'fileSections' cmd/nl/nl_test.go,grep,False,1,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,67,41,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/348/cmd/nl/main.go,,False,11208,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,69,42,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/348/cmd/nl/main.go,,False,139,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,70,43,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/348/cmd/nl/main.go,,False,139,0
-348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,71,44,Bash,"gofmt -e cmd/nl/main.go > /dev/null 2>&1 && echo ""syntax OK"" || gofmt -e cmd/nl/main.go 2>&1",other,False,9,0
-348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,72,45,Bash,"diff <(gofmt cmd/nl/main.go) cmd/nl/main.go > /dev/null && echo ""formatted OK"" || diff <(gofmt cmd/nl/main.go) cmd/nl/main.go",other,False,12,0
+348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,71,44,Bash,"gofmt -e cmd/nl/main.go > /dev/null 2>&1 && echo ""syntax OK"" || gofmt -e cmd/nl/main.go 2>&1",format,False,9,0
+348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,72,45,Bash,"diff <(gofmt cmd/nl/main.go) cmd/nl/main.go > /dev/null && echo ""formatted OK"" || diff <(gofmt cmd/nl/main.go) cmd/nl/main.go",diff,False,12,0
 348,numeric,gh-336-generate-code-r05.0,73afb809-9fcb-49d3-bc09-5bbb3bc45bed,,73,46,TodoWrite,"{""todos"": [{""content"": ""Read required specs (PRD, use case, test suite, testutils, sys)"", ""status"": ""completed"", ""activeForm"": ""Reading required specifications""}, {""content"": ""Implement cmd/nl/main.go",,False,160,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,2,1,ToolSearch,"{""query"": ""select:Read,Bash,Write,Edit,Glob,TodoWrite"", ""max_results"": 6}",,False,300,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,4,2,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/349/docs/specs/product-requirements/prd023-fold.yaml,,False,4757,0
@@ -2566,18 +2566,18 @@ echo ""=== seq -w 1 10 ==="" && ./bin/seq -w 1 ",other,False,284,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,25,17,Write,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/349/pkg/testutils/difftest.go,,False,140,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,26,18,Bash,go build -o bin/fold ./cmd/fold/,go_build,False,0,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,28,19,Bash,go test ./cmd/fold/ -v -count=1 2>&1 | tail -40,go_test,False,254,0
-349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,30,20,Bash,which fold 2>/dev/null; which gfold 2>/dev/null; brew list coreutils 2>/dev/null | grep fold | head -5,other,False,29,0
+349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,30,20,Bash,which fold 2>/dev/null; which gfold 2>/dev/null; brew list coreutils 2>/dev/null | grep fold | head -5,env_check,False,29,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,31,21,Bash,"ls /opt/homebrew/opt/coreutils/libexec/gnubin/fold 2>/dev/null || ls /usr/local/opt/coreutils/libexec/gnubin/fold 2>/dev/null || echo ""not found""",ls,False,9,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,32,22,Bash,"brew --prefix coreutils 2>/dev/null && ls ""$(brew --prefix coreutils)/libexec/gnubin/"" 2>/dev/null | grep fold || echo ""coreutils not installed or fold not found""",other,False,69,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,33,23,Bash,ls /opt/homebrew/opt/coreutils/libexec/gnubin/ 2>/dev/null | head -20,ls,False,0,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,34,24,Bash,ls /opt/homebrew/opt/coreutils/bin/ 2>/dev/null | grep fold; ls /opt/homebrew/Cellar/coreutils/*/bin/ 2>/dev/null | grep fold,ls,False,65,0
-349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,36,25,Bash,printf 'abcdefghij' | ./bin/fold -w 4,other,False,12,0
-349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,37,26,Bash,printf 'hello world foo bar' | ./bin/fold -w 11 -s,other,False,21,0
-349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,39,27,Bash,printf 'hello world foo bar' | /usr/bin/fold -w 11 -s | cat -A,other,True,130,0
-349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,40,28,Bash,printf 'hello world foo bar' | /usr/bin/fold -w 11 -s | od -c,other,False,153,0
+349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,36,25,Bash,printf 'abcdefghij' | ./bin/fold -w 4,binary_exercise,False,12,0
+349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,37,26,Bash,printf 'hello world foo bar' | ./bin/fold -w 11 -s,binary_exercise,False,21,0
+349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,39,27,Bash,printf 'hello world foo bar' | /usr/bin/fold -w 11 -s | cat -A,setup,True,130,0
+349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,40,28,Bash,printf 'hello world foo bar' | /usr/bin/fold -w 11 -s | od -c,binary_exercise,False,153,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,42,29,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/349/cmd/fold/main.go,,False,1888,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,44,30,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/349/cmd/fold/main.go,,False,141,0
-349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,46,31,Bash,printf 'ab cd efg' | /usr/bin/fold -w 5 -s | od -c,other,False,80,0
+349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,46,31,Bash,printf 'ab cd efg' | /usr/bin/fold -w 5 -s | od -c,binary_exercise,False,80,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,48,32,Bash,go build -o bin/fold ./cmd/fold/ && printf 'hello world foo\n' | ./bin/fold -w 11 -s | od -c,go_build,False,153,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,50,33,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/349/cmd/fold/main.go,,False,997,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,52,34,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/349/cmd/fold/main.go,,False,141,0
@@ -2589,20 +2589,20 @@ echo ""=== seq -w 1 10 ==="" && ./bin/seq -w 1 ",other,False,284,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,62,40,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/349/cmd/fold/main.go,,False,141,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,64,41,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/349/cmd/fold/main.go,,False,141,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,65,42,Bash,go build -o bin/fold ./cmd/fold/ && printf 'hello world foo\n' | ./bin/fold -w 11 -s | od -c,go_build,False,80,0
-349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,67,43,Bash,"printf 'abcdefghij' | ./bin/fold -w 4 | od -c && echo ""---"" && printf 'abcdefgh\n' | ./bin/fold -w 4 -s | od -c && echo ""---"" && printf 'a\tbcde\n' | ./bin/fold -w 9 | od -c && echo ""---"" && printf 'a",other,False,335,0
-349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,69,44,Bash,printf 'a\tbcde\n' | ./bin/fold -w 9 | xxd,other,False,59,0
-349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,71,45,Bash,printf 'a\tbcde\n' | /usr/bin/fold -w 9 | xxd,other,False,59,0
-349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,73,46,Bash,"printf 'hello world foo bar' | ./bin/fold -w 11 -s && echo ""=="" && printf 'abcdefgh\n' | ./bin/fold -w 4 -s && echo ""=="" && printf 'one two three four five six\n' | ./bin/fold -w 10 -s",other,False,65,0
+349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,67,43,Bash,"printf 'abcdefghij' | ./bin/fold -w 4 | od -c && echo ""---"" && printf 'abcdefgh\n' | ./bin/fold -w 4 -s | od -c && echo ""---"" && printf 'a\tbcde\n' | ./bin/fold -w 9 | od -c && echo ""---"" && printf 'a",binary_exercise,False,335,0
+349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,69,44,Bash,printf 'a\tbcde\n' | ./bin/fold -w 9 | xxd,binary_exercise,False,59,0
+349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,71,45,Bash,printf 'a\tbcde\n' | /usr/bin/fold -w 9 | xxd,binary_exercise,False,59,0
+349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,73,46,Bash,"printf 'hello world foo bar' | ./bin/fold -w 11 -s && echo ""=="" && printf 'abcdefgh\n' | ./bin/fold -w 4 -s && echo ""=="" && printf 'one two three four five six\n' | ./bin/fold -w 10 -s",binary_exercise,False,65,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,75,47,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/349/cmd/fold/main.go,,False,493,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,76,48,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/349/cmd/fold/main.go,,False,141,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,77,49,Bash,"go build -o bin/fold ./cmd/fold/ && printf 'one two three four five six\n' | ./bin/fold -w 10 -s && echo ""=="" && printf 'hello world foo\n' | ./bin/fold -w 11 -s && echo ""=="" && printf 'abcdefgh\n' | ",go_build,False,60,0
-349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,79,50,Bash,printf 'one two three four five six\n' | /usr/bin/fold -w 10 -s | od -c,other,False,153,0
+349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,79,50,Bash,printf 'one two three four five six\n' | /usr/bin/fold -w 10 -s | od -c,binary_exercise,False,153,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,81,51,Bash,go test ./cmd/fold/ -v -count=1 2>&1 | tail -10,go_test,False,254,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,83,52,Bash,"go build -o bin/fold ./cmd/fold/ && echo ""Build OK"" && go vet ./cmd/fold/ && echo ""Vet OK""",go_build,False,15,0
-349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,85,53,Bash,"printf '' | ./bin/fold | od -c && echo ""---empty"" && printf '\n' | ./bin/fold | od -c && echo ""---newline"" && printf 'abc' | ./bin/fold -w 1 | od -c && echo ""---width1""",other,False,191,0
-349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,87,54,Bash,"which golangci-lint 2>/dev/null && golangci-lint run ./cmd/fold/ 2>&1 || echo ""golangci-lint not installed""",other,False,227,0
+349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,85,53,Bash,"printf '' | ./bin/fold | od -c && echo ""---empty"" && printf '\n' | ./bin/fold | od -c && echo ""---newline"" && printf 'abc' | ./bin/fold -w 1 | od -c && echo ""---width1""",binary_exercise,False,191,0
+349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,87,54,Bash,"which golangci-lint 2>/dev/null && golangci-lint run ./cmd/fold/ 2>&1 || echo ""golangci-lint not installed""",env_check,False,227,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,89,55,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/349/cmd/fold/main.go,,False,141,0
-349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,90,56,Bash,golangci-lint run ./cmd/fold/ 2>&1,other,False,9,0
+349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,90,56,Bash,golangci-lint run ./cmd/fold/ 2>&1,lint,False,9,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,92,57,Bash,go build -o bin/fold ./cmd/fold/ && go test ./cmd/fold/ -count=1 2>&1,go_build,False,58,0
 349,numeric,gh-336-generate-code-r05.0,ab279970-93cc-4d72-a577-0214f24f20cf,,93,58,TodoWrite,"{""todos"": [{""content"": ""Create cmd/fold/main.go"", ""status"": ""completed"", ""activeForm"": ""Creating cmd/fold/main.go""}, {""content"": ""Create cmd/fold/fold_test.go"", ""status"": ""completed"", ""activeForm"": ""C",,False,160,0
 351,numeric,gh-336-generate-code-r05.1,7a7c2a9f-55e1-4be3-bdbc-961046b78ffd,,2,1,ToolSearch,"{""query"": ""select:Read,Bash,Write,Glob,TodoWrite"", ""max_results"": 5}",,False,251,0
@@ -2634,11 +2634,11 @@ echo ""=== seq -w 1 10 ==="" && ./bin/seq -w 1 ",other,False,284,0
 351,numeric,gh-336-generate-code-r05.1,7a7c2a9f-55e1-4be3-bdbc-961046b78ffd,,38,27,Bash,go build -o bin/expand ./cmd/expand/ 2>&1,go_build,False,0,0
 351,numeric,gh-336-generate-code-r05.1,7a7c2a9f-55e1-4be3-bdbc-961046b78ffd,,39,28,Bash,go vet ./cmd/expand/ 2>&1,go_vet,False,0,0
 351,numeric,gh-336-generate-code-r05.1,7a7c2a9f-55e1-4be3-bdbc-961046b78ffd,,41,29,Bash,go test ./cmd/expand/ -v -count=1 2>&1,go_test,False,262,0
-351,numeric,gh-336-generate-code-r05.1,7a7c2a9f-55e1-4be3-bdbc-961046b78ffd,,43,30,Bash,"printf 'a\tb\n' | ./bin/expand | cat -A; echo ""---""; printf '\t\tx\n' | ./bin/expand | cat -A; echo ""---""; printf 'hello world\n' | ./bin/expand | cat -A; echo ""---""; printf 'a\tb\n' | ./bin/expand -t",other,True,886,0
-351,numeric,gh-336-generate-code-r05.1,7a7c2a9f-55e1-4be3-bdbc-961046b78ffd,,44,31,Bash,"printf 'a\tb\n' | ./bin/expand | od -c | head -5; echo ""===expected: a + 7 spaces + b + newline===""; printf '\t\tx\n' | ./bin/expand | od -c | head -5; echo ""===expected: 16 spaces + x + newline===""; ",other,False,576,0
-351,numeric,gh-336-generate-code-r05.1,7a7c2a9f-55e1-4be3-bdbc-961046b78ffd,,46,32,Bash,"printf '\ta\tb\n' | ./bin/expand -i | od -c; echo ""===expected: 8 spaces + a + tab + b + newline (only leading tab converted)===""; printf '\ta\n\tb\n' | ./bin/expand | od -c; echo ""===expected: 8 spac",other,False,376,0
-351,numeric,gh-336-generate-code-r05.1,7a7c2a9f-55e1-4be3-bdbc-961046b78ffd,,48,33,Bash,"printf '\t\t\tx\n' | ./bin/expand -t 4,8 | od -c; echo ""===tab1->col4, tab2->col8, tab3 past last stop: single space===""",other,False,144,0
-351,numeric,gh-336-generate-code-r05.1,7a7c2a9f-55e1-4be3-bdbc-961046b78ffd,,51,34,Bash,"./bin/expand --help > /dev/null 2>&1; echo ""help exit: $?""; ./bin/expand --version > /dev/null 2>&1; echo ""version exit: $?""",other,False,28,0
+351,numeric,gh-336-generate-code-r05.1,7a7c2a9f-55e1-4be3-bdbc-961046b78ffd,,43,30,Bash,"printf 'a\tb\n' | ./bin/expand | cat -A; echo ""---""; printf '\t\tx\n' | ./bin/expand | cat -A; echo ""---""; printf 'hello world\n' | ./bin/expand | cat -A; echo ""---""; printf 'a\tb\n' | ./bin/expand -t",binary_exercise,True,886,0
+351,numeric,gh-336-generate-code-r05.1,7a7c2a9f-55e1-4be3-bdbc-961046b78ffd,,44,31,Bash,"printf 'a\tb\n' | ./bin/expand | od -c | head -5; echo ""===expected: a + 7 spaces + b + newline===""; printf '\t\tx\n' | ./bin/expand | od -c | head -5; echo ""===expected: 16 spaces + x + newline===""; ",binary_exercise,False,576,0
+351,numeric,gh-336-generate-code-r05.1,7a7c2a9f-55e1-4be3-bdbc-961046b78ffd,,46,32,Bash,"printf '\ta\tb\n' | ./bin/expand -i | od -c; echo ""===expected: 8 spaces + a + tab + b + newline (only leading tab converted)===""; printf '\ta\n\tb\n' | ./bin/expand | od -c; echo ""===expected: 8 spac",binary_exercise,False,376,0
+351,numeric,gh-336-generate-code-r05.1,7a7c2a9f-55e1-4be3-bdbc-961046b78ffd,,48,33,Bash,"printf '\t\t\tx\n' | ./bin/expand -t 4,8 | od -c; echo ""===tab1->col4, tab2->col8, tab3 past last stop: single space===""",binary_exercise,False,144,0
+351,numeric,gh-336-generate-code-r05.1,7a7c2a9f-55e1-4be3-bdbc-961046b78ffd,,51,34,Bash,"./bin/expand --help > /dev/null 2>&1; echo ""help exit: $?""; ./bin/expand --version > /dev/null 2>&1; echo ""version exit: $?""",binary_run,False,28,0
 351,numeric,gh-336-generate-code-r05.1,7a7c2a9f-55e1-4be3-bdbc-961046b78ffd,,52,35,TodoWrite,"{""todos"": [{""content"": ""Read PRD, use case, test suite, and reference implementations"", ""status"": ""completed"", ""activeForm"": ""Reading required documentation""}, {""content"": ""Implement cmd/expand/main.g",,False,160,0
 352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,2,1,ToolSearch,"{""query"": ""select:Read,Bash,Write,TodoWrite"", ""max_results"": 4}",,False,202,0
 352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,4,2,TodoWrite,"{""todos"": [{""content"": ""Read PRD and specs for unexpand"", ""status"": ""in_progress"", ""activeForm"": ""Reading PRD and specs for unexpand""}, {""content"": ""Create cmd/unexpand/main.go"", ""status"": ""pending"", ",,False,160,0
@@ -2655,18 +2655,18 @@ echo ""=== seq -w 1 10 ==="" && ./bin/seq -w 1 ",other,False,284,0
 352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,16,13,Bash,go build -o bin/unexpand ./cmd/unexpand/,go_build,False,0,0
 352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,17,14,Bash,go vet ./cmd/unexpand/,go_vet,False,0,0
 352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,18,15,Bash,go test ./cmd/unexpand/ -v 2>&1,go_test,False,270,0
-352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,20,16,Bash,"PATH=""/opt/homebrew/bin:/usr/local/bin:$PATH"" go test ./cmd/unexpand/ -v 2>&1",other,False,270,0
-352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,21,17,Bash,which gunexpand 2>/dev/null || find /opt/homebrew /usr/local -name gunexpand 2>/dev/null | head -3,other,False,19,0
-352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,23,18,Bash,printf '        text\n' | ./bin/unexpand | cat -A,other,True,130,0
-352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,24,19,Bash,printf 'a        b\n' | ./bin/unexpand | cat -A,other,True,118,0
-352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,25,20,Bash,printf 'a        b\n' | ./bin/unexpand -a | cat -A,other,True,118,0
-352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,26,21,Bash,printf '   text\n' | ./bin/unexpand | cat -A,other,True,118,0
-352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,27,22,Bash,printf '    text\n' | ./bin/unexpand -t 4 | cat -A,other,True,118,0
-352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,28,23,Bash,printf '        text\n' | ./bin/unexpand | od -c | head -5,other,False,80,0
-352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,29,24,Bash,printf 'a        b\n' | ./bin/unexpand | od -c | head -5,other,False,80,0
-352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,30,25,Bash,printf 'a        b\n' | ./bin/unexpand -a | od -c | head -5,other,False,80,0
-352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,31,26,Bash,printf '   text\n' | ./bin/unexpand | od -c | head -5,other,False,80,0
-352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,32,27,Bash,printf '    text\n' | ./bin/unexpand -t 4 | od -c | head -5,other,False,80,0
+352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,20,16,Bash,"PATH=""/opt/homebrew/bin:/usr/local/bin:$PATH"" go test ./cmd/unexpand/ -v 2>&1",go_test,False,270,0
+352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,21,17,Bash,which gunexpand 2>/dev/null || find /opt/homebrew /usr/local -name gunexpand 2>/dev/null | head -3,env_check,False,19,0
+352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,23,18,Bash,printf '        text\n' | ./bin/unexpand | cat -A,binary_exercise,True,130,0
+352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,24,19,Bash,printf 'a        b\n' | ./bin/unexpand | cat -A,binary_exercise,True,118,0
+352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,25,20,Bash,printf 'a        b\n' | ./bin/unexpand -a | cat -A,binary_exercise,True,118,0
+352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,26,21,Bash,printf '   text\n' | ./bin/unexpand | cat -A,binary_exercise,True,118,0
+352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,27,22,Bash,printf '    text\n' | ./bin/unexpand -t 4 | cat -A,binary_exercise,True,118,0
+352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,28,23,Bash,printf '        text\n' | ./bin/unexpand | od -c | head -5,binary_exercise,False,80,0
+352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,29,24,Bash,printf 'a        b\n' | ./bin/unexpand | od -c | head -5,binary_exercise,False,80,0
+352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,30,25,Bash,printf 'a        b\n' | ./bin/unexpand -a | od -c | head -5,binary_exercise,False,80,0
+352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,31,26,Bash,printf '   text\n' | ./bin/unexpand | od -c | head -5,binary_exercise,False,80,0
+352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,32,27,Bash,printf '    text\n' | ./bin/unexpand -t 4 | od -c | head -5,binary_exercise,False,80,0
 352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,34,28,Bash,wc -l cmd/unexpand/main.go,wc,False,29,0
 352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,36,29,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/352/cmd/unexpand/main.go,,False,10901,0
 352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,38,30,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/352/cmd/unexpand/main.go,,False,145,0
@@ -2679,7 +2679,7 @@ echo ""=== seq -w 1 10 ==="" && ./bin/seq -w 1 ",other,False,284,0
 352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,50,37,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/352/cmd/unexpand/main.go,,False,145,0
 352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,51,38,Bash,wc -l cmd/unexpand/main.go && go build -o bin/unexpand ./cmd/unexpand/ && go vet ./cmd/unexpand/,wc,False,29,0
 352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,53,39,Bash,go test ./cmd/unexpand/ -v 2>&1,go_test,False,270,0
-352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,54,40,Bash,printf '        text\n' | ./bin/unexpand | od -c | head -3 && printf 'a        b\n' | ./bin/unexpand | od -c | head -3 && printf 'a        b\n' | ./bin/unexpand -a | od -c | head -3 && printf '   text,other,False,323,0
+352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,54,40,Bash,printf '        text\n' | ./bin/unexpand | od -c | head -3 && printf 'a        b\n' | ./bin/unexpand | od -c | head -3 && printf 'a        b\n' | ./bin/unexpand -a | od -c | head -3 && printf '   text,binary_exercise,False,323,0
 352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,56,41,Bash,go test ./cmd/expand/ -v 2>&1 | tail -5,go_test,False,224,0
 352,numeric,gh-336-generate-code-r05.1,a8da431a-575c-43a7-97e5-a163d19babfc,,57,42,TodoWrite,"{""todos"": [{""content"": ""Read PRD and specs for unexpand"", ""status"": ""completed"", ""activeForm"": ""Reading PRD and specs for unexpand""}, {""content"": ""Create cmd/unexpand/main.go"", ""status"": ""completed"", ",,False,160,0
 354,numeric,gh-336-generate-code-r05.2,7f934305-abec-4afb-9510-aae792fc87a6,,3,1,ToolSearch,"{""query"": ""select:Read,Write,Bash,Glob"", ""max_results"": 4}",,False,197,0
@@ -2695,8 +2695,8 @@ echo ""=== seq -w 1 10 ==="" && ./bin/seq -w 1 ",other,False,284,0
 354,numeric,gh-336-generate-code-r05.2,7f934305-abec-4afb-9510-aae792fc87a6,,19,11,ToolSearch,"{""query"": ""select:Edit"", ""max_results"": 1}",,False,49,0
 354,numeric,gh-336-generate-code-r05.2,7f934305-abec-4afb-9510-aae792fc87a6,,22,12,Write,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/354/cmd/cut/main.go,,False,140,0
 354,numeric,gh-336-generate-code-r05.2,7f934305-abec-4afb-9510-aae792fc87a6,,24,13,Bash,go build -o bin/cut ./cmd/cut/,go_build,False,0,0
-354,numeric,gh-336-generate-code-r05.2,7f934305-abec-4afb-9510-aae792fc87a6,,26,14,Bash,echo '--- AC2: -d: -f2 ---' && echo 'a:b:c' | ./bin/cut -d: -f2 && echo '--- AC3a: -b 2-4 ---' && echo 'abcdef' | ./bin/cut -b2-4 && echo '--- AC3b: -b 3- ---' && echo 'abcdef' | ./bin/cut -b3- && ech,echo,False,333,0
-354,numeric,gh-336-generate-code-r05.2,7f934305-abec-4afb-9510-aae792fc87a6,,28,15,Bash,"echo '--- Error: no mode ---' && ./bin/cut 2>&1; echo ""exit: $?"" && echo '--- Error: -s without -f ---' && ./bin/cut -b1 -s 2>&1; echo ""exit: $?"" && echo '--- Error: missing file ---' && ./bin/cut -f1",echo,False,371,0
+354,numeric,gh-336-generate-code-r05.2,7f934305-abec-4afb-9510-aae792fc87a6,,26,14,Bash,echo '--- AC2: -d: -f2 ---' && echo 'a:b:c' | ./bin/cut -d: -f2 && echo '--- AC3a: -b 2-4 ---' && echo 'abcdef' | ./bin/cut -b2-4 && echo '--- AC3b: -b 3- ---' && echo 'abcdef' | ./bin/cut -b3- && ech,binary_exercise,False,333,0
+354,numeric,gh-336-generate-code-r05.2,7f934305-abec-4afb-9510-aae792fc87a6,,28,15,Bash,"echo '--- Error: no mode ---' && ./bin/cut 2>&1; echo ""exit: $?"" && echo '--- Error: -s without -f ---' && ./bin/cut -b1 -s 2>&1; echo ""exit: $?"" && echo '--- Error: missing file ---' && ./bin/cut -f1",binary_exercise,False,371,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,2,1,ToolSearch,"{""query"": ""select:Read,Bash,Write,Glob,TodoWrite"", ""max_results"": 5}",,False,251,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,4,2,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/355/docs/specs/product-requirements/prd027-paste.yaml,,False,4369,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,5,3,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/355/docs/specs/use-cases/rel05.2-uc002-paste.yaml,,False,3364,0
@@ -2715,39 +2715,39 @@ echo ""=== seq -w 1 10 ==="" && ./bin/seq -w 1 ",other,False,284,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,24,16,TodoWrite,"{""todos"": [{""content"": ""Create cmd/paste/main.go with parallel merge, serial mode, delimiter cycling, file handling"", ""status"": ""completed"", ""activeForm"": ""Creating cmd/paste/main.go""}, {""content"": ""C",,False,160,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,25,17,Bash,go build -o bin/paste ./cmd/paste/ 2>&1,go_build,False,0,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,26,18,Bash,go test ./cmd/paste/ -v -count=1 2>&1,go_test,False,221,0
-355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,28,19,Bash,"which gpaste 2>/dev/null || brew --prefix coreutils 2>/dev/null && ls ""$(brew --prefix coreutils)/libexec/gnubin/paste"" 2>/dev/null || echo ""gpaste not found""",other,False,61,0
+355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,28,19,Bash,"which gpaste 2>/dev/null || brew --prefix coreutils 2>/dev/null && ls ""$(brew --prefix coreutils)/libexec/gnubin/paste"" 2>/dev/null || echo ""gpaste not found""",env_check,False,61,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,29,20,Bash,"ls ""$(brew --prefix coreutils)/libexec/gnubin/"" 2>/dev/null | head -20",ls,False,0,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,30,21,Bash,ls /opt/homebrew/opt/coreutils/bin/ 2>/dev/null | grep paste,ls,False,0,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,31,22,Bash,ls /opt/homebrew/bin/gpaste 2>/dev/null; which paste 2>/dev/null; ls /opt/homebrew/Cellar/coreutils/*/bin/ 2>/dev/null | grep paste,ls,False,80,0
-355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,33,23,Bash,cd /tmp && mkdir -p paste_test && printf 'a\nb\n' > paste_test/f1.txt && printf '1\n2\n' > paste_test/f2.txt && /private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/355/bin,other,True,130,0
-355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,34,24,Bash,BIN=/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/355/bin/paste && cd /tmp && printf 'a\nb\n' > f1.txt && printf '1\n2\n' > f2.txt && printf 'x\ny\nz\n' > f3.txt && ,other,True,209,0
-355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,35,25,Bash,PASTE=/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/355/bin/paste && printf 'a\nb\n' > /tmp/f1.txt && printf '1\n2\n' > /tmp/f2.txt && printf 'x\ny\nz\n' > /tmp/f3.t,other,True,209,0
+355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,33,23,Bash,cd /tmp && mkdir -p paste_test && printf 'a\nb\n' > paste_test/f1.txt && printf '1\n2\n' > paste_test/f2.txt && /private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/355/bin,env_inspect,True,130,0
+355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,34,24,Bash,BIN=/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/355/bin/paste && cd /tmp && printf 'a\nb\n' > f1.txt && printf '1\n2\n' > f2.txt && printf 'x\ny\nz\n' > f3.txt && ,env_inspect,True,209,0
+355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,35,25,Bash,PASTE=/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/355/bin/paste && printf 'a\nb\n' > /tmp/f1.txt && printf '1\n2\n' > /tmp/f2.txt && printf 'x\ny\nz\n' > /tmp/f3.t,binary_exercise,True,209,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,36,26,Bash,ls -la /private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/355/bin/paste,ls,False,144,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,37,27,Bash,"P=""/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/355/bin/paste""
 printf 'a\nb\n' > /tmp/f1.txt
 printf '1\n2\n' > /tmp/f2.txt
-""$P"" /tmp/f1.txt /tmp/f2.txt",other,False,7,0
+""$P"" /tmp/f1.txt /tmp/f2.txt",setup,False,7,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,38,28,Bash,"P=""/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/355/bin/paste""
 printf 'a\nb\nc\n' > /tmp/f3.txt
 echo ""=== custom delim ==="" && ""$P"" -d: /tmp/f1.txt /tmp/f2.txt
-echo",other,True,73,0
+echo",setup,True,73,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,39,29,Bash,"P=""/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/355/bin/paste""; ""$P"" -d: /tmp/f1.txt /tmp/f2.txt",other,False,7,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,40,30,Bash,"P=""/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/355/bin/paste""; ""$P"" -s /tmp/f1.txt",other,False,3,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,41,31,Bash,"P=""/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/355/bin/paste""
 printf 'a\nb\nc\n' > /tmp/f3.txt
-""$P"" /tmp/f3.txt /tmp/f2.txt",other,False,9,0
+""$P"" /tmp/f3.txt /tmp/f2.txt",setup,False,9,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,43,32,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/355/cmd/paste/main.go,,False,919,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,45,33,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/355/cmd/paste/main.go,,False,142,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,46,34,Bash,"go build -o bin/paste ./cmd/paste/ && P=""bin/paste"" && printf 'a\nb\nc\n' > /tmp/f3.txt && printf '1\n' > /tmp/f2s.txt && ""$P"" /tmp/f3.txt /tmp/f2s.txt | xxd",go_build,False,28,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,47,35,Bash,go build -o bin/paste ./cmd/paste/,go_build,False,0,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,48,36,Bash,"printf 'a\nb\nc\n' > /tmp/f3.txt
 printf '1\n' > /tmp/f2s.txt
-./bin/paste /tmp/f3.txt /tmp/f2s.txt | od -c",other,False,80,0
-355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,50,37,Bash,pwd,other,False,84,0
+./bin/paste /tmp/f3.txt /tmp/f2s.txt | od -c",binary_exercise,False,80,0
+355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,50,37,Bash,pwd,env_inspect,False,84,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,51,38,Bash,go build -o /tmp/paste_test_bin ./cmd/paste/ && printf 'a\nb\nc\n' > /tmp/f3.txt && printf '1\n' > /tmp/f2s.txt && /tmp/paste_test_bin /tmp/f3.txt /tmp/f2s.txt | od -c,go_build,False,80,0
-355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,53,39,Bash,printf 'a\nb\n' > /tmp/f1.txt && printf '1\n2\n' > /tmp/f2.txt && /tmp/paste_test_bin /tmp/f1.txt /tmp/f2.txt | od -c,other,False,80,0
+355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,53,39,Bash,printf 'a\nb\n' > /tmp/f1.txt && printf '1\n2\n' > /tmp/f2.txt && /tmp/paste_test_bin /tmp/f1.txt /tmp/f2.txt | od -c,binary_exercise,False,80,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,54,40,Bash,"/tmp/paste_test_bin -s /tmp/f1.txt && echo ""---"" && /tmp/paste_test_bin -d: /tmp/f1.txt /tmp/f2.txt && echo ""---"" && printf 'a\nb\n' > /tmp/fa.txt && /tmp/paste_test_bin ""-d,:"" /tmp/fa.txt /tmp/f2.txt",other,False,31,0
-355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,56,41,Bash,"echo hello | /tmp/paste_test_bin && echo ""---"" && printf '' > /tmp/empty.txt && /tmp/paste_test_bin /tmp/f1.txt /tmp/empty.txt | od -c",echo,False,90,0
+355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,56,41,Bash,"echo hello | /tmp/paste_test_bin && echo ""---"" && printf '' > /tmp/empty.txt && /tmp/paste_test_bin /tmp/f1.txt /tmp/empty.txt | od -c",binary_exercise,False,90,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,58,42,Bash,go test ./cmd/paste/ -v -count=1 2>&1,go_test,False,221,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,59,43,Bash,go build ./... 2>&1,go_build,False,0,0
 355,numeric,gh-336-generate-code-r05.2,8cc92e92-4320-4730-860e-38fed7bca8cc,,60,44,Bash,go vet ./cmd/paste/ 2>&1,go_vet,False,0,0
@@ -2767,17 +2767,17 @@ printf '1\n' > /tmp/f2s.txt
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,21,13,Write,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/357/cmd/uniq/main.go,,False,131,0
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,23,14,Bash,go build -o bin/uniq ./cmd/uniq/ 2>&1,go_build,False,0,0
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,24,15,Bash,go vet ./cmd/uniq/ 2>&1 && go vet ./pkg/sys/ 2>&1,go_vet,False,0,0
-357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,25,16,Bash,printf 'a\na\nb\nb\na\n' | bin/uniq,other,False,5,0
-357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,26,17,Bash,bin/uniq --version,other,False,24,0
-357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,27,18,Bash,bin/uniq --help | head -5,other,False,212,0
-357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,28,19,Bash,printf 'a\na\nb\n' | bin/uniq -c,other,False,19,0
-357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,29,20,Bash,printf 'a\na\nb\n' | bin/uniq -d,other,False,1,0
-357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,30,21,Bash,printf 'a\na\nb\n' | bin/uniq -u,other,False,1,0
-357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,31,22,Bash,printf 'A\na\nb\n' | bin/uniq -i,other,False,3,0
-357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,32,23,Bash,printf 'a\na\nb\n' | bin/uniq -D,other,False,3,0
-357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,33,24,Bash,printf 'key1 val\nkey2 val\nkey3 other\n' | bin/uniq -f 1,other,False,19,0
-357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,35,25,Bash,"which guniq 2>&1 || echo ""not found""",other,False,25,0
-357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,36,26,Bash,"which guniq 2>/dev/null || brew --prefix coreutils 2>/dev/null && ls ""$(brew --prefix coreutils)/bin/guniq"" 2>/dev/null || echo ""guniq not available""",other,False,63,0
+357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,25,16,Bash,printf 'a\na\nb\nb\na\n' | bin/uniq,binary_exercise,False,5,0
+357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,26,17,Bash,bin/uniq --version,binary_run,False,24,0
+357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,27,18,Bash,bin/uniq --help | head -5,binary_run,False,212,0
+357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,28,19,Bash,printf 'a\na\nb\n' | bin/uniq -c,binary_exercise,False,19,0
+357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,29,20,Bash,printf 'a\na\nb\n' | bin/uniq -d,binary_exercise,False,1,0
+357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,30,21,Bash,printf 'a\na\nb\n' | bin/uniq -u,binary_exercise,False,1,0
+357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,31,22,Bash,printf 'A\na\nb\n' | bin/uniq -i,binary_exercise,False,3,0
+357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,32,23,Bash,printf 'a\na\nb\n' | bin/uniq -D,binary_exercise,False,3,0
+357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,33,24,Bash,printf 'key1 val\nkey2 val\nkey3 other\n' | bin/uniq -f 1,binary_exercise,False,19,0
+357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,35,25,Bash,"which guniq 2>&1 || echo ""not found""",env_check,False,25,0
+357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,36,26,Bash,"which guniq 2>/dev/null || brew --prefix coreutils 2>/dev/null && ls ""$(brew --prefix coreutils)/bin/guniq"" 2>/dev/null || echo ""guniq not available""",env_check,False,63,0
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,38,27,Bash,wc -l cmd/uniq/main.go,wc,False,25,0
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,40,28,Write,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/357/cmd/uniq/main.go,,False,141,0
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,41,29,Bash,wc -l cmd/uniq/main.go,wc,False,25,0
@@ -2786,7 +2786,7 @@ printf '1\n' > /tmp/f2s.txt
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,45,32,Bash,wc -l cmd/uniq/main.go,wc,False,25,0
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,47,33,Bash,go build -o bin/uniq ./cmd/uniq/ && go vet ./cmd/uniq/ ./pkg/sys/ 2>&1,go_build,False,0,0
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,48,34,Bash,"# AC4: Basic functionality tests
-echo ""=== default dedup ==="" && printf 'a\na\nb\nb\na\n' | bin/uniq && echo ""=== -c count ==="" && printf 'a\na\nb\n' | bin/uniq -c && echo ""=== -d repeated ==="" && pri",other,True,1858,0
+echo ""=== default dedup ==="" && printf 'a\na\nb\nb\na\n' | bin/uniq && echo ""=== -c count ==="" && printf 'a\na\nb\n' | bin/uniq -c && echo ""=== -d repeated ==="" && pri",binary_exercise,True,1858,0
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,50,35,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/357/cmd/uniq/main.go,,False,7861,0
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,53,36,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/357/cmd/uniq/main.go,,False,141,0
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,54,37,Bash,wc -l cmd/uniq/main.go,wc,False,25,0
@@ -2796,23 +2796,23 @@ echo ""=== default dedup ==="" && printf 'a\na\nb\nb\na\n' | bin/uniq && echo ""
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,61,41,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/357/cmd/uniq/main.go,,False,141,0
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,62,42,Bash,wc -l cmd/uniq/main.go && go build -o bin/uniq ./cmd/uniq/ && go vet ./cmd/uniq/ 2>&1,wc,False,25,0
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,64,43,Bash,"# AC4: basic dedup
-printf 'a\na\nb\nb\na\n' | bin/uniq",other,False,5,0
+printf 'a\na\nb\nb\na\n' | bin/uniq",binary_exercise,False,5,0
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,65,44,Bash,"# AC4: -c count
-printf 'a\na\nb\n' | bin/uniq -c",other,False,19,0
+printf 'a\na\nb\n' | bin/uniq -c",binary_exercise,False,19,0
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,66,45,Bash,"# AC4: -d repeated
-printf 'a\na\nb\n' | bin/uniq -d",other,False,1,0
+printf 'a\na\nb\n' | bin/uniq -d",binary_exercise,False,1,0
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,67,46,Bash,"# AC4: -u unique
-printf 'a\na\nb\n' | bin/uniq -u",other,False,1,0
+printf 'a\na\nb\n' | bin/uniq -u",binary_exercise,False,1,0
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,68,47,Bash,"# AC5: -i case insensitive
-printf 'A\na\nb\n' | bin/uniq -i",other,False,3,0
+printf 'A\na\nb\n' | bin/uniq -i",binary_exercise,False,3,0
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,69,48,Bash,"# AC5: -D all duplicates
-printf 'a\na\nb\n' | bin/uniq -D",other,False,3,0
+printf 'a\na\nb\n' | bin/uniq -D",binary_exercise,False,3,0
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,70,49,Bash,"# AC5: -f 1 skip fields
-printf 'key1 val\nkey2 val\nkey3 other\n' | bin/uniq -f 1",other,False,19,0
+printf 'key1 val\nkey2 val\nkey3 other\n' | bin/uniq -f 1",binary_exercise,False,19,0
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,71,50,Bash,"# AC5: -z NUL terminator
-printf 'a\0a\0b\0' | bin/uniq -z | od -c | head",other,False,80,0
+printf 'a\0a\0b\0' | bin/uniq -z | od -c | head",binary_exercise,False,80,0
 357,numeric,gh-336-generate-code-r05.3,80e98de1-9ba5-41b6-9248-92412e595065,,72,51,Bash,"# AC3: --version and --help
-bin/uniq --version; echo ""exit=$?""; bin/uniq --help >/dev/null; echo ""exit=$?""",other,False,38,0
+bin/uniq --version; echo ""exit=$?""; bin/uniq --help >/dev/null; echo ""exit=$?""",binary_run,False,38,0
 358,numeric,gh-336-generate-code-r05.3,4c872d7a-5073-490d-aeb2-b9cbd293cce9,,2,1,ToolSearch,"{""query"": ""select:Read,Write,Bash,Glob,TodoWrite"", ""max_results"": 5}",,False,251,0
 358,numeric,gh-336-generate-code-r05.3,4c872d7a-5073-490d-aeb2-b9cbd293cce9,,4,2,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/358/docs/specs/product-requirements/prd029-comm.yaml,,False,4670,0
 358,numeric,gh-336-generate-code-r05.3,4c872d7a-5073-490d-aeb2-b9cbd293cce9,,5,3,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/358/docs/specs/use-cases/rel05.3-uc002-comm.yaml,,False,3310,0
@@ -2829,12 +2829,12 @@ bin/uniq --version; echo ""exit=$?""; bin/uniq --help >/dev/null; echo ""exit=$?
 358,numeric,gh-336-generate-code-r05.3,4c872d7a-5073-490d-aeb2-b9cbd293cce9,,20,14,TodoWrite,"{""todos"": [{""content"": ""Implement cmd/comm/main.go"", ""status"": ""completed"", ""activeForm"": ""Implementing cmd/comm/main.go""}, {""content"": ""Implement cmd/comm/comm_test.go"", ""status"": ""completed"", ""activ",,False,160,0
 358,numeric,gh-336-generate-code-r05.3,4c872d7a-5073-490d-aeb2-b9cbd293cce9,,21,15,Bash,go build -o bin/comm ./cmd/comm/ 2>&1,go_build,False,0,0
 358,numeric,gh-336-generate-code-r05.3,4c872d7a-5073-490d-aeb2-b9cbd293cce9,,22,16,Bash,go test ./cmd/comm/... -v -count=1 2>&1,go_test,False,554,0
-358,numeric,gh-336-generate-code-r05.3,4c872d7a-5073-490d-aeb2-b9cbd293cce9,,24,17,Bash,which gcomm 2>/dev/null || which comm 2>/dev/null || brew list coreutils 2>/dev/null | grep comm | head -3,other,False,29,0
+358,numeric,gh-336-generate-code-r05.3,4c872d7a-5073-490d-aeb2-b9cbd293cce9,,24,17,Bash,which gcomm 2>/dev/null || which comm 2>/dev/null || brew list coreutils 2>/dev/null | grep comm | head -3,env_check,False,29,0
 358,numeric,gh-336-generate-code-r05.3,4c872d7a-5073-490d-aeb2-b9cbd293cce9,,25,18,Bash,"brew --prefix coreutils 2>/dev/null && ls ""$(brew --prefix coreutils)/libexec/gnubin/"" 2>/dev/null | grep comm",other,False,27,0
 358,numeric,gh-336-generate-code-r05.3,4c872d7a-5073-490d-aeb2-b9cbd293cce9,,26,19,Bash,ls /opt/homebrew/opt/coreutils/libexec/gnubin/comm 2>/dev/null && /opt/homebrew/opt/coreutils/libexec/gnubin/comm --version 2>&1 | head -1,ls,True,11,0
 358,numeric,gh-336-generate-code-r05.3,4c872d7a-5073-490d-aeb2-b9cbd293cce9,,27,20,Bash,"ls /opt/homebrew/bin/gcomm 2>/dev/null; ls /opt/homebrew/opt/coreutils/bin/gcomm 2>/dev/null; find /opt/homebrew -name ""gcomm"" -type f 2>/dev/null | head -3",ls,False,0,0
-358,numeric,gh-336-generate-code-r05.3,4c872d7a-5073-490d-aeb2-b9cbd293cce9,,29,21,Bash,"printf 'a\nb\nc\n' > /tmp/comm_f1.txt && printf 'b\nc\nd\n' > /tmp/comm_f2.txt && echo ""=== basic ==="" && ./bin/comm /tmp/comm_f1.txt /tmp/comm_f2.txt && echo ""=== -12 ==="" && ./bin/comm -12 /tmp/comm",other,False,141,0
-358,numeric,gh-336-generate-code-r05.3,4c872d7a-5073-490d-aeb2-b9cbd293cce9,,30,22,Bash,"echo ""=== empty file1 ==="" && printf '' > /tmp/comm_empty.txt && ./bin/comm /tmp/comm_empty.txt /tmp/comm_f2.txt && echo ""=== identical ==="" && ./bin/comm /tmp/comm_f1.txt /tmp/comm_f1.txt && echo ""==",echo,False,128,0
+358,numeric,gh-336-generate-code-r05.3,4c872d7a-5073-490d-aeb2-b9cbd293cce9,,29,21,Bash,"printf 'a\nb\nc\n' > /tmp/comm_f1.txt && printf 'b\nc\nd\n' > /tmp/comm_f2.txt && echo ""=== basic ==="" && ./bin/comm /tmp/comm_f1.txt /tmp/comm_f2.txt && echo ""=== -12 ==="" && ./bin/comm -12 /tmp/comm",binary_exercise,False,141,0
+358,numeric,gh-336-generate-code-r05.3,4c872d7a-5073-490d-aeb2-b9cbd293cce9,,30,22,Bash,"echo ""=== empty file1 ==="" && printf '' > /tmp/comm_empty.txt && ./bin/comm /tmp/comm_empty.txt /tmp/comm_f2.txt && echo ""=== identical ==="" && ./bin/comm /tmp/comm_f1.txt /tmp/comm_f1.txt && echo ""==",binary_exercise,False,128,0
 358,numeric,gh-336-generate-code-r05.3,4c872d7a-5073-490d-aeb2-b9cbd293cce9,,32,23,Bash,wc -l cmd/comm/main.go cmd/comm/comm_test.go,wc,False,71,0
 358,numeric,gh-336-generate-code-r05.3,4c872d7a-5073-490d-aeb2-b9cbd293cce9,,35,24,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/358/cmd/comm/main.go,,False,7902,0
 358,numeric,gh-336-generate-code-r05.3,4c872d7a-5073-490d-aeb2-b9cbd293cce9,,38,25,Write,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/358/cmd/comm/main.go,,False,141,0
@@ -2876,7 +2876,7 @@ bin/uniq --version; echo ""exit=$?""; bin/uniq --help >/dev/null; echo ""exit=$?
 "" | ./bin/md5sum && echo -n ""hello
 "" | ./bin/sha1sum && echo -n ""hello
 "" | ./bin/sha256sum && echo -n ""hello
-"" | ./bin/sha512sum",echo,False,279,0
+"" | ./bin/sha512sum",binary_exercise,False,279,0
 360,numeric,gh-336-generate-code-r05.4,1b52bc7a-0751-4578-acf9-09f67b12fb5a,,44,33,Bash,go test ./cmd/md5sum/... ./cmd/sha1sum/... ./cmd/sha256sum/... ./cmd/sha512sum/... -v -count=1 2>&1 | head -80,go_test,False,927,0
 360,numeric,gh-336-generate-code-r05.4,1b52bc7a-0751-4578-acf9-09f67b12fb5a,,46,34,Bash,wc -l cmd/md5sum/main.go cmd/sha1sum/main.go cmd/sha256sum/main.go cmd/sha512sum/main.go,wc,False,133,0
 360,numeric,gh-336-generate-code-r05.4,1b52bc7a-0751-4578-acf9-09f67b12fb5a,,49,35,Bash,"for f in cmd/md5sum/main.go cmd/sha1sum/main.go cmd/sha256sum/main.go cmd/sha512sum/main.go; do echo -n ""$f: ""; grep -cvE '^\s*$|^\s*//' ""$f""; done",other,False,102,0
@@ -2892,11 +2892,11 @@ bin/uniq --version; echo ""exit=$?""; bin/uniq --help >/dev/null; echo ""exit=$?
 360,numeric,gh-336-generate-code-r05.4,1b52bc7a-0751-4578-acf9-09f67b12fb5a,,66,45,Bash,"echo -n ""hello
 "" | ./bin/md5sum | grep -q ""b1946ac92492d2347c6235b4d2611184  -"" && echo ""md5sum stdin: OK"" || echo ""md5sum stdin: FAIL""
 echo -n ""hello
-"" | ./bin/sha1sum | grep -q ""f572d396fae920662871",echo,False,74,0
+"" | ./bin/sha1sum | grep -q ""f572d396fae920662871",binary_exercise,False,74,0
 360,numeric,gh-336-generate-code-r05.4,1b52bc7a-0751-4578-acf9-09f67b12fb5a,,67,46,Bash,"# Test --check mode and --tag mode
 cd /tmp && echo ""hello"" > hello.txt
 echo ""b1946ac92492d2347c6235b4d2611184  hello.txt"" > checksums.md5
-/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-un",other,False,200,108
+/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-un",env_inspect,False,200,108
 360,numeric,gh-336-generate-code-r05.4,1b52bc7a-0751-4578-acf9-09f67b12fb5a,,69,47,TodoWrite,"{""todos"": [{""content"": ""Read PRDs, use cases, test suite, and existing cmd/ patterns"", ""status"": ""completed"", ""activeForm"": ""Reading required specifications and patterns""}, {""content"": ""Create pkg/sys",,False,160,0
 361,numeric,gh-336-generate-code-r05.4,51232ce4-c523-4362-91b9-8c0518fc2217,,3,1,ToolSearch,"{""query"": ""select:Read,Bash,Write,Glob,TodoWrite"", ""max_results"": 5}",,False,251,0
 361,numeric,gh-336-generate-code-r05.4,51232ce4-c523-4362-91b9-8c0518fc2217,,6,2,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/361/docs/specs/test-suites/test-rel05.4.yaml,,False,8837,0
@@ -2954,8 +2954,8 @@ echo ""b1946ac92492d2347c6235b4d2611184  hello.txt"" > checksums.md5
 361,numeric,gh-336-generate-code-r05.4,51232ce4-c523-4362-91b9-8c0518fc2217,,70,54,TodoWrite,"{""todos"": [{""content"": ""Add --strict flag to all 4 main.go files"", ""status"": ""completed"", ""activeForm"": ""Adding --strict flag to all 4 main.go files""}, {""content"": ""Add --quiet/--status/--strict test ",,False,160,0
 361,numeric,gh-336-generate-code-r05.4,51232ce4-c523-4362-91b9-8c0518fc2217,,71,55,Bash,"go build -o bin/md5sum ./cmd/md5sum/ && go build -o bin/sha1sum ./cmd/sha1sum/ && go build -o bin/sha256sum ./cmd/sha256sum/ && go build -o bin/sha512sum ./cmd/sha512sum/ && echo ""All builds succeeded",go_build,False,20,0
 361,numeric,gh-336-generate-code-r05.4,51232ce4-c523-4362-91b9-8c0518fc2217,,72,56,Bash,go test ./cmd/md5sum/ ./cmd/sha1sum/ ./cmd/sha256sum/ ./cmd/sha512sum/ -v -count=1 2>&1 | tail -80,go_test,False,927,0
-361,numeric,gh-336-generate-code-r05.4,51232ce4-c523-4362-91b9-8c0518fc2217,,74,57,Bash,"echo -n ""hello\n"" | bin/md5sum && echo ""hello"" | bin/sha1sum && echo ""hello"" | bin/sha256sum --tag && echo ""hello"" | bin/sha512sum -b",echo,False,289,0
-361,numeric,gh-336-generate-code-r05.4,51232ce4-c523-4362-91b9-8c0518fc2217,,76,58,Bash,"cd /tmp && echo ""hello"" > test_hello.txt && echo ""b1946ac92492d2347c6235b4d2611184  test_hello.txt"" > test.md5 && /private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/361/b",other,False,26,108
+361,numeric,gh-336-generate-code-r05.4,51232ce4-c523-4362-91b9-8c0518fc2217,,74,57,Bash,"echo -n ""hello\n"" | bin/md5sum && echo ""hello"" | bin/sha1sum && echo ""hello"" | bin/sha256sum --tag && echo ""hello"" | bin/sha512sum -b",binary_exercise,False,289,0
+361,numeric,gh-336-generate-code-r05.4,51232ce4-c523-4362-91b9-8c0518fc2217,,76,58,Bash,"cd /tmp && echo ""hello"" > test_hello.txt && echo ""b1946ac92492d2347c6235b4d2611184  test_hello.txt"" > test.md5 && /private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/361/b",env_inspect,False,26,108
 361,numeric,gh-336-generate-code-r05.4,51232ce4-c523-4362-91b9-8c0518fc2217,,77,59,TodoWrite,"{""todos"": [{""content"": ""Add --strict flag to all 4 main.go files"", ""status"": ""completed"", ""activeForm"": ""Adding --strict flag to all 4 main.go files""}, {""content"": ""Add --quiet/--status/--strict test ",,False,160,0
 362,numeric,gh-336-generate-code-r05.4,2bda088f-835f-41f4-a067-e4777e2c7a08,,3,1,ToolSearch,"{""query"": ""select:Bash"", ""max_results"": 1}",,False,49,0
 362,numeric,gh-336-generate-code-r05.4,2bda088f-835f-41f4-a067-e4777e2c7a08,,5,2,Bash,"go build ./cmd/md5sum/ && go build ./cmd/sha1sum/ && go build ./cmd/sha256sum/ && go build ./cmd/sha512sum/ && echo ""AC1: All four binaries compile OK""",go_build,False,33,0
@@ -3002,8 +3002,8 @@ echo ""b1946ac92492d2347c6235b4d2611184  hello.txt"" > checksums.md5
 365,numeric,gh-336-generate-code-r05.4,a5a08475-4479-43a3-92cd-6e4ca4b8f781,,32,21,Bash,"go build -o bin/md5sum ./cmd/md5sum/ && go build -o bin/sha1sum ./cmd/sha1sum/ && go build -o bin/sha256sum ./cmd/sha256sum/ && go build -o bin/sha512sum ./cmd/sha512sum/ && echo ""All builds passed""",go_build,False,17,0
 365,numeric,gh-336-generate-code-r05.4,a5a08475-4479-43a3-92cd-6e4ca4b8f781,,33,22,Bash,"go vet ./cmd/md5sum/ ./cmd/sha1sum/ ./cmd/sha256sum/ ./cmd/sha512sum/ && echo ""go vet passed""",go_vet,False,13,0
 365,numeric,gh-336-generate-code-r05.4,a5a08475-4479-43a3-92cd-6e4ca4b8f781,,34,23,Bash,go test ./cmd/md5sum/ ./cmd/sha1sum/ ./cmd/sha256sum/ ./cmd/sha512sum/ -v -count=1 2>&1 | tail -60,go_test,False,927,0
-365,numeric,gh-336-generate-code-r05.4,a5a08475-4479-43a3-92cd-6e4ca4b8f781,,36,24,Bash,"echo -n ""hello"" | ./bin/md5sum && echo -n ""hello"" | ./bin/sha1sum && echo -n ""hello"" | ./bin/sha256sum && echo -n ""hello"" | ./bin/sha512sum",echo,False,279,0
-365,numeric,gh-336-generate-code-r05.4,a5a08475-4479-43a3-92cd-6e4ca4b8f781,,37,25,Bash,"./bin/md5sum --version && ./bin/md5sum --ignore-missing --check /dev/null 2>&1; echo ""exit: $?""",other,False,30,0
+365,numeric,gh-336-generate-code-r05.4,a5a08475-4479-43a3-92cd-6e4ca4b8f781,,36,24,Bash,"echo -n ""hello"" | ./bin/md5sum && echo -n ""hello"" | ./bin/sha1sum && echo -n ""hello"" | ./bin/sha256sum && echo -n ""hello"" | ./bin/sha512sum",binary_exercise,False,279,0
+365,numeric,gh-336-generate-code-r05.4,a5a08475-4479-43a3-92cd-6e4ca4b8f781,,37,25,Bash,"./bin/md5sum --version && ./bin/md5sum --ignore-missing --check /dev/null 2>&1; echo ""exit: $?""",binary_run,False,30,0
 365,numeric,gh-336-generate-code-r05.4,a5a08475-4479-43a3-92cd-6e4ca4b8f781,,38,26,TodoWrite,"{""todos"": [{""content"": ""Read PRDs and plan changes"", ""status"": ""completed"", ""activeForm"": ""Reading PRDs and planning changes""}, {""content"": ""Add --ignore-missing and --version flags to cmd/md5sum/main",,False,160,0
 366,numeric,gh-336-generate-code-r05.4,ef125972-10ce-4077-b34c-f485fae2bc58,,2,1,ToolSearch,"{""query"": ""select:Read,Bash,Write,TodoWrite"", ""max_results"": 4}",,False,202,0
 366,numeric,gh-336-generate-code-r05.4,ef125972-10ce-4077-b34c-f485fae2bc58,,4,2,TodoWrite,"{""todos"": [{""content"": ""Read required files not in context"", ""status"": ""in_progress"", ""activeForm"": ""Reading required files""}, {""content"": ""Write cmd/md5sum/md5sum_test.go"", ""status"": ""pending"", ""acti",,False,160,0
@@ -3056,8 +3056,8 @@ echo ""b1946ac92492d2347c6235b4d2611184  hello.txt"" > checksums.md5
 "" | ./bin/md5sum && echo -n ""hello
 "" | ./bin/sha1sum && echo -n ""hello
 "" | ./bin/sha256sum && echo -n ""hello
-"" | ./bin/sha512sum",echo,False,279,0
-368,numeric,gh-336-generate-code-r05.4,7899558e-bdfd-4af6-9414-b11565fa6b8f,,32,24,Bash,"cd /tmp && echo ""hello"" > testfile.txt && /private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/368/bin/md5sum -b testfile.txt && echo ""b1946ac92492d2347c6235b4d2611184  tes",other,False,117,108
+"" | ./bin/sha512sum",binary_exercise,False,279,0
+368,numeric,gh-336-generate-code-r05.4,7899558e-bdfd-4af6-9414-b11565fa6b8f,,32,24,Bash,"cd /tmp && echo ""hello"" > testfile.txt && /private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/368/bin/md5sum -b testfile.txt && echo ""b1946ac92492d2347c6235b4d2611184  tes",env_inspect,False,117,108
 368,numeric,gh-336-generate-code-r05.4,7899558e-bdfd-4af6-9414-b11565fa6b8f,,33,25,TodoWrite,"{""todos"": [{""content"": ""Verify all four binaries compile"", ""status"": ""completed"", ""activeForm"": ""Verifying all four binaries compile""}, {""content"": ""Run go vet on all four packages"", ""status"": ""comple",,False,160,0
 368,numeric,gh-336-generate-code-r05.4,7899558e-bdfd-4af6-9414-b11565fa6b8f,,35,26,TodoWrite,"{""todos"": [{""content"": ""Verify all four binaries compile"", ""status"": ""completed"", ""activeForm"": ""Verifying all four binaries compile""}, {""content"": ""Run go vet on all four packages"", ""status"": ""comple",,False,160,0
 369,numeric,gh-336-generate-code-r05.4,e032c6a3-9269-42c2-a424-00a840ed811d,,2,1,ToolSearch,"{""query"": ""select:Read,Write,Bash,Glob,TodoWrite"", ""max_results"": 5}",,False,251,0
@@ -3069,22 +3069,22 @@ echo ""b1946ac92492d2347c6235b4d2611184  hello.txt"" > checksums.md5
 369,numeric,gh-336-generate-code-r05.4,e032c6a3-9269-42c2-a424-00a840ed811d,,12,7,Bash,go build -o bin/md5sum ./cmd/md5sum/,go_build,False,0,0
 369,numeric,gh-336-generate-code-r05.4,e032c6a3-9269-42c2-a424-00a840ed811d,,13,8,Bash,go vet ./cmd/md5sum/,go_vet,False,0,0
 369,numeric,gh-336-generate-code-r05.4,e032c6a3-9269-42c2-a424-00a840ed811d,,14,9,Bash,go test ./cmd/md5sum/ -v -count=1 2>&1,go_test,False,224,0
-369,numeric,gh-336-generate-code-r05.4,e032c6a3-9269-42c2-a424-00a840ed811d,,15,10,Bash,"echo ""hello"" | bin/md5sum",echo,False,35,0
+369,numeric,gh-336-generate-code-r05.4,e032c6a3-9269-42c2-a424-00a840ed811d,,15,10,Bash,"echo ""hello"" | bin/md5sum",binary_exercise,False,35,0
 370,numeric,gh-336-generate-code-r05.4,411257da-9ae6-4829-b69f-0fc2e5cbb1a4,,3,1,ToolSearch,"{""query"": ""select:Bash"", ""max_results"": 1}",,False,49,0
 370,numeric,gh-336-generate-code-r05.4,411257da-9ae6-4829-b69f-0fc2e5cbb1a4,,5,2,Bash,"go build -o bin/md5sum ./cmd/md5sum/ && go build -o bin/sha1sum ./cmd/sha1sum/ && go build -o bin/sha256sum ./cmd/sha256sum/ && go build -o bin/sha512sum ./cmd/sha512sum/ && echo ""All builds succeeded",go_build,False,20,0
 370,numeric,gh-336-generate-code-r05.4,411257da-9ae6-4829-b69f-0fc2e5cbb1a4,,6,3,Bash,"go vet ./cmd/md5sum/ ./cmd/sha1sum/ ./cmd/sha256sum/ ./cmd/sha512sum/ && echo ""go vet passed""",go_vet,False,13,0
-370,numeric,gh-336-generate-code-r05.4,411257da-9ae6-4829-b69f-0fc2e5cbb1a4,,7,4,Bash,echo -n hello | bin/md5sum,echo,False,35,0
-370,numeric,gh-336-generate-code-r05.4,411257da-9ae6-4829-b69f-0fc2e5cbb1a4,,8,5,Bash,echo -n hello | bin/sha1sum,echo,False,43,0
-370,numeric,gh-336-generate-code-r05.4,411257da-9ae6-4829-b69f-0fc2e5cbb1a4,,9,6,Bash,echo -n hello | bin/sha256sum,echo,False,67,0
-370,numeric,gh-336-generate-code-r05.4,411257da-9ae6-4829-b69f-0fc2e5cbb1a4,,10,7,Bash,echo -n hello | bin/sha512sum,echo,False,131,0
-370,numeric,gh-336-generate-code-r05.4,411257da-9ae6-4829-b69f-0fc2e5cbb1a4,,12,8,Bash,"cd /tmp && echo ""hello"" > testfile.txt && echo ""f572d396fae9206628714fb2ce00f72e94f2258f  testfile.txt"" > checksums.txt && /private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktr",other,False,101,108
+370,numeric,gh-336-generate-code-r05.4,411257da-9ae6-4829-b69f-0fc2e5cbb1a4,,7,4,Bash,echo -n hello | bin/md5sum,binary_exercise,False,35,0
+370,numeric,gh-336-generate-code-r05.4,411257da-9ae6-4829-b69f-0fc2e5cbb1a4,,8,5,Bash,echo -n hello | bin/sha1sum,binary_exercise,False,43,0
+370,numeric,gh-336-generate-code-r05.4,411257da-9ae6-4829-b69f-0fc2e5cbb1a4,,9,6,Bash,echo -n hello | bin/sha256sum,binary_exercise,False,67,0
+370,numeric,gh-336-generate-code-r05.4,411257da-9ae6-4829-b69f-0fc2e5cbb1a4,,10,7,Bash,echo -n hello | bin/sha512sum,binary_exercise,False,131,0
+370,numeric,gh-336-generate-code-r05.4,411257da-9ae6-4829-b69f-0fc2e5cbb1a4,,12,8,Bash,"cd /tmp && echo ""hello"" > testfile.txt && echo ""f572d396fae9206628714fb2ce00f72e94f2258f  testfile.txt"" > checksums.txt && /private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktr",env_inspect,False,101,108
 370,numeric,gh-336-generate-code-r05.4,411257da-9ae6-4829-b69f-0fc2e5cbb1a4,,13,9,Bash,go test ./cmd/md5sum/ ./cmd/sha1sum/ ./cmd/sha256sum/ ./cmd/sha512sum/ -v -count=1 2>&1 | tail -40,go_test,False,927,0
 371,numeric,gh-336-generate-code-r05.4,0a77507c-6c30-4c03-b4b5-706ccfccee09,,3,1,ToolSearch,"{""query"": ""select:Bash"", ""max_results"": 1}",,False,49,0
 371,numeric,gh-336-generate-code-r05.4,0a77507c-6c30-4c03-b4b5-706ccfccee09,,5,2,Bash,"go build -o bin/md5sum ./cmd/md5sum/ && go build -o bin/sha1sum ./cmd/sha1sum/ && go build -o bin/sha256sum ./cmd/sha256sum/ && go build -o bin/sha512sum ./cmd/sha512sum/ && echo ""All four binaries co",go_build,False,39,0
-371,numeric,gh-336-generate-code-r05.4,0a77507c-6c30-4c03-b4b5-706ccfccee09,,6,3,Bash,"echo ""hello"" | bin/md5sum && echo ""hello"" | bin/sha1sum && echo ""hello"" | bin/sha256sum && echo ""hello"" | bin/sha512sum",echo,False,279,0
+371,numeric,gh-336-generate-code-r05.4,0a77507c-6c30-4c03-b4b5-706ccfccee09,,6,3,Bash,"echo ""hello"" | bin/md5sum && echo ""hello"" | bin/sha1sum && echo ""hello"" | bin/sha256sum && echo ""hello"" | bin/sha512sum",binary_exercise,False,279,0
 371,numeric,gh-336-generate-code-r05.4,0a77507c-6c30-4c03-b4b5-706ccfccee09,,8,4,Bash,go test ./cmd/md5sum/ ./cmd/sha1sum/ ./cmd/sha256sum/ ./cmd/sha512sum/ -v -count=1 2>&1 | tail -40,go_test,False,927,0
-371,numeric,gh-336-generate-code-r05.4,0a77507c-6c30-4c03-b4b5-706ccfccee09,,9,5,Bash,golangci-lint run ./cmd/md5sum/ ./cmd/sha1sum/ ./cmd/sha256sum/ ./cmd/sha512sum/ 2>&1,other,True,1576,0
-371,numeric,gh-336-generate-code-r05.4,0a77507c-6c30-4c03-b4b5-706ccfccee09,,11,6,Bash,"golangci-lint run ./cmd/md5sum/ 2>&1; echo ""exit: $?""",other,False,279,0
+371,numeric,gh-336-generate-code-r05.4,0a77507c-6c30-4c03-b4b5-706ccfccee09,,9,5,Bash,golangci-lint run ./cmd/md5sum/ ./cmd/sha1sum/ ./cmd/sha256sum/ ./cmd/sha512sum/ 2>&1,lint,True,1576,0
+371,numeric,gh-336-generate-code-r05.4,0a77507c-6c30-4c03-b4b5-706ccfccee09,,11,6,Bash,"golangci-lint run ./cmd/md5sum/ 2>&1; echo ""exit: $?""",lint,False,279,0
 371,numeric,gh-336-generate-code-r05.4,0a77507c-6c30-4c03-b4b5-706ccfccee09,,13,7,ToolSearch,"{""query"": ""select:Edit"", ""max_results"": 1}",,False,49,0
 371,numeric,gh-336-generate-code-r05.4,0a77507c-6c30-4c03-b4b5-706ccfccee09,,14,8,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/371/cmd/md5sum/main.go,,True,96,0
 371,numeric,gh-336-generate-code-r05.4,0a77507c-6c30-4c03-b4b5-706ccfccee09,,15,9,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/371/cmd/md5sum/main.go,,True,96,0
@@ -3108,7 +3108,7 @@ echo ""b1946ac92492d2347c6235b4d2611184  hello.txt"" > checksums.md5
 371,numeric,gh-336-generate-code-r05.4,0a77507c-6c30-4c03-b4b5-706ccfccee09,,35,27,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/371/cmd/sha512sum/main.go,,False,146,0
 371,numeric,gh-336-generate-code-r05.4,0a77507c-6c30-4c03-b4b5-706ccfccee09,,36,28,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/371/cmd/sha512sum/main.go,,False,146,0
 371,numeric,gh-336-generate-code-r05.4,0a77507c-6c30-4c03-b4b5-706ccfccee09,,38,29,Bash,"go build -o bin/md5sum ./cmd/md5sum/ && go build -o bin/sha1sum ./cmd/sha1sum/ && go build -o bin/sha256sum ./cmd/sha256sum/ && go build -o bin/sha512sum ./cmd/sha512sum/ && echo ""OK""",go_build,False,2,0
-371,numeric,gh-336-generate-code-r05.4,0a77507c-6c30-4c03-b4b5-706ccfccee09,,39,30,Bash,"golangci-lint run ./cmd/md5sum/ ./cmd/sha1sum/ ./cmd/sha256sum/ ./cmd/sha512sum/ 2>&1; echo ""exit: $?""",other,False,17,0
+371,numeric,gh-336-generate-code-r05.4,0a77507c-6c30-4c03-b4b5-706ccfccee09,,39,30,Bash,"golangci-lint run ./cmd/md5sum/ ./cmd/sha1sum/ ./cmd/sha256sum/ ./cmd/sha512sum/ 2>&1; echo ""exit: $?""",lint,False,17,0
 371,numeric,gh-336-generate-code-r05.4,0a77507c-6c30-4c03-b4b5-706ccfccee09,,40,31,Bash,go test ./cmd/md5sum/ ./cmd/sha1sum/ ./cmd/sha256sum/ ./cmd/sha512sum/ -count=1 2>&1,go_test,False,250,0
 372,numeric,gh-336-generate-code-r05.4,4c927fb3-444c-4f7d-863b-08a94c529f16,,3,1,ToolSearch,"{""query"": ""select:Read,Bash,Write,Glob"", ""max_results"": 4}",,False,197,0
 372,numeric,gh-336-generate-code-r05.4,4c927fb3-444c-4f7d-863b-08a94c529f16,,5,2,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/372/docs/specs/test-suites/test-rel05.4.yaml,,False,8837,0
@@ -3120,7 +3120,7 @@ echo ""b1946ac92492d2347c6235b4d2611184  hello.txt"" > checksums.md5
 372,numeric,gh-336-generate-code-r05.4,4c927fb3-444c-4f7d-863b-08a94c529f16,,13,8,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/372/cmd/sha256sum/sha256sum_test.go,,False,2651,0
 372,numeric,gh-336-generate-code-r05.4,4c927fb3-444c-4f7d-863b-08a94c529f16,,14,9,Read,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/372/cmd/sha512sum/sha512sum_test.go,,False,2781,0
 372,numeric,gh-336-generate-code-r05.4,4c927fb3-444c-4f7d-863b-08a94c529f16,,17,10,Bash,go test ./cmd/md5sum/ ./cmd/sha1sum/ ./cmd/sha256sum/ ./cmd/sha512sum/ -v -count=1 2>&1,go_test,False,927,0
-372,numeric,gh-336-generate-code-r05.4,4c927fb3-444c-4f7d-863b-08a94c529f16,,20,11,Bash,which gmd5sum gsha1sum gsha256sum gsha512sum 2>&1 || brew --prefix coreutils 2>/dev/null,other,False,106,0
+372,numeric,gh-336-generate-code-r05.4,4c927fb3-444c-4f7d-863b-08a94c529f16,,20,11,Bash,which gmd5sum gsha1sum gsha256sum gsha512sum 2>&1 || brew --prefix coreutils 2>/dev/null,env_check,False,106,0
 372,numeric,gh-336-generate-code-r05.4,4c927fb3-444c-4f7d-863b-08a94c529f16,,21,12,Bash,ls /opt/homebrew/opt/coreutils/libexec/gnubin/ | grep -E '(md5sum|sha1sum|sha256sum|sha512sum)' 2>&1,ls,False,74,0
 372,numeric,gh-336-generate-code-r05.4,4c927fb3-444c-4f7d-863b-08a94c529f16,,22,13,Bash,"ls /opt/homebrew/opt/coreutils/bin/ 2>/dev/null | grep -E '(md5sum|sha1sum|sha256sum|sha512sum)' || echo ""not found""",ls,False,9,0
 372,numeric,gh-336-generate-code-r05.4,4c927fb3-444c-4f7d-863b-08a94c529f16,,23,14,Bash,"find /opt/homebrew -name ""gmd5sum"" -o -name ""md5sum"" 2>/dev/null | head -5; find /opt/homebrew -name ""gsha256sum"" -o -name ""sha256sum"" 2>/dev/null | head -5",find,False,0,0
@@ -3152,12 +3152,12 @@ echo ""b1946ac92492d2347c6235b4d2611184  hello.txt"" > checksums.md5
 375,numeric,gh-336-generate-code-r05.4,a39c2daa-64d0-494a-8cfd-c05281f49680,,27,19,Edit,/private/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/375/cmd/sha512sum/main.go,,False,146,0
 375,numeric,gh-336-generate-code-r05.4,a39c2daa-64d0-494a-8cfd-c05281f49680,,29,20,TodoWrite,"{""todos"": [{""content"": ""Update cmd/md5sum/main.go with --help and correct --version format"", ""status"": ""completed"", ""activeForm"": ""Updating cmd/md5sum/main.go""}, {""content"": ""Update cmd/sha1sum/main.g",,False,160,0
 375,numeric,gh-336-generate-code-r05.4,a39c2daa-64d0-494a-8cfd-c05281f49680,,30,21,Bash,"go build -o bin/md5sum ./cmd/md5sum/ && go build -o bin/sha1sum ./cmd/sha1sum/ && go build -o bin/sha256sum ./cmd/sha256sum/ && go build -o bin/sha512sum ./cmd/sha512sum/ && echo ""All four utilities c",go_build,False,40,0
-375,numeric,gh-336-generate-code-r05.4,a39c2daa-64d0-494a-8cfd-c05281f49680,,32,22,Bash,"echo -n hello | bin/md5sum && echo ""---"" && echo -n hello | bin/sha1sum && echo ""---"" && echo -n hello | bin/sha256sum && echo ""---"" && echo -n hello | bin/sha512sum",echo,False,291,0
-375,numeric,gh-336-generate-code-r05.4,a39c2daa-64d0-494a-8cfd-c05281f49680,,33,23,Bash,bin/md5sum --version && bin/sha1sum --version && bin/sha256sum --version && bin/sha512sum --version,other,False,110,0
-375,numeric,gh-336-generate-code-r05.4,a39c2daa-64d0-494a-8cfd-c05281f49680,,34,24,Bash,"bin/md5sum --help | head -2 && echo ""---"" && bin/sha512sum --help | head -2",other,False,141,0
-375,numeric,gh-336-generate-code-r05.4,a39c2daa-64d0-494a-8cfd-c05281f49680,,36,25,Bash,echo -n hello > /tmp/test_hash1.txt && echo -n world > /tmp/test_hash2.txt && bin/md5sum /tmp/test_hash1.txt /tmp/test_hash2.txt,echo,False,107,0
-375,numeric,gh-336-generate-code-r05.4,a39c2daa-64d0-494a-8cfd-c05281f49680,,37,26,Bash,bin/md5sum /tmp/test_hash1.txt /tmp/test_hash2.txt > /tmp/test_checksums.md5 && bin/md5sum --check /tmp/test_checksums.md5,other,False,47,0
-375,numeric,gh-336-generate-code-r05.4,a39c2daa-64d0-494a-8cfd-c05281f49680,,39,27,Bash,"echo ""0000000000000000000000000000000  /tmp/test_hash1.txt"" > /tmp/test_bad.md5 && bin/md5sum --check /tmp/test_bad.md5; echo ""exit code: $?""",echo,False,91,0
+375,numeric,gh-336-generate-code-r05.4,a39c2daa-64d0-494a-8cfd-c05281f49680,,32,22,Bash,"echo -n hello | bin/md5sum && echo ""---"" && echo -n hello | bin/sha1sum && echo ""---"" && echo -n hello | bin/sha256sum && echo ""---"" && echo -n hello | bin/sha512sum",binary_exercise,False,291,0
+375,numeric,gh-336-generate-code-r05.4,a39c2daa-64d0-494a-8cfd-c05281f49680,,33,23,Bash,bin/md5sum --version && bin/sha1sum --version && bin/sha256sum --version && bin/sha512sum --version,binary_run,False,110,0
+375,numeric,gh-336-generate-code-r05.4,a39c2daa-64d0-494a-8cfd-c05281f49680,,34,24,Bash,"bin/md5sum --help | head -2 && echo ""---"" && bin/sha512sum --help | head -2",binary_run,False,141,0
+375,numeric,gh-336-generate-code-r05.4,a39c2daa-64d0-494a-8cfd-c05281f49680,,36,25,Bash,echo -n hello > /tmp/test_hash1.txt && echo -n world > /tmp/test_hash2.txt && bin/md5sum /tmp/test_hash1.txt /tmp/test_hash2.txt,binary_exercise,False,107,0
+375,numeric,gh-336-generate-code-r05.4,a39c2daa-64d0-494a-8cfd-c05281f49680,,37,26,Bash,bin/md5sum /tmp/test_hash1.txt /tmp/test_hash2.txt > /tmp/test_checksums.md5 && bin/md5sum --check /tmp/test_checksums.md5,binary_run,False,47,0
+375,numeric,gh-336-generate-code-r05.4,a39c2daa-64d0-494a-8cfd-c05281f49680,,39,27,Bash,"echo ""0000000000000000000000000000000  /tmp/test_hash1.txt"" > /tmp/test_bad.md5 && bin/md5sum --check /tmp/test_bad.md5; echo ""exit code: $?""",binary_exercise,False,91,0
 375,numeric,gh-336-generate-code-r05.4,a39c2daa-64d0-494a-8cfd-c05281f49680,,40,28,Bash,go test ./cmd/md5sum/ ./cmd/sha1sum/ ./cmd/sha256sum/ ./cmd/sha512sum/ 2>&1,go_test,False,250,0
 375,numeric,gh-336-generate-code-r05.4,a39c2daa-64d0-494a-8cfd-c05281f49680,,42,29,TodoWrite,"{""todos"": [{""content"": ""Update cmd/md5sum/main.go with --help and correct --version format"", ""status"": ""completed"", ""activeForm"": ""Updating cmd/md5sum/main.go""}, {""content"": ""Update cmd/sha1sum/main.g",,False,160,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,3,2,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/generation-2026-02-27-21-48-32-21v/cmd/ls/main.go,,True,169,0
@@ -3181,8 +3181,8 @@ generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea0
 generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,21,19,Bash,git log --oneline -20 2>/dev/null,git_log,True,13,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,22,20,Bash,git log --oneline -20 2>&1,git_log,True,244,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,24,21,Bash,go version 2>&1; which go 2>&1,go_other,False,52,0
-generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,25,22,Bash,which gls 2>&1; which gdu 2>&1; which gwc 2>&1; which gcat 2>&1,other,True,11,0
-generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,26,23,Bash,which ls; ls --version 2>&1 | head -5; uname -a,other,False,270,0
+generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,25,22,Bash,which gls 2>&1; which gdu 2>&1; which gwc 2>&1; which gcat 2>&1,env_check,True,11,0
+generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,26,23,Bash,which ls; ls --version 2>&1 | head -5; uname -a,env_check,False,270,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,28,24,Bash,"find /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/generation-2026-02-27-21-48-32-21v/ -name ""go.*"" -o -name ""*.go"" 2>/dev/null",find,False,383,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,29,25,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/generation-2026-02-27-21-48-32-21v/magefiles/go.mod,,False,296,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,30,26,TodoWrite,"{""todos"": [{""content"": ""Create go.mod and pkg/sys package for compilation support"", ""status"": ""in_progress"", ""activeForm"": ""Creating go.mod and pkg/sys package""}, {""content"": ""Create pkg/testutils pac",,False,160,0
@@ -3236,11 +3236,11 @@ TESTDIR=$(mktemp -d)
 echo ""regular content"" > ""$TESTDIR/regular.txt""
 chmod 644 ""$TESTDIR/regular.txt""
 printf '#!/bin/",go_build,False,1406,0
-generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,80,58,Bash,which golangci-lint 2>&1 || go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest 2>&1 | tail -5,other,False,33,0
-generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,81,59,Bash,golangci-lint run ./cmd/ls/ 2>&1,other,True,244,0
+generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,80,58,Bash,which golangci-lint 2>&1 || go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest 2>&1 | tail -5,env_check,False,33,0
+generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,81,59,Bash,golangci-lint run ./cmd/ls/ 2>&1,lint,True,244,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,83,60,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/generation-2026-02-27-21-48-32-21v/cmd/ls/main.go,,False,162,0
-generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,84,61,Bash,golangci-lint run ./cmd/ls/ 2>&1,other,False,9,0
-generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,85,62,Bash,golangci-lint run ./pkg/... 2>&1,other,False,9,0
+generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,84,61,Bash,golangci-lint run ./cmd/ls/ 2>&1,lint,False,9,0
+generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,85,62,Bash,golangci-lint run ./pkg/... 2>&1,lint,False,9,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,87,63,Bash,go build ./cmd/ls/ 2>&1 && go vet ./... 2>&1 && go test ./cmd/ls/ -v -count=1 2>&1,go_build,False,236,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,69a146e4-fa50-4ec5-bd01-ac65e0ea05f2,,88,64,TodoWrite,"{""todos"": [{""content"": ""Create go.mod and pkg/sys package for compilation support"", ""status"": ""completed"", ""activeForm"": ""Creating go.mod and pkg/sys package""}, {""content"": ""Create pkg/testutils packa",,False,160,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,3,2,Glob,cmd/ls/*.go,,False,14,0
@@ -3280,7 +3280,7 @@ generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9fe
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,38,35,Bash,"ls -la /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/generation-2026-02-27-21-48-32-21v/pkg/ 2>&1 || echo ""pkg/ does not exist""",ls,False,163,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,39,36,Bash,"ls -la /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/generation-2026-02-27-21-48-32-21v/go.mod 2>&1 || echo ""go.mod does not exist""",ls,False,167,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,42,37,TodoWrite,"{""todos"": [{""content"": ""Create go.mod and check Go toolchain availability"", ""status"": ""in_progress"", ""activeForm"": ""Setting up Go module""}, {""content"": ""Create pkg/sys package (FileInfo, Stat, Lstat, ",,False,160,0
-generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,43,38,Bash,"which go && go version && which golangci-lint 2>/dev/null; which gls 2>/dev/null || echo ""gls not found""",other,False,100,0
+generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,43,38,Bash,"which go && go version && which golangci-lint 2>/dev/null; which gls 2>/dev/null || echo ""gls not found""",env_check,False,100,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,46,39,Bash,ls /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/generation-2026-02-27-21-48-32-21v/,ls,False,68,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,47,40,Bash,mkdir -p /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/generation-2026-02-27-21-48-32-21v/pkg/sys /var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/ge,mkdir,False,0,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,49,41,Write,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/generation-2026-02-27-21-48-32-21v/go.mod,,False,144,0
@@ -3294,21 +3294,21 @@ generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9fe
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,59,49,TodoWrite,"{""todos"": [{""content"": ""Create go.mod and check Go toolchain availability"", ""status"": ""completed"", ""activeForm"": ""Setting up Go module""}, {""content"": ""Create pkg/sys package (FileInfo, Stat, Lstat, Te",,False,160,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,60,50,Bash,go mod tidy 2>&1,go_mod,False,40,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,61,51,Bash,go build ./cmd/ls/ 2>&1,go_build,False,0,0
-generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,63,52,Bash,golangci-lint run ./cmd/ls/ ./pkg/sys/ ./pkg/testutils/ 2>&1,other,True,334,0
+generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,63,52,Bash,golangci-lint run ./cmd/ls/ ./pkg/sys/ ./pkg/testutils/ 2>&1,lint,True,334,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,64,53,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/generation-2026-02-27-21-48-32-21v/cmd/ls/ls_test.go,,False,373,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,65,54,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/generation-2026-02-27-21-48-32-21v/cmd/ls/ls_test.go,,False,165,0
-generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,66,55,Bash,golangci-lint run ./cmd/ls/ ./pkg/sys/ ./pkg/testutils/ 2>&1,other,False,9,0
+generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,66,55,Bash,golangci-lint run ./cmd/ls/ ./pkg/sys/ ./pkg/testutils/ 2>&1,lint,False,9,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,68,56,Bash,go test -v ./cmd/ls/ 2>&1,go_test,False,1087,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,71,57,Bash,"mkdir -p /tmp/ls-test-fixture && cd /tmp/ls-test-fixture && rm -rf * .hidden 2>/dev/null; echo ""hello"" > regular.txt && echo ""#!/bin/sh"" > script.sh && chmod 755 script.sh && mkdir -p subdir && echo """,mkdir,True,200,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,72,58,Bash,"mkdir -p /tmp/ls-test-fixture && rm -rf /tmp/ls-test-fixture/* /tmp/ls-test-fixture/.hidden 2>/dev/null; echo ""hello"" > /tmp/ls-test-fixture/regular.txt && echo ""#!/bin/sh"" > /tmp/ls-test-fixture/scri",mkdir,False,791,0
-generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,74,59,Bash,"echo ""=== -lF ==="" && go run ./cmd/ls/ -lF --color=never /tmp/ls-test-fixture && echo ""=== -1is ==="" && go run ./cmd/ls/ -1is --color=never /tmp/ls-test-fixture && echo ""=== -1 ==="" && go run ./cmd/ls",echo,False,534,0
+generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,74,59,Bash,"echo ""=== -lF ==="" && go run ./cmd/ls/ -lF --color=never /tmp/ls-test-fixture && echo ""=== -1is ==="" && go run ./cmd/ls/ -1is --color=never /tmp/ls-test-fixture && echo ""=== -1 ==="" && go run ./cmd/ls",binary_exercise,False,534,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,77,60,Read,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/generation-2026-02-27-21-48-32-21v/cmd/ls/ls_test.go,,False,10144,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,78,61,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/generation-2026-02-27-21-48-32-21v/cmd/ls/ls_test.go,,False,165,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,80,62,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/generation-2026-02-27-21-48-32-21v/cmd/ls/ls_test.go,,False,165,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,81,63,Bash,go build ./cmd/ls/ 2>&1 && golangci-lint run ./cmd/ls/ 2>&1,go_build,False,9,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,82,64,Bash,go test -v ./cmd/ls/ 2>&1,go_test,False,1647,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,84,65,Bash,go test ./... 2>&1,go_test,False,196,0
-generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,85,66,Bash,golangci-lint run ./... 2>&1,other,False,9,0
+generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,85,66,Bash,golangci-lint run ./... 2>&1,lint,False,9,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,86,67,TodoWrite,"{""todos"": [{""content"": ""Create go.mod and check Go toolchain availability"", ""status"": ""completed"", ""activeForm"": ""Setting up Go module""}, {""content"": ""Create pkg/sys package (FileInfo, Stat, Lstat, Te",,False,160,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f6586651-9e84-4147-a394-d5fc5f9feda5,,88,68,TodoWrite,"{""todos"": [{""content"": ""Create go.mod and check Go toolchain availability"", ""status"": ""completed"", ""activeForm"": ""Setting up Go module""}, {""content"": ""Create pkg/sys package (FileInfo, Stat, Lstat, Te",,False,160,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,2,1,TodoWrite,"{""todos"": [{""content"": ""Read existing cmd/ls/main.go and cmd/ls/ls_test.go"", ""status"": ""in_progress"", ""activeForm"": ""Reading existing source files""}, {""content"": ""Implement -i, -s, -n, -F flag parsing",,False,160,0
@@ -3333,11 +3333,11 @@ generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1
 generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,29,20,Glob,pkg/testutils/*.go,,False,14,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,31,21,TodoWrite,"{""todos"": [{""content"": ""Create go.mod and dependency packages (pkg/sys, pkg/testutils)"", ""status"": ""in_progress"", ""activeForm"": ""Creating dependency infrastructure""}, {""content"": ""Implement cmd/ls/mai",,False,160,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,32,22,Bash,uname -s && uname -m,other,False,13,0
-generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,33,23,Bash,which go && go version,other,False,52,0
-generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,34,24,Bash,"which gls 2>/dev/null && gls --version 2>&1 | head -1 || echo ""gls not found""",other,False,13,0
-generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,35,25,Bash,which ls && ls --version 2>&1 | head -1,other,False,40,0
+generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,33,23,Bash,which go && go version,env_check,False,52,0
+generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,34,24,Bash,"which gls 2>/dev/null && gls --version 2>&1 | head -1 || echo ""gls not found""",env_check,False,13,0
+generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,35,25,Bash,which ls && ls --version 2>&1 | head -1,env_check,False,40,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,36,26,Bash,ls --help 2>&1 | head -3,ls,False,119,0
-generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,38,27,Bash,"which ls && rpm -qf /bin/ls 2>/dev/null || dpkg -S /bin/ls 2>/dev/null || echo ""package unknown""",other,False,23,0
+generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,38,27,Bash,"which ls && rpm -qf /bin/ls 2>/dev/null || dpkg -S /bin/ls 2>/dev/null || echo ""package unknown""",env_check,False,23,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,39,28,Bash,find /usr -name 'ls' -type f 2>/dev/null | head -5; find /usr/local -name 'gls' -type f 2>/dev/null | head -5,find,False,0,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,40,29,Bash,ls /usr/bin/ls 2>/dev/null; /bin/ls --version 2>&1 | head -2; file /bin/ls,ls,True,298,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,43,30,TodoWrite,"{""todos"": [{""content"": ""Create go.mod and dependency packages (pkg/sys, pkg/testutils)"", ""status"": ""in_progress"", ""activeForm"": ""Creating dependency infrastructure""}, {""content"": ""Implement cmd/ls/mai",,False,160,0
@@ -3360,8 +3360,8 @@ generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1
 generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,66,47,Edit,/var/folders/dl/cbns6zkx7txc7pt64b6cgzp40000gn/T/go-unix-utils-worktrees/generation-2026-02-27-21-48-32-21v/cmd/ls/ls_test.go,,False,165,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,67,48,Bash,go test ./cmd/ls/... -v -count=1 2>&1,go_test,False,1181,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,69,49,Bash,"go build -o /tmp/test-ls ./cmd/ls/ && cd /tmp && mkdir -p ls-test-fixture && cd ls-test-fixture && rm -rf * .hidden 2>/dev/null; echo ""hello"" > regular.txt && echo ""#!/bin/sh"" > runme && chmod 755 run",go_build,False,879,131
-generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,71,50,Bash,"which golangci-lint 2>/dev/null && golangci-lint --version || echo ""golangci-lint not found""",other,False,187,0
-generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,72,51,Bash,golangci-lint run ./cmd/ls/... ./pkg/sys/... ./pkg/testutils/... 2>&1,other,False,9,0
+generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,71,50,Bash,"which golangci-lint 2>/dev/null && golangci-lint --version || echo ""golangci-lint not found""",env_check,False,187,0
+generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,72,51,Bash,golangci-lint run ./cmd/ls/... ./pkg/sys/... ./pkg/testutils/... 2>&1,lint,False,9,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,74,52,Bash,"go build ./... 2>&1 && echo ""BUILD ALL OK""",go_build,False,12,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,75,53,Bash,go test ./... -count=1 2>&1,go_test,False,196,0
 generation-2026-02-27-21-48-32-21v,slug,orphan,f938a1db-ca48-4fa6-a8e3-0206563f1b89,,77,54,Bash,"go vet ./... 2>&1 && echo ""VET OK""",go_vet,False,6,0

--- a/analysis/scripts/extract_transcripts.py
+++ b/analysis/scripts/extract_transcripts.py
@@ -46,48 +46,86 @@ TURNS_COLUMNS = [
 ]
 
 
-def classify_bash(command: str) -> str:
-    cmd = command.lstrip()
-    if re.match(r"go\s+(build|install)\b", cmd):
+_ENV_VAR_PREFIX_RE = re.compile(r"^(?:[A-Z_][A-Z0-9_]*=\S+\s+)+")
+_PIPELINE_SPLIT_RE = re.compile(r"\|\||&&|;|\|")
+_BINARY_RUN_RE = re.compile(
+    r"^(?:\./)?(?:bin/[A-Za-z0-9_-]+|cmd/[A-Za-z0-9_-]+|go\s+run)\b"
+)
+_INSPECT_RE = re.compile(r"^(?:xxd|od|hexdump|wc|head|tail|diff)\b")
+_SETUP_RE = re.compile(r"^(?:printf|echo|cat\s*<<)\b")
+
+
+def normalize_command(cmd: str) -> str:
+    """Strip leading `# comment` lines and `VAR=val ` env prefixes."""
+    lines = cmd.split("\n")
+    while lines and lines[0].lstrip().startswith("#"):
+        lines.pop(0)
+    cmd = "\n".join(lines).strip()
+    return _ENV_VAR_PREFIX_RE.sub("", cmd)
+
+
+def pipeline_segments(cmd: str) -> list[str]:
+    """Split on |, ||, &&, ; — naive (no quote awareness, but rare in practice)."""
+    return [s.strip() for s in _PIPELINE_SPLIT_RE.split(cmd) if s.strip()]
+
+
+def _classify_segment(seg: str) -> str | None:
+    """Classify a single pipeline segment by its first verb. None = unknown."""
+    if re.match(r"go\s+(?:build|install)\b", seg):
         return "go_build"
-    if re.match(r"go\s+vet\b", cmd):
+    if re.match(r"go\s+vet\b", seg):
         return "go_vet"
-    if re.match(r"go\s+test\b", cmd):
+    if re.match(r"go\s+test\b", seg):
         return "go_test"
-    if re.match(r"go\s+mod\b", cmd):
+    if re.match(r"go\s+mod\b", seg):
         return "go_mod"
-    if re.match(r"go\s+\w+", cmd):
-        return "go_other"
-    if re.match(r"mage\b", cmd):
+    if _BINARY_RUN_RE.match(seg):
+        return "binary_run"
+    if re.match(r"golangci-lint\b", seg):
+        return "lint"
+    if re.match(r"gofmt\b", seg):
+        return "format"
+    if re.match(r"mage\b", seg):
         return "mage"
-    git_m = re.match(r"git\s+(\w+)", cmd)
+    git_m = re.match(r"git\s+(\w+)", seg)
     if git_m:
         return f"git_{git_m.group(1)}"
-    if re.match(r"mkdir\b", cmd):
-        return "mkdir"
-    if re.match(r"ls\b", cmd):
-        return "ls"
-    if re.match(r"cat\b", cmd):
-        return "cat"
-    if re.match(r"find\b", cmd):
-        return "find"
-    if re.match(r"grep\b", cmd):
-        return "grep"
-    if re.match(r"rm\b", cmd):
-        return "rm"
-    if re.match(r"cp\b", cmd):
-        return "cp"
-    if re.match(r"mv\b", cmd):
-        return "mv"
-    if re.match(r"echo\b", cmd):
-        return "echo"
-    if re.match(r"head\b", cmd):
-        return "head"
-    if re.match(r"tail\b", cmd):
-        return "tail"
-    if re.match(r"wc\b", cmd):
-        return "wc"
-    return "other"
+    if re.match(r"which\b", seg):
+        return "env_check"
+    if re.match(r"(?:pwd|cd)\b", seg):
+        return "env_inspect"
+    if re.match(r"go\s+\w+", seg):
+        return "go_other"
+    for verb in ("mkdir", "rm", "cp", "mv", "find", "grep", "cat", "head",
+                 "tail", "wc", "echo", "ls", "diff", "xxd", "od"):
+        if re.match(rf"{verb}\b", seg):
+            return verb
+    return None
+
+
+def classify_bash(command: str) -> str:
+    """Walk the pipeline; if leading segment is setup (printf/echo/cat <<)
+    and a downstream segment runs a compiled binary or inspects its output,
+    label the whole call as `binary_exercise`. Otherwise classify by the
+    first meaningful verb."""
+    cmd = normalize_command(command)
+    if not cmd:
+        return "empty"
+
+    segs = pipeline_segments(cmd)
+    if not segs:
+        return "other"
+    first = segs[0]
+
+    # printf/echo/cat-here-doc piped into a binary or inspector → exercise
+    if _SETUP_RE.match(first):
+        for seg in segs[1:]:
+            if _BINARY_RUN_RE.match(seg) or _INSPECT_RE.match(seg):
+                return "binary_exercise"
+        return "setup"
+
+    label = _classify_segment(first)
+    return label if label is not None else "other"
 
 
 def summarize_input(tool_name: str, tool_input: dict) -> str:
@@ -261,7 +299,41 @@ def find_logs(repo_root: Path) -> Iterator[tuple[str, Path]]:
             yield "gh-4994-run43", f
 
 
+def _self_check_classifier() -> None:
+    """Sanity asserts so refactor regressions show up loudly."""
+    cases = [
+        ("go build ./pkg/testutils/...", "go_build"),
+        ("go vet ./cmd/ts/...", "go_vet"),
+        ("go test ./cmd/cat/... -v", "go_test"),
+        ("printf 'a\\nb\\n' | go run ./cmd/cat", "binary_exercise"),
+        ("printf 'x' | ./bin/wc -l", "binary_exercise"),
+        ("printf 'x' | xxd", "binary_exercise"),
+        ("printf 'x'", "setup"),
+        ("# Test R3.2\nprintf 'a\\n' | ./bin/cat", "binary_exercise"),
+        ("CGO_ENABLED=0 go build ./cmd/cat", "go_build"),
+        ("./bin/du -sh ./pkg/", "binary_run"),
+        ("golangci-lint run ./pkg/...", "lint"),
+        ("gofmt -l ./", "format"),
+        ("which golangci-lint", "env_check"),
+        ("pwd", "env_inspect"),
+        ("git status", "git_status"),
+        ("mage stats:loc", "mage"),
+        ("mkdir -p /tmp/foo", "mkdir"),
+        ("ls -la", "ls"),
+    ]
+    failures = []
+    for cmd, expected in cases:
+        got = classify_bash(cmd)
+        if got != expected:
+            failures.append((cmd, expected, got))
+    if failures:
+        for cmd, exp, got in failures:
+            print(f"  CLASSIFIER FAIL: {cmd!r}  expected={exp}  got={got}", file=sys.stderr)
+        sys.exit(2)
+
+
 def main() -> int:
+    _self_check_classifier()
     repo_root = Path(__file__).resolve().parent.parent.parent
     all_tools: list[dict] = []
     all_turns: list[dict] = []


### PR DESCRIPTION
## Summary

Refines `extract_transcripts.py:classify_bash` to walk shell pipelines and apply preprocessing (strip leading `# comment` lines and `VAR=val ` env prefixes). Reduces `other` from 476 → 49 (-90%) and exposes a meaningful `binary_exercise` / `lint` / `format` / `env_check` breakdown for downstream charts (#5026).

## Changes

- `analysis/scripts/extract_transcripts.py` — refactored classifier (~80 LOC of new logic) plus `_self_check_classifier()` with 18 spot-check assertions that gate `main()`.
- `analysis/datasets/tools.csv` — regenerated with new classification.

## New classification breakdown

| Class | Count | What it captures |
|---|---:|---|
| `binary_exercise` | 238 | `printf X \| ./bin/Y` or `printf X \| go run ./cmd/Y` — testing the utility |
| `go_build` | 205 | unchanged in concept, +3 from `CGO_ENABLED=…` prefixed commands |
| `go_test` | 138 | (was 137) |
| `go_vet` | 110 | unchanged |
| `binary_run` | 104 | `./bin/X` or `go run ./cmd/Y` — direct execution |
| `lint` | 53 | `golangci-lint run …` |
| `env_check` | 43 | `which X` |
| `format` | 5 | `gofmt …` |
| `other` | 49 | tail (Python helpers, command substitutions, sed/awk) |

## Stats

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| Go production LOC | 44,350 | 44,350 | 0 |
| Go test LOC | 31,043 | 31,043 | 0 |
| Doc words | 130,957 | 130,957 | 0 |

## Test plan

- [ ] `pixi run python scripts/extract_transcripts.py` runs `_self_check_classifier()` first; any classifier regression exits 2.
- [ ] Spot-check: `printf 'a\\n' | go run ./cmd/cat` → `binary_exercise`.
- [ ] Spot-check: `# comment\\nprintf x | ./bin/wc` → `binary_exercise`.
- [ ] `tools.csv.bash_command_class.value_counts()` shows `other < 100`.

Closes #5034