### PR TITLE
GH-4409: Upgrade cobbler-scaffold v0.20260406.0 → v0.20260513.0

### DIFF
--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260406.0
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260513.0
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260406.0 h1:gvqx/AGvq8Q86bvLjdQmYY1KAsvq/AT+m215L0f6KzI=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260406.0/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260513.0 h1:gGPoqeadkNvkBxUwdgNF3s11YFDnNFzAYk6Y7ykXjZk=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260513.0/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/magefiles/orchestrator.go
+++ b/magefiles/orchestrator.go
@@ -28,6 +28,9 @@ type Prompt mg.Namespace
 // Stats groups the stats targets (LOC, tokens).
 type Stats mg.Namespace
 
+// Validate groups validation targets for agent tool use.
+type Validate mg.Namespace
+
 // Tests: run directly with go test:
 //   go test -tags=usecase -v -count=1 -timeout 1800s ./tests/rel01.0/...          # all
 //   go test -tags=usecase -v ./tests/rel01.0/uc001/                               # one UC
@@ -80,9 +83,6 @@ func Install() error { return newOrch().Builder.Install() }
 
 // Clean removes build artifacts.
 func Clean() error { return newOrch().Builder.Clean() }
-
-// Credentials extracts Claude credentials from the macOS Keychain.
-func Credentials() error { return newOrch().Builder.ExtractCredentials() }
 
 // Analyze performs cross-artifact consistency checks (SRDs, use cases, test suites, roadmap).
 func Analyze() error { return newOrch().Analyzer.Analyze() }
@@ -154,4 +154,10 @@ func (Prompt) Measure() error { return newOrch().DumpMeasurePrompt() }
 
 // Stitch prints the assembled stitch prompt to stdout.
 func (Prompt) Stitch() error { return newOrch().DumpStitchPrompt() }
+
+// --- Validate targets ---
+
+// Weights validates a proposed task's weight budget against MaxWeightPerTask.
+// Pass a string like 'srd005-wc R2.5, R2.6, R3.1, R3.2'.
+func (Validate) Weights(input string) error { return newOrch().ValidateTaskWeights(input) }
 


### PR DESCRIPTION
## Summary

Upgrades cobbler-scaffold from v0.20260406.0 to v0.20260513.0. This brings in the requirement state machine (GH-2123), --model flag passthrough (GH-2130), full SRD ID enforcement (GH-2120), and weight validation tooling (GH-2078).

## Changes

- Remove `Credentials` mage target (no longer needed in CLI mode)
- Add `Validate` namespace and `validate:weights` target
- Bump go.mod dependency to v0.20260513.0

## Test plan

- [x] `go vet` passes on `magefiles/orchestrator.go`
- [x] `mage -l` lists `validate:weights` target
- [x] `mage -l` does not list `credentials` target

Closes #4409