### PR TITLE
GH-5062: Upgrade cobbler-scaffold v0.20260513.0 → v0.20260612.0

### DIFF
--- a/.cobbler/measure_context.yaml
+++ b/.cobbler/measure_context.yaml
@@ -1,0 +1,17 @@
+# Phase context for the measure workflow.
+# Fields override the corresponding configuration.yaml settings when present.
+# Remove or leave fields empty to use configuration.yaml defaults.
+# See docs/engineering/eng08-phase-context-files.yaml for schema details.
+
+# include: |
+#   docs/VISION.yaml
+#   docs/ARCHITECTURE.yaml
+#   docs/specs/**/*.yaml
+
+# exclude: |
+#   docs/engineering/*
+
+# sources: |
+#   docs/constitutions/*.yaml
+
+# release: "01.0"

--- a/.cobbler/stitch_context.yaml
+++ b/.cobbler/stitch_context.yaml
@@ -1,0 +1,16 @@
+# Phase context for the stitch workflow.
+# Fields override the corresponding configuration.yaml settings when present.
+# Remove or leave fields empty to use configuration.yaml defaults.
+# See docs/engineering/eng08-phase-context-files.yaml for schema details.
+
+# include: |
+#   docs/ARCHITECTURE.yaml
+#   docs/specs/software-requirements/srd*.yaml
+
+# exclude: |
+#   docs/engineering/*
+
+# sources: |
+#   docs/constitutions/*.yaml
+
+# release: "01.0"

--- a/docs/SPECIFICATIONS.yaml
+++ b/docs/SPECIFICATIONS.yaml
@@ -184,186 +184,186 @@ use_case_index:
     title: "Count lines, words, and bytes via wc"
     release: rel03.0
     status: spec_complete
-    test_suite: test-rel03.0
+    test_suite: test-rel-03.0
     path: docs/specs/use-cases/rel03.0-uc001-wc.yaml
   - id: rel01.1-uc001-cat
     title: "Concatenate and display files via cat"
     release: rel01.1
     status: spec_complete
-    test_suite: test-rel01.1
+    test_suite: test-rel-01.1
     path: docs/specs/use-cases/rel01.1-uc001-cat.yaml
   - id: rel01.2-uc001-sponge
     title: "Soak stdin and write to file via sponge"
     release: rel01.2
     status: spec_complete
-    test_suite: test-rel01.2
+    test_suite: test-rel-01.2
     path: docs/specs/use-cases/rel01.2-uc001-sponge.yaml
   - id: rel01.3-uc001-du
     title: "Report recursive directory disk usage via du"
     release: rel01.3
     status: spec_complete
-    test_suite: test-rel01.3
+    test_suite: test-rel-01.3
     path: docs/specs/use-cases/rel01.3-uc001-du.yaml
   - id: rel04.0-uc001-ls
     title: "List directory contents via ls (core flags)"
     release: rel04.0
     status: spec_complete
-    test_suite: test-rel04.0
+    test_suite: test-rel-04.0
     path: docs/specs/use-cases/rel04.0-uc001-ls.yaml
   - id: rel04.0-uc002-ls-extended
     title: "List directory contents via ls (extended flags)"
     release: rel04.0
     status: spec_complete
-    test_suite: test-rel04.0-ext
+    test_suite: test-rel-04.0-ext
     path: docs/specs/use-cases/rel04.0-uc002-ls-extended.yaml
   - id: rel15.0-uc001-ts
     title: "Timestamp stdin lines via ts"
     release: rel15.0
     status: spec_complete
-    test_suite: test-rel15.0
+    test_suite: test-rel-15.0
     path: docs/specs/use-cases/rel15.0-uc001-ts.yaml
 
   - id: rel02.0-uc001-true
     title: "Exit successfully via true"
     release: rel02.0
     status: pending
-    test_suite: test-rel02.0
+    test_suite: test-rel-02.0
     path: docs/specs/use-cases/rel02.0-uc001-true.yaml
   - id: rel02.0-uc002-false
     title: "Exit unsuccessfully via false"
     release: rel02.0
     status: pending
-    test_suite: test-rel02.0
+    test_suite: test-rel-02.0
     path: docs/specs/use-cases/rel02.0-uc002-false.yaml
   - id: rel02.0-uc003-yes
     title: "Repeatedly output a string via yes"
     release: rel02.0
     status: pending
-    test_suite: test-rel02.0
+    test_suite: test-rel-02.0
     path: docs/specs/use-cases/rel02.0-uc003-yes.yaml
   - id: rel02.0-uc004-basename
     title: "Strip directory and suffix from filenames via basename"
     release: rel02.0
     status: pending
-    test_suite: test-rel02.0
+    test_suite: test-rel-02.0
     path: docs/specs/use-cases/rel02.0-uc004-basename.yaml
   - id: rel02.0-uc005-dirname
     title: "Strip last component from file paths via dirname"
     release: rel02.0
     status: pending
-    test_suite: test-rel02.0
+    test_suite: test-rel-02.0
     path: docs/specs/use-cases/rel02.0-uc005-dirname.yaml
   - id: rel02.1-uc001-tee
     title: "Copy stdin to stdout and files via tee"
     release: rel02.1
     status: pending
-    test_suite: test-rel02.1
+    test_suite: test-rel-02.1
     path: docs/specs/use-cases/rel02.1-uc001-tee.yaml
   - id: rel02.2-uc001-head
     title: "Print the first lines or bytes of files via head"
     release: rel02.2
     status: pending
-    test_suite: test-rel02.2
+    test_suite: test-rel-02.2
     path: docs/specs/use-cases/rel02.2-uc001-head.yaml
   - id: rel06.0-uc001-mkdir
     title: "Create directories via mkdir"
     release: rel06.0
     status: spec_complete
-    test_suite: test-rel06.0
+    test_suite: test-rel-06.0
     path: docs/specs/use-cases/rel06.0-uc001-mkdir.yaml
   - id: rel06.0-uc002-rmdir
     title: "Remove empty directories via rmdir"
     release: rel06.0
     status: spec_complete
-    test_suite: test-rel06.0
+    test_suite: test-rel-06.0
     path: docs/specs/use-cases/rel06.0-uc002-rmdir.yaml
   - id: rel06.0-uc003-mktemp
     title: "Create temporary files and directories via mktemp"
     release: rel06.0
     status: spec_complete
-    test_suite: test-rel06.0
+    test_suite: test-rel-06.0
     path: docs/specs/use-cases/rel06.0-uc003-mktemp.yaml
   - id: rel06.0-uc004-ln
     title: "Create links between files via ln"
     release: rel06.0
     status: spec_complete
-    test_suite: test-rel06.0
+    test_suite: test-rel-06.0
     path: docs/specs/use-cases/rel06.0-uc004-ln.yaml
   - id: rel06.0-uc005-unlink
     title: "Remove a single file via unlink"
     release: rel06.0
     status: spec_complete
-    test_suite: test-rel06.0
+    test_suite: test-rel-06.0
     path: docs/specs/use-cases/rel06.0-uc005-unlink.yaml
   - id: rel06.1-uc001-env
     title: "Run a command in a modified environment via env"
     release: rel06.1
     status: spec_complete
-    test_suite: test-rel06.1
+    test_suite: test-rel-06.1
     path: docs/specs/use-cases/rel06.1-uc001-env.yaml
   - id: rel06.1-uc002-printenv
     title: "Print environment variables via printenv"
     release: rel06.1
     status: spec_complete
-    test_suite: test-rel06.1
+    test_suite: test-rel-06.1
     path: docs/specs/use-cases/rel06.1-uc002-printenv.yaml
   - id: rel06.1-uc003-id
     title: "Print user and group information via id"
     release: rel06.1
     status: spec_complete
-    test_suite: test-rel06.1
+    test_suite: test-rel-06.1
     path: docs/specs/use-cases/rel06.1-uc003-id.yaml
   - id: rel06.1-uc004-whoami
     title: "Print effective user name via whoami"
     release: rel06.1
     status: spec_complete
-    test_suite: test-rel06.1
+    test_suite: test-rel-06.1
     path: docs/specs/use-cases/rel06.1-uc004-whoami.yaml
   - id: rel06.1-uc005-groups
     title: "Print group memberships via groups"
     release: rel06.1
     status: spec_complete
-    test_suite: test-rel06.1
+    test_suite: test-rel-06.1
     path: docs/specs/use-cases/rel06.1-uc005-groups.yaml
 
 test_suite_index:
-  - id: test-rel03.0
+  - id: test-rel-03.0
     title: "Test Suite: rel03.0 — wc specification and differential test"
     traces:
       - rel03.0-uc001-wc
     test_case_count: 13
-    path: docs/specs/test-suites/test-rel03.0.yaml
-  - id: test-rel01.1
+    path: docs/specs/test-suites/test-rel-03.0.yaml
+  - id: test-rel-01.1
     title: "Test Suite: rel01.1 — cat specification and differential test"
     traces:
       - rel01.1-uc001-cat
     test_case_count: 16
-    path: docs/specs/test-suites/test-rel01.1.yaml
-  - id: test-rel01.2
+    path: docs/specs/test-suites/test-rel-01.1.yaml
+  - id: test-rel-01.2
     title: "Test Suite: rel01.2 — sponge specification and differential test"
     traces:
       - rel01.2-uc001-sponge
     test_case_count: 8
-    path: docs/specs/test-suites/test-rel01.2.yaml
-  - id: test-rel01.3
+    path: docs/specs/test-suites/test-rel-01.2.yaml
+  - id: test-rel-01.3
     title: "Test Suite: rel01.3 — du specification and differential test"
     traces:
       - rel01.3-uc001-du
     test_case_count: 11
-    path: docs/specs/test-suites/test-rel01.3.yaml
-  - id: test-rel04.0
+    path: docs/specs/test-suites/test-rel-01.3.yaml
+  - id: test-rel-04.0
     title: "Test Suite: rel04.0 — ls core flag listing"
     traces:
       - rel04.0-uc001-ls
     test_case_count: 13
-    path: docs/specs/test-suites/test-rel04.0.yaml
-  - id: test-rel04.0-ext
+    path: docs/specs/test-suites/test-rel-04.0.yaml
+  - id: test-rel-04.0-ext
     title: "Test Suite: rel04.0 extended — ls extended flag listing"
     traces:
       - rel04.0-uc002-ls-extended
     test_case_count: 14
-    path: docs/specs/test-suites/test-rel04.0-ext.yaml
-  - id: test-rel15.0
+    path: docs/specs/test-suites/test-rel-04.0-ext.yaml
+  - id: test-rel-15.0
     title: "Test Suite: rel15.0 — ts, stty, pr, ptx"
     traces:
       - rel15.0-uc001-ts
@@ -371,9 +371,9 @@ test_suite_index:
       - rel15.0-uc003-pr
       - rel15.0-uc004-ptx
     test_case_count: 17
-    path: docs/specs/test-suites/test-rel15.0.yaml
+    path: docs/specs/test-suites/test-rel-15.0.yaml
 
-  - id: test-rel02.0
+  - id: test-rel-02.0
     title: "Test Suite: rel02.0 — trivial utilities (true, false, yes, basename, dirname)"
     traces:
       - rel02.0-uc001-true
@@ -382,20 +382,20 @@ test_suite_index:
       - rel02.0-uc004-basename
       - rel02.0-uc005-dirname
     test_case_count: 25
-    path: docs/specs/test-suites/test-rel02.0.yaml
-  - id: test-rel02.1
+    path: docs/specs/test-suites/test-rel-02.0.yaml
+  - id: test-rel-02.1
     title: "Test Suite: rel02.1 — tee"
     traces:
       - rel02.1-uc001-tee
     test_case_count: 9
-    path: docs/specs/test-suites/test-rel02.1.yaml
-  - id: test-rel02.2
+    path: docs/specs/test-suites/test-rel-02.1.yaml
+  - id: test-rel-02.2
     title: "Test Suite: rel02.2 — head"
     traces:
       - rel02.2-uc001-head
     test_case_count: 16
-    path: docs/specs/test-suites/test-rel02.2.yaml
-  - id: test-rel06.0
+    path: docs/specs/test-suites/test-rel-02.2.yaml
+  - id: test-rel-06.0
     title: "Test Suite: rel06.0 — file/directory creation and removal (mkdir, rmdir, mktemp, ln, unlink)"
     traces:
       - rel06.0-uc001-mkdir
@@ -404,8 +404,8 @@ test_suite_index:
       - rel06.0-uc004-ln
       - rel06.0-uc005-unlink
     test_case_count: 20
-    path: docs/specs/test-suites/test-rel06.0.yaml
-  - id: test-rel06.1
+    path: docs/specs/test-suites/test-rel-06.0.yaml
+  - id: test-rel-06.1
     title: "Test Suite: rel06.1 — environment and identity (env, printenv, id, whoami, groups)"
     traces:
       - rel06.1-uc001-env
@@ -414,7 +414,7 @@ test_suite_index:
       - rel06.1-uc004-whoami
       - rel06.1-uc005-groups
     test_case_count: 18
-    path: docs/specs/test-suites/test-rel06.1.yaml
+    path: docs/specs/test-suites/test-rel-06.1.yaml
 
 srd_to_use_case_mapping:
   - use_case: rel03.0-uc001-wc
@@ -551,10 +551,10 @@ traceability_diagram: |
     UC18["rel06.0-uc004-ln"] & UC19["rel06.0-uc005-unlink"]
     UC20["rel06.1-uc001-env"] & UC21["rel06.1-uc002-printenv"] & UC22["rel06.1-uc003-id"]
     UC23["rel06.1-uc004-whoami"] & UC24["rel06.1-uc005-groups"]
-    TS1["test-rel03.0"] & TS2["test-rel01.1"] & TS3["test-rel01.2"]
-    TS4["test-rel01.3"] & TS5["test-rel04.0"] & TS6["test-rel04.0-ext"] & TS7["test-rel15.0"]
-    TS8["test-rel02.0"] & TS9["test-rel02.1"] & TS10["test-rel02.2"]
-    TS11["test-rel06.0"] & TS12["test-rel06.1"]
+    TS1["test-rel-03.0"] & TS2["test-rel-01.1"] & TS3["test-rel-01.2"]
+    TS4["test-rel-01.3"] & TS5["test-rel-04.0"] & TS6["test-rel-04.0-ext"] & TS7["test-rel-15.0"]
+    TS8["test-rel-02.0"] & TS9["test-rel-02.1"] & TS10["test-rel-02.2"]
+    TS11["test-rel-06.0"] & TS12["test-rel-06.1"]
     V --> A
     A --> P1 & P2 & P3 & P4 & P5 & P6 & P7 & P8 & P9
     A --> P12 & P13 & P14 & P15 & P16 & P17 & P18

--- a/docs/constitutions/design.yaml
+++ b/docs/constitutions/design.yaml
@@ -209,7 +209,7 @@ document_types:
     location: "docs/specs/test-suites/test-rel-[release-id].yaml"
     format_rule: test-case-format
     required_fields:
-      - id (matching filename, e.g. test-rel01.0)
+      - id (matching filename, e.g. test-rel-01.0)
       - title
       - release (release ID this suite covers)
       - traces (list of use case IDs covered by this suite)
@@ -260,6 +260,24 @@ document_types:
       Go-specific signatures inlined in ARCHITECTURE.yaml with
       machine-parseable definitions. See eng10-interface-specifications for
       the full format and examples.
+
+  semantic_model:
+    location: "docs/specs/semantic-models/[domain]-[behavior].yaml"
+    format_rule: semantic-model-format
+    required_fields:
+      - name (pattern {domain}-{behavior})
+      - version (semver MAJOR.MINOR.PATCH)
+      - "data_sources (list with connector and queries)"
+      - "features (list with name, source, extraction)"
+      - "algorithm (type, parameters, logic)"
+      - output_format (type and fields)
+    purpose: |
+      Declarative behavioral specification for one agent capability. Declares
+      what the agent observes (data_sources), how it interprets observations
+      (features), how it reasons (algorithm), and what it produces
+      (output_format). Mutable layer between the SRD (stable architecture) and
+      generated code (implementation). See docs/constitutions/semantic-model.yaml
+      for the full ten-article schema (SM1-SM10).
 
   specification:
     location: docs/SPECIFICATIONS.yaml
@@ -322,9 +340,10 @@ document_types:
 naming_conventions:
   srd: "srd[NNN]-[feature-name].yaml (e.g., srd001-cupboard-core.yaml)"
   use_case: "rel[NN].[N]-uc[NNN]-[short-name].yaml (e.g., rel01.0-uc001-cupboard-lifecycle.yaml)"
-  test_suite: "test-[use-case-id].yaml (e.g., test-rel01.0-uc001-cupboard-lifecycle.yaml)"
+  test_suite: "test-rel-[release-id].yaml (e.g., test-rel-01.0.yaml)"
   engineering_guideline: "eng[NN]-[short-name].yaml (e.g., eng01-git-integration.yaml)"
   interface_specification: "ifc-[kebab-case-name].yaml (e.g., ifc-generation-lifecycle.yaml)"
+  semantic_model: "[domain]-[behavior].yaml (e.g., cobbler-measure.yaml, edge-compute-capacity-predictor.yaml)"
   architecture: "ARCHITECTURE.yaml"
   vision: "VISION.yaml"
   specification: "SPECIFICATIONS.yaml"
@@ -342,7 +361,8 @@ traceability_model:
   srds: Numbered requirements (architecture points to SRDs for detail)
   use_cases: Tracer bullets (exercise architecture components via touchpoints)
   test_suites: Validation (validate use case success criteria)
-  code: Implementation (traces to SRDs via commit messages)
+  semantic_models: Behavioral specs (declarative what-the-agent-does, output_format aligns with SRD IFunctional outputs)
+  code: Implementation (traces to SRDs via commit messages and to semantic models via algorithm logic)
 
 completeness_checklists:
   vision:
@@ -405,6 +425,18 @@ completeness_checklists:
     - references list SRD or use case IDs the interface traces to
     - File saved as ifc-[kebab-case-name].yaml in docs/interfaces/
 
+  semantic_model:
+    - name matches the pattern {domain}-{behavior}
+    - version follows semver (MAJOR.MINOR.PATCH)
+    - exactly four top-level sections present (data_sources, features, algorithm, output_format) per SM1
+    - every data source declares a connector type, not an implementation URL or library (SM2)
+    - every feature references at least one data source by id and query name; feature graph is acyclic (SM3)
+    - algorithm declares a named type, parameters, and pseudocode logic (not executable code) (SM4)
+    - output_format aligns with the agent's IFunctional interface in the SRD (SM5)
+    - one coherent behavior per semantic model (SM6)
+    - no prohibitive statements ("do not", "never", "must not") — those belong in constitutions (SM8)
+    - File saved as [domain]-[behavior].yaml in docs/specs/semantic-models/
+
 sections:
   - tag: articles
     title: Core Principles
@@ -422,10 +454,10 @@ sections:
   - tag: document_types
     title: Document Types
     content: |
-      Eight document types are defined: vision, architecture, SRD, use case,
-      test suite, engineering guideline, interface specification, and
-      specification. Each has a canonical location, format rule, required
-      fields, and optional fields.
+      Eleven document types are defined: vision, architecture, SRD, use case,
+      test suite, engineering guideline, interface specification, semantic
+      model, specification, roadmap, and generation run report. Each has a
+      canonical location, format rule, required fields, and optional fields.
   - tag: naming_conventions
     title: Naming Conventions
     content: |
@@ -443,7 +475,7 @@ sections:
     content: |
       Every artifact traces through the chain: vision goals → architecture
       components → SRD requirements → use case tracer bullets → test suite
-      validation → code implementation.
+      validation → semantic model behavior → code implementation.
   - tag: completeness_checklists
     title: Completeness Checklists
     content: |

--- a/docs/constitutions/interface.yaml
+++ b/docs/constitutions/interface.yaml
@@ -1,0 +1,135 @@
+# Interface Constitution
+#
+# This constitution governs the definition, naming, and traceability of
+# interfaces in the architecture and SRDs. It is scaffolded into consuming
+# projects so Claude knows how to write well-formed interface specifications
+# and how SRDs reference interfaces.
+
+articles:
+  - id: I1
+    title: Interface specifications live in docs/interfaces/
+    rule: |
+      Every interface has a specification file in docs/interfaces/. The
+      specification file is the authoritative contract: it defines data
+      structures with typed fields and operations with typed parameters and
+      return values. See eng10-interface-specifications for the full format.
+
+      ARCHITECTURE.yaml declares each interface in its interfaces section
+      with a name, summary, and a spec_file field pointing to the
+      specification file. The ARCHITECTURE.yaml entry is a discovery point
+      and summary; the specification file is the source of truth.
+
+  - id: I2
+    title: Required interface fields
+    rule: |
+      Every interface entry in ARCHITECTURE.yaml must have a name, a
+      summary, and a spec_file. The name is a short, unique identifier
+      (e.g., "Orchestrator and Config", "Prompt Templates"). The summary
+      describes what the interface provides in one to three sentences. The
+      spec_file is the path to the specification file in docs/interfaces/.
+      Optional fields are data_structures (list of type names with brief
+      descriptions) and operations (list of method or function signatures).
+
+      Interface specification files in docs/interfaces/ must have id, name,
+      and summary. Optional fields are data_structures (with typed field
+      lists), operations (with typed parameters and returns), announcements,
+      and references.
+
+  - id: I3
+    title: Naming conventions
+    rule: |
+      Interface names use title case with spaces (e.g., "Generation
+      Lifecycle", "Issue Tracker"). Names must be unique within
+      ARCHITECTURE.yaml. Abbreviations are permitted when the abbreviation
+      is standard in the domain (e.g., "OOD" for object-oriented design),
+      but must be explained in the summary on first use.
+
+      Specification file names use kebab case matching the interface name:
+      ifc-[kebab-case-name].yaml (e.g., ifc-generation-lifecycle.yaml).
+
+  - id: I4
+    title: SRD interface references
+    rule: |
+      SRDs may declare interface relationships using two optional fields:
+      implemented_by and used_by. Both are lists of interface names that
+      must resolve to entries in ARCHITECTURE.yaml's interfaces section.
+
+      implemented_by declares that the SRD's requirements define the
+      implementation of the named interface. The SRD's package_contract
+      exports correspond to the interface's operations.
+
+      used_by declares that the SRD's implementation consumes the named
+      interface. The SRD depends on the interface being available but does
+      not define it.
+
+      A single SRD may appear in both lists for different interfaces. An
+      interface may be implemented by one SRD and used by many.
+
+  - id: I5
+    title: Port and adapter semantics
+    rule: |
+      Interfaces follow the ports and adapters pattern. The specification
+      file in docs/interfaces/ is the port: it defines the contract without
+      specifying implementation. ARCHITECTURE.yaml is the discovery index
+      that points to ports via spec_file. SRDs that list the interface in
+      implemented_by are adapters: they provide a concrete implementation
+      of the port.
+
+      This separation means changing an adapter (rewriting a SRD's
+      implementation) does not change the port (the specification file).
+      Consumers that reference the interface via used_by depend on the
+      port, not the adapter. Analysis enforces that every referenced
+      interface name resolves to a declared port.
+
+      The port contract is defined in the specification file using typed
+      field lists for data structures and typed parameter/return lists for
+      operations.
+
+  - id: I6
+    title: Interface traceability
+    rule: |
+      The traceability chain for interfaces runs: ARCHITECTURE.yaml
+      (declares the interface with spec_file) -> specification file in
+      docs/interfaces/ (defines the contract) -> SRD implemented_by
+      (provides the implementation) -> SRD used_by (consumes the
+      interface). Analysis validates both directions: every name in
+      implemented_by and used_by must match an interface name in
+      ARCHITECTURE.yaml. Broken references fail the analysis check.
+
+      Specification files include a references field listing SRD and use
+      case IDs that the interface traces to, completing the bidirectional
+      link.
+
+sections:
+  - tag: articles
+    title: Core Principles
+    content: |
+      Six principles govern interface specifications: interfaces live in
+      docs/interfaces/ as standalone specification files referenced from
+      ARCHITECTURE.yaml via spec_file (I1), required ARCHITECTURE.yaml
+      fields are name, summary, and spec_file (I2), names use title case
+      and specification files use kebab case (I3), SRDs reference
+      interfaces via implemented_by and used_by (I4), specification files
+      are the ports in ports-and-adapters semantics (I5), and traceability
+      runs from architecture through specification files through SRDs (I6).
+  - tag: structure
+    title: Interface Structure
+    content: |
+      An interface entry in ARCHITECTURE.yaml is a YAML mapping with five
+      fields: name (required), summary (required), spec_file (required),
+      data_structures (optional list), and operations (optional list). SRDs
+      reference interfaces by name using implemented_by and used_by string
+      lists.
+
+      Specification files in docs/interfaces/ use typed field lists for
+      data structures and typed parameter/return lists for operations.
+      See eng10-interface-specifications for the full format.
+  - tag: validation
+    title: Analysis Validation
+    content: |
+      The mage analyze target validates interface references. Every entry
+      in a SRD's implemented_by and used_by lists must match the name
+      field of an interface in ARCHITECTURE.yaml. Unresolved references
+      are reported as errors. Missing or empty interface lists are not
+      errors; the fields are optional. Analyze validates that spec_file
+      paths point to existing files.

--- a/docs/constitutions/issue-format.yaml
+++ b/docs/constitutions/issue-format.yaml
@@ -1,0 +1,225 @@
+# Issue Format Constitution
+#
+# Formal YAML schema for issue descriptions produced by the measure phase
+# and consumed by the stitch phase. Referenced by the measure prompt (to
+# tell Claude what format to produce) and used by stitch (to validate what
+# it reads back).
+
+schema:
+  description: |
+    Every issue description must be a valid YAML document conforming to this
+    schema. The stitch agent parses the description as YAML to extract
+    required_reading, files, requirements, and acceptance_criteria.
+
+  required_fields:
+    - deliverable_type
+    - required_reading
+    - files
+    - requirements
+    - acceptance_criteria
+
+  optional_fields:
+    - format_rule
+    - required_sections
+    - design_decisions
+
+yaml_rules:
+  - rule: All strings containing colons, commas, or special YAML characters must be quoted.
+    example_bad: "- R1: Implement feature: core"
+    example_good: '- "R1: Implement feature: core"'
+
+  - rule: List items are YAML mappings, not bare strings, when they have sub-fields.
+    example_bad: "- Use table accessor pattern"
+    example_good: |
+      - id: D1
+        text: Use table accessor pattern
+
+  - rule: Use ASCII dashes (--) not Unicode em dashes or en dashes.
+    example_bad: "Flag interactions — especially combined flags"
+    example_good: "Flag interactions -- especially combined flags"
+
+  - rule: Requirements, design decisions, and acceptance criteria are all mappings with id and text fields.
+    example_bad: "- Use singleton pattern"
+    example_good: |
+      - id: D1
+        text: Use singleton pattern
+
+field_specs:
+  deliverable_type:
+    type: string
+    values: [documentation, code]
+    required: true
+    description: What kind of deliverable this issue produces.
+
+  required_reading:
+    type: list of strings
+    required: true
+    description: |
+      Files the agent must read before starting. Each entry is a file path
+      with an optional parenthetical reason. This is mandatory for all issues.
+
+  files:
+    type: list of mappings
+    required: true
+    sub_fields:
+      path:
+        type: string
+        required: true
+        description: Absolute path from repo root.
+      action:
+        type: string
+        required: true
+        values: [create, modify]
+      note:
+        type: string
+        required: false
+        description: Brief purpose of this file change.
+
+  requirements:
+    type: list of mappings
+    required: true
+    sub_fields:
+      id:
+        type: string
+        required: true
+        description: "Sequential ID: R1, R2, R3, ..."
+      text:
+        type: string
+        required: true
+        description: What needs to be built or written. Be specific and actionable.
+
+  design_decisions:
+    type: list of mappings
+    required: false
+    sub_fields:
+      id:
+        type: string
+        required: true
+        description: "Sequential ID: D1, D2, D3, ..."
+      text:
+        type: string
+        required: true
+        description: The decision text.
+
+  acceptance_criteria:
+    type: list of mappings
+    required: true
+    sub_fields:
+      id:
+        type: string
+        required: true
+        description: "Sequential ID: AC1, AC2, AC3, ..."
+      text:
+        type: string
+        required: true
+        description: Checkable outcome. Must be verifiable without ambiguity.
+
+  format_rule:
+    type: string
+    required: false
+    description: |
+      For documentation issues only. The rule file that governs the output
+      format (e.g., srd-format, use-case-format).
+
+  required_sections:
+    type: list of strings
+    required: false
+    description: |
+      For documentation issues only. Sections the document must contain.
+
+examples:
+  code_issue: |
+    deliverable_type: code
+
+    required_reading:
+      - docs/specs/software-requirements/srd003-crumbs-interface.yaml
+      - pkg/types/cupboard.go
+
+    files:
+      - path: pkg/types/crumb.go
+        action: create
+        note: Crumb struct, Filter type
+      - path: internal/sqlite/crumbs.go
+        action: create
+        note: CrumbTable implementation
+
+    requirements:
+      - id: R1
+        text: Implement CrumbTable interface per srd003-crumbs-interface
+      - id: R2
+        text: Add, Get, Archive, Purge, Fetch operations
+      - id: R3
+        text: Property operations (Set/Get/Clear)
+
+    design_decisions:
+      - id: D1
+        text: Use table accessor pattern from srd001-cupboard-core
+      - id: D2
+        text: Filter as map[string]any per SRD
+
+    acceptance_criteria:
+      - id: AC1
+        text: All CrumbTable operations implemented
+      - id: AC2
+        text: Tests pass for each operation
+      - id: AC3
+        text: Errors match SRD error types
+
+  documentation_issue: |
+    deliverable_type: documentation
+    format_rule: srd-format
+
+    required_reading:
+      - docs/ARCHITECTURE.yaml (components section)
+      - docs/specs/software-requirements/srd001-cupboard-core.yaml
+
+    files:
+      - path: docs/specs/software-requirements/srd-feature-name.yaml
+        action: create
+
+    required_sections:
+      - "Problem: explain the problem and why it matters"
+      - "Goals: G1 ..., G2 ..."
+      - "Requirements: R1.1 ..., R1.2 ..."
+      - "Non-Goals: what is out of scope"
+      - "Acceptance Criteria: checkable outcomes"
+
+    requirements:
+      - id: R1
+        text: Write SRD covering all identified requirements
+      - id: R2
+        text: Include acceptance criteria for each requirement
+
+    acceptance_criteria:
+      - id: AC1
+        text: All required sections present
+      - id: AC2
+        text: File saved as srd-feature-name.yaml
+      - id: AC3
+        text: Requirements numbered and specific
+
+sections:
+  - tag: schema
+    title: Issue Schema
+    content: |
+      Each issue description is a YAML document with five required fields:
+      deliverable_type, required_reading, files, requirements, and
+      acceptance_criteria. Optional fields include design_decisions and
+      format_rule.
+  - tag: yaml_rules
+    title: YAML Formatting Rules
+    content: |
+      Use multi-line block literals (|) for prose. Keys are lowercase with
+      underscores. Avoid unnecessary quoting. Each requirement and acceptance
+      criterion is a mapping with id and text fields.
+  - tag: field_specs
+    title: Field Specifications
+    content: |
+      Field specifications define the type, allowed values, whether the field is
+      required, and sub-field structure for each issue description field.
+  - tag: examples
+    title: Examples
+    content: |
+      Reference examples for documentation issues and code issues show the full
+      expected YAML structure, including required reading, output paths, format
+      rules, requirements, and acceptance criteria.

--- a/docs/constitutions/semantic-model.yaml
+++ b/docs/constitutions/semantic-model.yaml
@@ -1,0 +1,237 @@
+# Semantic Model Constitution
+#
+# This constitution governs the authoring and validation of semantic models.
+# It is injected into the specification authoring phase so the Generator
+# (human or machine) knows how to produce well-formed, complete behavioral
+# specifications.
+#
+# A semantic model is the mutable behavioral layer of an agent specification.
+# It declares what the agent observes, how it reasons, and what it produces—
+# without prescribing code structure. The SRD defines architecture (stable).
+# The semantic model defines behavior (mutable). Constitutions and guidelines
+# constrain how behavior is implemented (prohibitive). The semantic model
+# declares what behavior IS (declarative).
+
+articles:
+  - id: SM1
+    title: Four mandatory sections
+    rule: |
+      Every semantic model must contain exactly four top-level sections:
+      data_sources, features, algorithm, and output_format. A semantic
+      model that omits any section is incomplete. A semantic model that
+      adds sections beyond these four is overspecified—move the extra
+      content to the SRD, architectural guidelines, or domain knowledge.
+
+      data_sources: what the agent observes (inputs)
+      features: how the agent interprets observations (derived signals)
+      algorithm: how the agent reasons (decision logic)
+      output_format: what the agent produces (outputs)
+
+  - id: SM2
+    title: Data sources are connectors, not implementations
+    rule: |
+      Each data source declares a connector type and a set of named
+      queries. The connector type names an interface or protocol—not a
+      library, endpoint URL, or implementation class. Queries declare
+      parameters and return types using domain types, not language-specific
+      types.
+
+      Good:
+        connector: INetworkState
+        queries:
+          - name: site_capacity
+            parameters: [site_id]
+            returns: {compute_available: float, memory_available: float}
+
+      Bad:
+        connector: "http://10.0.1.5:8080/api/v2"
+        queries:
+          - name: get_capacity
+            parameters: ["string siteId"]
+            returns: "json.RawMessage"
+
+      The semantic model specifies what data the agent needs, not where
+      or how it fetches it. Binding data sources to concrete endpoints
+      happens at deployment through configuration, not at specification
+      time through the semantic model.
+
+  - id: SM3
+    title: Features derive from data sources
+    rule: |
+      Every feature must reference at least one data source by id and
+      query name using dot notation (e.g., network_state.site_capacity).
+      Features that do not trace to a declared data source are untethered—
+      they claim to observe something the agent has no access to.
+
+      The extraction field describes the derivation in domain language,
+      not in code. It should be readable by a domain expert who does not
+      program. The Generator translates extraction descriptions into code;
+      the semantic model author describes the intent.
+
+      Features may reference other features to build derived signals.
+      Feature references must not form cycles. The dependency graph of
+      features must be a DAG.
+
+  - id: SM4
+    title: Algorithm declares logic, not code
+    rule: |
+      The algorithm section specifies the agent's reasoning as a named
+      type, a parameter set, and a logic block written in structured
+      pseudocode or domain language.
+
+      The type field names the reasoning pattern (e.g.,
+      threshold_with_trend, gap_ordered_task_generation,
+      ensemble_prediction). Types should be reusable across semantic
+      models—they name a family of algorithms, not a specific
+      implementation.
+
+      The parameters field declares the tunable knobs of the algorithm.
+      Parameters are the primary target of runtime configuration changes—
+      a threshold change should not require a specification delta if the
+      parameter is already declared.
+
+      The logic block is pseudocode, not executable code. It describes
+      the decision flow using feature names and domain concepts. The
+      Generator reads the logic block to understand the intended behavior
+      and produces the implementation. If the logic block is precise
+      enough to be executable, it is overspecified—it has become code
+      in disguise.
+
+  - id: SM5
+    title: Output format matches the functional interface
+    rule: |
+      The output_format section must align with the agent's IFunctional
+      interface as declared in the SRD. Every field in the output format
+      must correspond to a return type or response structure in the
+      functional interface.
+
+      If the semantic model produces outputs that IFunctional cannot
+      express, either the semantic model is wrong (specifying behavior
+      the architecture does not support) or the SRD needs a delta (the
+      architecture must grow to support the new behavior). This cross-
+      reference between semantic model and SRD is what makes specification
+      layers a graph, not a stack.
+
+  - id: SM6
+    title: One semantic model per behavior
+    rule: |
+      Each semantic model specifies one coherent behavior—one
+      observation-reasoning-output pipeline. An agent that performs
+      multiple behaviors (e.g., capacity prediction AND fault diagnosis)
+      has multiple semantic models, not one large one.
+
+      Semantic models are composed at the specification level. The
+      Specification Selector assembles the set of semantic models an
+      agent instance needs. The SRD defines the architectural slots
+      these models fill. Each slot corresponds to one behavioral
+      capability.
+
+      Splitting behaviors into separate semantic models enables
+      independent evolution. A new fault diagnosis algorithm does not
+      require re-specifying capacity prediction. The evolution pipeline
+      applies the delta to one semantic model without touching others.
+
+  - id: SM7
+    title: Naming and versioning
+    rule: |
+      Every semantic model has a name and a version.
+
+      The name follows the pattern: {domain}-{behavior}
+      Examples: edge-compute-capacity-predictor, transport-fault-diagnoser,
+      cobbler-measure, ran-latency-monitor.
+
+      The version follows semantic versioning (MAJOR.MINOR.PATCH):
+      - MAJOR: breaking changes to data sources or output format
+      - MINOR: new features or algorithm changes (backward compatible)
+      - PATCH: parameter tuning or extraction refinements
+
+      Version changes trigger different evolution responses. A PATCH
+      change may only require regenerating the algorithm implementation.
+      A MAJOR change may require regenerating data connectors, feature
+      extractors, and output formatters—touching multiple components.
+
+  - id: SM8
+    title: Semantic models are declarative, not prohibitive
+    rule: |
+      A semantic model declares what the agent DOES. It does not declare
+      what the agent must NOT do. Prohibitions belong in architectural
+      guidelines or constitutions.
+
+      Declarative (semantic model):
+        "Observe the specification tree, identify unimplemented use cases,
+        order by release priority, decompose into sized tasks."
+
+      Prohibitive (constitution/guideline):
+        "Do NOT propose tasks for implemented use cases."
+        "Do NOT exceed 350 lines per task."
+
+      If a statement in the semantic model begins with "do not," "never,"
+      "must not," or "avoid," it is a constraint and belongs in the
+      architectural guidelines layer. Move it there.
+
+      This separation matters because constraints are stable across
+      instances (every Analyst follows the same coding standards) while
+      behaviors are mutable per instance (each Analyst observes different
+      data and runs different algorithms).
+
+  - id: SM9
+    title: Testability
+    rule: |
+      Every semantic model must be testable through its output format.
+      Given known inputs to data_sources and known feature extractions,
+      the algorithm must produce deterministic or bounded outputs that
+      tests can verify.
+
+      When authoring a semantic model, ask: "Can I write a test that
+      provides mock data sources, runs the algorithm, and checks the
+      output?" If the answer is no, the semantic model is underspecified—
+      it does not declare enough about the algorithm's behavior for the
+      Generator to produce testable code.
+
+      The test suite layer of the agent specification contains tests
+      derived from the semantic model. Each feature should have at least
+      one test validating its extraction. The algorithm should have tests
+      for each branch of its logic. The output format should have tests
+      validating structure and value ranges.
+
+  - id: SM10
+    title: Domain knowledge references, not domain knowledge
+    rule: |
+      The semantic model may reference domain knowledge (ontologies,
+      protocol specs, vendor documentation) but must not embed it.
+      Data source connectors reference interface names defined in
+      domain knowledge. Feature extractions reference domain concepts
+      explained in domain knowledge. The semantic model says "use X";
+      domain knowledge defines what X is.
+
+      This separation keeps the semantic model portable. The same
+      capacity prediction semantic model can apply to different vendors
+      by swapping the domain knowledge binding—different equipment APIs,
+      same behavioral specification.
+
+sections:
+  - tag: articles
+    title: Core Principles
+    content: |
+      Ten principles govern semantic model authoring: four mandatory
+      sections (SM1), connector-based data sources (SM2), traceable
+      features (SM3), declarative algorithms (SM4), interface-aligned
+      outputs (SM5), one behavior per model (SM6), semantic versioning
+      (SM7), declarative not prohibitive (SM8), testability (SM9), and
+      referenced not embedded domain knowledge (SM10).
+  - tag: structure
+    title: Semantic Model Structure
+    content: |
+      A semantic model is a YAML document with four sections:
+      data_sources (inputs), features (derived signals), algorithm
+      (reasoning), and output_format (outputs). Each section has
+      specific structural requirements defined in the articles.
+  - tag: evolution
+    title: Semantic Model Evolution
+    content: |
+      The semantic model is the primary target for agent evolution.
+      Version changes signal the scope of regeneration needed. PATCH
+      changes tune parameters. MINOR changes add features or modify
+      algorithms. MAJOR changes alter inputs or outputs and may
+      require SRD changes. Each semantic model evolves independently
+      of others in the same agent.

--- a/docs/specs/test-suites/test-rel-00.0.yaml
+++ b/docs/specs/test-suites/test-rel-00.0.yaml
@@ -1,4 +1,4 @@
-id: test-rel00.0
+id: test-rel-00.0
 title: "Test Suite: rel00.0 — build lifecycle, cmd/version, pkg/format, pkg/sys, and pkg/testutils"
 release: rel00.0
 

--- a/docs/specs/test-suites/test-rel-01.1.yaml
+++ b/docs/specs/test-suites/test-rel-01.1.yaml
@@ -1,4 +1,4 @@
-id: test-rel01.1
+id: test-rel-01.1
 title: "Test Suite: rel01.1 — cat specification and differential test"
 release: rel01.1
 

--- a/docs/specs/test-suites/test-rel-01.2.yaml
+++ b/docs/specs/test-suites/test-rel-01.2.yaml
@@ -1,4 +1,4 @@
-id: test-rel01.2
+id: test-rel-01.2
 title: "Test Suite: rel01.2 — sponge specification and differential test"
 release: rel01.2
 

--- a/docs/specs/test-suites/test-rel-01.3.yaml
+++ b/docs/specs/test-suites/test-rel-01.3.yaml
@@ -1,4 +1,4 @@
-id: test-rel01.3
+id: test-rel-01.3
 title: "Test Suite: rel01.3 — du specification and differential test"
 release: rel01.3
 

--- a/docs/specs/test-suites/test-rel-02.0.yaml
+++ b/docs/specs/test-suites/test-rel-02.0.yaml
@@ -1,4 +1,4 @@
-id: test-rel02.0
+id: test-rel-02.0
 title: "Test Suite: rel02.0 — trivial utilities (true, false, yes, basename, dirname)"
 release: rel02.0
 

--- a/docs/specs/test-suites/test-rel-02.1.yaml
+++ b/docs/specs/test-suites/test-rel-02.1.yaml
@@ -1,4 +1,4 @@
-id: test-rel02.1
+id: test-rel-02.1
 title: "Test Suite: rel02.1 — tee"
 release: rel02.1
 

--- a/docs/specs/test-suites/test-rel-02.2.yaml
+++ b/docs/specs/test-suites/test-rel-02.2.yaml
@@ -1,4 +1,4 @@
-id: test-rel02.2
+id: test-rel-02.2
 title: "Test Suite: rel02.2 — head and seq"
 release: rel02.2
 

--- a/docs/specs/test-suites/test-rel-03.0.yaml
+++ b/docs/specs/test-suites/test-rel-03.0.yaml
@@ -1,4 +1,4 @@
-id: test-rel03.0
+id: test-rel-03.0
 title: "Test Suite: rel03.0 — wc specification and differential test"
 release: rel03.0
 

--- a/docs/specs/test-suites/test-rel-03.1.yaml
+++ b/docs/specs/test-suites/test-rel-03.1.yaml
@@ -1,4 +1,4 @@
-id: test-rel03.1
+id: test-rel-03.1
 title: "Test Suite: rel03.1 — system information (uname, arch, nproc, hostname, hostid)"
 release: rel03.1
 

--- a/docs/specs/test-suites/test-rel-04.0-ext.yaml
+++ b/docs/specs/test-suites/test-rel-04.0-ext.yaml
@@ -1,4 +1,4 @@
-id: test-rel04.0-ext
+id: test-rel-04.0-ext
 title: "Test Suite: rel04.0 extended — ls extended flag listing"
 release: rel04.0
 

--- a/docs/specs/test-suites/test-rel-04.0.yaml
+++ b/docs/specs/test-suites/test-rel-04.0.yaml
@@ -1,4 +1,4 @@
-id: test-rel04.0
+id: test-rel-04.0
 title: "Test Suite: rel04.0 — ls core flag listing"
 release: rel04.0
 

--- a/docs/specs/test-suites/test-rel-04.1.yaml
+++ b/docs/specs/test-suites/test-rel-04.1.yaml
@@ -1,4 +1,4 @@
-id: test-rel04.1
+id: test-rel-04.1
 title: "Test Suite: rel04.1 — path and terminal utilities (realpath, readlink, pwd, tty, logname)"
 release: rel04.1
 

--- a/docs/specs/test-suites/test-rel-05.0.yaml
+++ b/docs/specs/test-suites/test-rel-05.0.yaml
@@ -1,4 +1,4 @@
-id: test-rel05.0
+id: test-rel-05.0
 title: "Test Suite: rel05.0 — echo, tac, nl, fold"
 release: rel05.0
 

--- a/docs/specs/test-suites/test-rel-05.1.yaml
+++ b/docs/specs/test-suites/test-rel-05.1.yaml
@@ -1,4 +1,4 @@
-id: test-rel05.1
+id: test-rel-05.1
 title: "Test Suite: rel05.1 — expand, unexpand"
 release: rel05.1
 

--- a/docs/specs/test-suites/test-rel-05.2.yaml
+++ b/docs/specs/test-suites/test-rel-05.2.yaml
@@ -1,4 +1,4 @@
-id: test-rel05.2
+id: test-rel-05.2
 title: "Test Suite: rel05.2 — cut, paste"
 release: rel05.2
 

--- a/docs/specs/test-suites/test-rel-05.3.yaml
+++ b/docs/specs/test-suites/test-rel-05.3.yaml
@@ -1,4 +1,4 @@
-id: test-rel05.3
+id: test-rel-05.3
 title: "Test Suite: rel05.3 — uniq, comm"
 release: rel05.3
 

--- a/docs/specs/test-suites/test-rel-05.4.yaml
+++ b/docs/specs/test-suites/test-rel-05.4.yaml
@@ -1,4 +1,4 @@
-id: test-rel05.4
+id: test-rel-05.4
 title: "Test Suite: rel05.4 — md5sum, sha1sum, sha256sum, sha512sum"
 release: rel05.4
 

--- a/docs/specs/test-suites/test-rel-06.0.yaml
+++ b/docs/specs/test-suites/test-rel-06.0.yaml
@@ -1,4 +1,4 @@
-id: test-rel06.0
+id: test-rel-06.0
 title: "Test Suite: rel06.0 — file/directory creation and removal (mkdir, rmdir, mktemp, ln, unlink)"
 release: rel06.0
 

--- a/docs/specs/test-suites/test-rel-06.1.yaml
+++ b/docs/specs/test-suites/test-rel-06.1.yaml
@@ -1,4 +1,4 @@
-id: test-rel06.1
+id: test-rel-06.1
 title: "Test Suite: rel06.1 — environment and identity (env, printenv, id, whoami, groups)"
 release: rel06.1
 

--- a/docs/specs/test-suites/test-rel-07.0.yaml
+++ b/docs/specs/test-suites/test-rel-07.0.yaml
@@ -1,4 +1,4 @@
-id: test-rel07.0
+id: test-rel-07.0
 title: "Test Suite: rel07.0 — sort, tr, tail"
 release: rel07.0
 

--- a/docs/specs/test-suites/test-rel-07.1.yaml
+++ b/docs/specs/test-suites/test-rel-07.1.yaml
@@ -1,4 +1,4 @@
-id: test-rel07.1
+id: test-rel-07.1
 title: "Test Suite: rel07.1 — cp, mv, rm"
 release: rel07.1
 

--- a/docs/specs/test-suites/test-rel-08.0.yaml
+++ b/docs/specs/test-suites/test-rel-08.0.yaml
@@ -1,4 +1,4 @@
-id: test-rel08.0
+id: test-rel-08.0
 title: "Test Suite: rel08.0 — date, sleep, touch, timeout, shuf, factor, expr"
 release: rel08.0
 

--- a/docs/specs/test-suites/test-rel-08.1.yaml
+++ b/docs/specs/test-suites/test-rel-08.1.yaml
@@ -1,4 +1,4 @@
-id: test-rel08.1
+id: test-rel-08.1
 title: "Test Suite: rel08.1 — split, csplit, join, fmt, numfmt, od, printf"
 release: rel08.1
 

--- a/docs/specs/test-suites/test-rel-09.0.yaml
+++ b/docs/specs/test-suites/test-rel-09.0.yaml
@@ -1,4 +1,4 @@
-id: test-rel09.0
+id: test-rel-09.0
 title: "Test Suite: rel09.0 — sha224sum, sha384sum, b2sum, cksum, sum"
 release: rel09.0
 

--- a/docs/specs/test-suites/test-rel-09.1.yaml
+++ b/docs/specs/test-suites/test-rel-09.1.yaml
@@ -1,4 +1,4 @@
-id: test-rel09.1
+id: test-rel-09.1
 title: "Test Suite: rel09.1 — base32, base64, basenc"
 release: rel09.1
 

--- a/docs/specs/test-suites/test-rel-10.0.yaml
+++ b/docs/specs/test-suites/test-rel-10.0.yaml
@@ -1,4 +1,4 @@
-id: test-rel10.0
+id: test-rel-10.0
 title: "Test Suite: rel10.0 — stat, truncate, link, sync"
 release: rel10.0
 

--- a/docs/specs/test-suites/test-rel-10.1.yaml
+++ b/docs/specs/test-suites/test-rel-10.1.yaml
@@ -1,4 +1,4 @@
-id: test-rel10.1
+id: test-rel-10.1
 title: "Test Suite: rel10.1 — chmod, chgrp, chown"
 release: rel10.1
 

--- a/docs/specs/test-suites/test-rel-11.0.yaml
+++ b/docs/specs/test-suites/test-rel-11.0.yaml
@@ -1,4 +1,4 @@
-id: test-rel11.0
+id: test-rel-11.0
 title: "Test Suite: rel11.0 — mkfifo, mknod, nice, nohup"
 release: rel11.0
 

--- a/docs/specs/test-suites/test-rel-11.1.yaml
+++ b/docs/specs/test-suites/test-rel-11.1.yaml
@@ -1,4 +1,4 @@
-id: test-rel11.1
+id: test-rel-11.1
 title: "Test Suite: rel11.1 — users, who, pinky"
 release: rel11.1
 

--- a/docs/specs/test-suites/test-rel-12.0.yaml
+++ b/docs/specs/test-suites/test-rel-12.0.yaml
@@ -1,4 +1,4 @@
-id: test-rel12.0
+id: test-rel-12.0
 title: "Test Suite: rel12.0 — shred, chroot, install"
 release: rel12.0
 

--- a/docs/specs/test-suites/test-rel-12.1.yaml
+++ b/docs/specs/test-suites/test-rel-12.1.yaml
@@ -1,4 +1,4 @@
-id: test-rel12.1
+id: test-rel-12.1
 title: "Test Suite: rel12.1 — tsort, pathchk, test"
 release: rel12.1
 

--- a/docs/specs/test-suites/test-rel-13.0.yaml
+++ b/docs/specs/test-suites/test-rel-13.0.yaml
@@ -1,4 +1,4 @@
-id: test-rel13.0
+id: test-rel-13.0
 title: "Test Suite: rel13.0 — df, dir, vdir, dircolors"
 release: rel13.0
 

--- a/docs/specs/test-suites/test-rel-14.0.yaml
+++ b/docs/specs/test-suites/test-rel-14.0.yaml
@@ -1,4 +1,4 @@
-id: test-rel14.0
+id: test-rel-14.0
 title: "Test Suite: rel14.0 — chronic, pee, vidir"
 release: rel14.0
 

--- a/docs/specs/test-suites/test-rel-15.0.yaml
+++ b/docs/specs/test-suites/test-rel-15.0.yaml
@@ -1,4 +1,4 @@
-id: test-rel15.0
+id: test-rel-15.0
 title: "Test Suite: rel15.0 — ts, stty, pr, ptx"
 release: rel15.0
 

--- a/docs/specs/use-cases/rel00.0-uc001-magefiles.yaml
+++ b/docs/specs/use-cases/rel00.0-uc001-magefiles.yaml
@@ -64,4 +64,4 @@ out_of_scope:
   - mage install is exercised by the operator manually; it is not part of this use case's primary flow.
   - Orchestrator, generator, scaffold, and prompt targets are provided by cobbler-scaffold and not covered here.
 
-test_suite: test-rel00.0
+test_suite: test-rel-00.0

--- a/docs/specs/use-cases/rel00.0-uc002-format.yaml
+++ b/docs/specs/use-cases/rel00.0-uc002-format.yaml
@@ -64,4 +64,4 @@ out_of_scope:
   - Terminal hyperlinks are not in scope.
   - East-asian full-width character width computation is deferred.
 
-test_suite: test-rel00.0
+test_suite: test-rel-00.0

--- a/docs/specs/use-cases/rel00.0-uc003-sys.yaml
+++ b/docs/specs/use-cases/rel00.0-uc003-sys.yaml
@@ -65,4 +65,4 @@ out_of_scope:
   - Process-group management (setpgid, killpg) is deferred to the xargs PRD.
   - SIGUSR1/SIGUSR2 handling is deferred to the find PRD.
 
-test_suite: test-rel00.0
+test_suite: test-rel-00.0

--- a/docs/specs/use-cases/rel00.0-uc004-testutils.yaml
+++ b/docs/specs/use-cases/rel00.0-uc004-testutils.yaml
@@ -86,4 +86,4 @@ out_of_scope:
   - Binary compilation and installation are handled by magefiles, not pkg/testutils.
   - Retry logic and filesystem mocking are explicitly excluded by the PRD.
 
-test_suite: test-rel00.0
+test_suite: test-rel-00.0

--- a/docs/specs/use-cases/rel00.0-uc005-hashutil.yaml
+++ b/docs/specs/use-cases/rel00.0-uc005-hashutil.yaml
@@ -46,4 +46,4 @@ out_of_scope:
   - Specific hash algorithm implementations (provided by Go standard library).
   - SIGPIPE handling (each cmd/ utility handles independently).
 
-test_suite: test-rel00.0
+test_suite: test-rel-00.0

--- a/docs/specs/use-cases/rel00.0-uc006-sizeparse.yaml
+++ b/docs/specs/use-cases/rel00.0-uc006-sizeparse.yaml
@@ -42,4 +42,4 @@ out_of_scope:
   - Size formatting for output (handled by pkg/format.HumanSize).
   - Floating-point size parsing.
 
-test_suite: test-rel00.0
+test_suite: test-rel-00.0

--- a/docs/specs/use-cases/rel00.0-uc007-encutil.yaml
+++ b/docs/specs/use-cases/rel00.0-uc007-encutil.yaml
@@ -43,4 +43,4 @@ out_of_scope:
   - Specific encoding scheme implementations (provided by Go standard library).
   - SIGPIPE handling (each cmd/ utility handles independently).
 
-test_suite: test-rel00.0
+test_suite: test-rel-00.0

--- a/docs/specs/use-cases/rel01.1-uc001-cat.yaml
+++ b/docs/specs/use-cases/rel01.1-uc001-cat.yaml
@@ -71,4 +71,4 @@ out_of_scope:
   - Same-file detection warning (cat reading from its own output) is not tested.
   - -u flag is accepted but has no observable effect; a test verifies acceptance only.
 
-test_suite: test-rel01.1
+test_suite: test-rel-01.1

--- a/docs/specs/use-cases/rel01.2-uc001-sponge.yaml
+++ b/docs/specs/use-cases/rel01.2-uc001-sponge.yaml
@@ -74,4 +74,4 @@ out_of_scope:
     differential harness; it is verified by manual inspection.
   - Memory threshold tuning is not tested; the spill path is exercised by the large-input test.
 
-test_suite: test-rel01.2
+test_suite: test-rel-01.2

--- a/docs/specs/use-cases/rel01.3-uc001-du.yaml
+++ b/docs/specs/use-cases/rel01.3-uc001-du.yaml
@@ -78,4 +78,4 @@ out_of_scope:
   - Sparse file creation depends on the filesystem; --apparent-size tests use a regular file
     with known size rather than a true sparse file.
 
-test_suite: test-rel01.3
+test_suite: test-rel-01.3

--- a/docs/specs/use-cases/rel02.0-uc001-true.yaml
+++ b/docs/specs/use-cases/rel02.0-uc001-true.yaml
@@ -44,4 +44,4 @@ out_of_scope:
   - Write-error exit code (R2.3) is not tested in the differential harness; it requires
     closing stdout before invocation, which is platform-specific.
 
-test_suite: test-rel02.0
+test_suite: test-rel-02.0

--- a/docs/specs/use-cases/rel02.0-uc002-false.yaml
+++ b/docs/specs/use-cases/rel02.0-uc002-false.yaml
@@ -42,4 +42,4 @@ out_of_scope:
   - --help and --version output formatting is verified manually, not via differential testing.
   - Write-error exit code (R2.3) is not tested in the differential harness.
 
-test_suite: test-rel02.0
+test_suite: test-rel-02.0

--- a/docs/specs/use-cases/rel02.0-uc003-yes.yaml
+++ b/docs/specs/use-cases/rel02.0-uc003-yes.yaml
@@ -51,4 +51,4 @@ out_of_scope:
   - Empty string argument ("yes ''") behavior is documented in the PRD but may diverge
     between GNU versions; test with caution.
 
-test_suite: test-rel02.0
+test_suite: test-rel-02.0

--- a/docs/specs/use-cases/rel02.0-uc004-basename.yaml
+++ b/docs/specs/use-cases/rel02.0-uc004-basename.yaml
@@ -47,4 +47,4 @@ out_of_scope:
   - NUL-delimited output (-z) is tested for byte correctness but not for consumption by
     downstream tools (xargs -0).
 
-test_suite: test-rel02.0
+test_suite: test-rel-02.0

--- a/docs/specs/use-cases/rel02.0-uc005-dirname.yaml
+++ b/docs/specs/use-cases/rel02.0-uc005-dirname.yaml
@@ -48,4 +48,4 @@ out_of_scope:
   - NUL-delimited output (-z) is tested for byte correctness but not for consumption by
     downstream tools.
 
-test_suite: test-rel02.0
+test_suite: test-rel-02.0

--- a/docs/specs/use-cases/rel02.1-uc001-tee.yaml
+++ b/docs/specs/use-cases/rel02.1-uc001-tee.yaml
@@ -57,4 +57,4 @@ out_of_scope:
     is not automated in the differential harness.
   - Output-error modes (--output-error) and -p flag are excluded per the PRD.
 
-test_suite: test-rel02.1
+test_suite: test-rel-02.1

--- a/docs/specs/use-cases/rel02.2-uc001-head.yaml
+++ b/docs/specs/use-cases/rel02.2-uc001-head.yaml
@@ -57,4 +57,4 @@ out_of_scope:
   - Zero-terminated line mode (-z) is excluded per the PRD.
   - Decimal multiplier suffixes (kB, MB, GB) are excluded per the PRD.
 
-test_suite: test-rel02.2
+test_suite: test-rel-02.2

--- a/docs/specs/use-cases/rel02.2-uc002-seq.yaml
+++ b/docs/specs/use-cases/rel02.2-uc002-seq.yaml
@@ -54,4 +54,4 @@ out_of_scope:
   - Infinity (inf) as an endpoint is excluded; sequences must be bounded.
   - Locale-aware decimal separators are excluded; output always uses '.'.
 
-test_suite: test-rel02.2
+test_suite: test-rel-02.2

--- a/docs/specs/use-cases/rel03.0-uc001-wc.yaml
+++ b/docs/specs/use-cases/rel03.0-uc001-wc.yaml
@@ -61,4 +61,4 @@ out_of_scope:
   - --total=always and --total=only are covered in the test suite but are not part of the primary flow.
   - Binary input edge cases are covered in the test suite but are not the primary flow.
 
-test_suite: test-rel03.0
+test_suite: test-rel-03.0

--- a/docs/specs/use-cases/rel03.1-uc001-uname.yaml
+++ b/docs/specs/use-cases/rel03.1-uc001-uname.yaml
@@ -48,4 +48,4 @@ out_of_scope:
   - Setting system information is not supported and not tested.
   - Long-form flag names beyond --help and --version are not tested.
 
-test_suite: test-rel03.1
+test_suite: test-rel-03.1

--- a/docs/specs/use-cases/rel03.1-uc002-arch.yaml
+++ b/docs/specs/use-cases/rel03.1-uc002-arch.yaml
@@ -42,4 +42,4 @@ out_of_scope:
   - Processor type (-p) and hardware platform (-i) are not reported by arch;
     use uname for those fields.
 
-test_suite: test-rel03.1
+test_suite: test-rel-03.1

--- a/docs/specs/use-cases/rel03.1-uc003-nproc.yaml
+++ b/docs/specs/use-cases/rel03.1-uc003-nproc.yaml
@@ -47,4 +47,4 @@ out_of_scope:
   - CPU affinity and cgroup limits are not tested; on macOS, available and installed
     counts are typically identical.
 
-test_suite: test-rel03.1
+test_suite: test-rel-03.1

--- a/docs/specs/use-cases/rel03.1-uc004-hostname.yaml
+++ b/docs/specs/use-cases/rel03.1-uc004-hostname.yaml
@@ -43,4 +43,4 @@ out_of_scope:
   - Flags found in net-tools hostname (-s, -f, -d, -i) are not part of the
     GNU coreutils hostname and are not tested.
 
-test_suite: test-rel03.1
+test_suite: test-rel-03.1

--- a/docs/specs/use-cases/rel03.1-uc005-hostid.yaml
+++ b/docs/specs/use-cases/rel03.1-uc005-hostid.yaml
@@ -43,4 +43,4 @@ out_of_scope:
   - The meaning of the host identifier value is platform-dependent and not validated
     beyond matching the reference binary output.
 
-test_suite: test-rel03.1
+test_suite: test-rel-03.1

--- a/docs/specs/use-cases/rel04.0-uc001-ls.yaml
+++ b/docs/specs/use-cases/rel04.0-uc001-ls.yaml
@@ -72,4 +72,4 @@ out_of_scope:
   - SIGWINCH behavior is specified in srd008-ls R4.5 but is not directly testable in the
     differential harness.
 
-test_suite: test-rel04.0
+test_suite: test-rel-04.0

--- a/docs/specs/use-cases/rel04.0-uc002-ls-extended.yaml
+++ b/docs/specs/use-cases/rel04.0-uc002-ls-extended.yaml
@@ -74,4 +74,4 @@ out_of_scope:
   - SIGWINCH and terminal resize behavior during -R recursive listing is not testable in the
     differential harness.
 
-test_suite: test-rel04.0-ext
+test_suite: test-rel-04.0-ext

--- a/docs/specs/use-cases/rel04.1-uc001-realpath.yaml
+++ b/docs/specs/use-cases/rel04.1-uc001-realpath.yaml
@@ -51,4 +51,4 @@ out_of_scope:
   - Behavior on filesystems with unusual symlink configurations is not tested
     beyond what the test environment provides.
 
-test_suite: test-rel04.1
+test_suite: test-rel-04.1

--- a/docs/specs/use-cases/rel04.1-uc002-readlink.yaml
+++ b/docs/specs/use-cases/rel04.1-uc002-readlink.yaml
@@ -49,4 +49,4 @@ out_of_scope:
   - Creating or modifying symbolic links is not supported; use ln for that.
   - Relative output (--relative-to) is not supported; use realpath for that.
 
-test_suite: test-rel04.1
+test_suite: test-rel-04.1

--- a/docs/specs/use-cases/rel04.1-uc003-pwd.yaml
+++ b/docs/specs/use-cases/rel04.1-uc003-pwd.yaml
@@ -49,4 +49,4 @@ out_of_scope:
   - Logical mode (-L) behavior depends on the PWD environment variable, which
     may vary between test environments.
 
-test_suite: test-rel04.1
+test_suite: test-rel-04.1

--- a/docs/specs/use-cases/rel04.1-uc004-tty.yaml
+++ b/docs/specs/use-cases/rel04.1-uc004-tty.yaml
@@ -48,4 +48,4 @@ out_of_scope:
   - Testing with an actual terminal device depends on the test environment and
     may be skipped in CI.
 
-test_suite: test-rel04.1
+test_suite: test-rel-04.1

--- a/docs/specs/use-cases/rel04.1-uc005-logname.yaml
+++ b/docs/specs/use-cases/rel04.1-uc005-logname.yaml
@@ -44,4 +44,4 @@ out_of_scope:
   - The distinction between logname and whoami output depends on the login
     session and is not artificially tested.
 
-test_suite: test-rel04.1
+test_suite: test-rel-04.1

--- a/docs/specs/use-cases/rel05.0-uc001-echo.yaml
+++ b/docs/specs/use-cases/rel05.0-uc001-echo.yaml
@@ -52,4 +52,4 @@ out_of_scope:
   - Interactive shell built-in echo behavior is not tested; only the standalone binary is covered.
   - --help and --version output matching is not required.
 
-test_suite: test-rel05.0
+test_suite: test-rel-05.0

--- a/docs/specs/use-cases/rel05.0-uc002-tac.yaml
+++ b/docs/specs/use-cases/rel05.0-uc002-tac.yaml
@@ -52,4 +52,4 @@ out_of_scope:
   - Files larger than available memory are not supported; tac buffers the full input.
   - Regex separator testing (-r) is covered but not the primary use case.
 
-test_suite: test-rel05.0
+test_suite: test-rel-05.0

--- a/docs/specs/use-cases/rel05.0-uc003-nl.yaml
+++ b/docs/specs/use-cases/rel05.0-uc003-nl.yaml
@@ -52,4 +52,4 @@ out_of_scope:
   - Regex numbering style (-b p RE) beyond basic pattern matching is not the primary test focus.
   - Locale-aware regex collation is not tested; LC_ALL=C is used throughout.
 
-test_suite: test-rel05.0
+test_suite: test-rel-05.0

--- a/docs/specs/use-cases/rel05.0-uc004-fold.yaml
+++ b/docs/specs/use-cases/rel05.0-uc004-fold.yaml
@@ -52,4 +52,4 @@ out_of_scope:
   - Unicode multi-byte grapheme width calculation is not implemented; LC_ALL=C single-byte behavior is the requirement.
   - Lines without a trailing newline are handled by matching GNU behavior exactly.
 
-test_suite: test-rel05.0
+test_suite: test-rel-05.0

--- a/docs/specs/use-cases/rel05.1-uc001-expand.yaml
+++ b/docs/specs/use-cases/rel05.1-uc001-expand.yaml
@@ -53,4 +53,4 @@ out_of_scope:
   - Unicode multi-column character width is not tested; LC_ALL=C single-byte behavior is the requirement.
   - Backspace column adjustment is not implemented.
 
-test_suite: test-rel05.1
+test_suite: test-rel-05.1

--- a/docs/specs/use-cases/rel05.1-uc002-unexpand.yaml
+++ b/docs/specs/use-cases/rel05.1-uc002-unexpand.yaml
@@ -54,4 +54,4 @@ out_of_scope:
   - unexpand is not a lossless inverse of expand for all inputs; the asymmetry is intentional.
   - Unicode multi-column character width is not tested; LC_ALL=C is used.
 
-test_suite: test-rel05.1
+test_suite: test-rel-05.1

--- a/docs/specs/use-cases/rel05.2-uc001-cut.yaml
+++ b/docs/specs/use-cases/rel05.2-uc001-cut.yaml
@@ -54,4 +54,4 @@ out_of_scope:
   - Multi-byte delimiter support is not tested; -d accepts one byte.
   - Locale-aware character cutting for -c is not tested beyond LC_ALL=C behavior.
 
-test_suite: test-rel05.2
+test_suite: test-rel-05.2

--- a/docs/specs/use-cases/rel05.2-uc002-paste.yaml
+++ b/docs/specs/use-cases/rel05.2-uc002-paste.yaml
@@ -52,4 +52,4 @@ out_of_scope:
   - Files larger than available file descriptors are not a concern; paste opens all files simultaneously.
   - Multi-byte delimiter escape sequences beyond the defined set are not tested.
 
-test_suite: test-rel05.2
+test_suite: test-rel-05.2

--- a/docs/specs/use-cases/rel05.3-uc001-uniq.yaml
+++ b/docs/specs/use-cases/rel05.3-uc001-uniq.yaml
@@ -54,4 +54,4 @@ out_of_scope:
   - uniq does not sort its input; tests use pre-sorted or deliberately ordered input.
   - The --group flag is not implemented.
 
-test_suite: test-rel05.3
+test_suite: test-rel-05.3

--- a/docs/specs/use-cases/rel05.3-uc002-comm.yaml
+++ b/docs/specs/use-cases/rel05.3-uc002-comm.yaml
@@ -53,4 +53,4 @@ out_of_scope:
   - comm does not sort its inputs; tests use pre-sorted files.
   - Locale-aware collation is not tested; LC_ALL=C is used throughout.
 
-test_suite: test-rel05.3
+test_suite: test-rel-05.3

--- a/docs/specs/use-cases/rel05.4-uc001-md5sum.yaml
+++ b/docs/specs/use-cases/rel05.4-uc001-md5sum.yaml
@@ -52,4 +52,4 @@ out_of_scope:
   - HMAC-MD5 variants are not tested.
   - md5sum is not used for security; only format compatibility is verified.
 
-test_suite: test-rel05.4
+test_suite: test-rel-05.4

--- a/docs/specs/use-cases/rel05.4-uc002-sha1sum.yaml
+++ b/docs/specs/use-cases/rel05.4-uc002-sha1sum.yaml
@@ -50,4 +50,4 @@ success_criteria:
 out_of_scope:
   - SHA-1 is cryptographically broken; this implementation targets format compatibility only.
 
-test_suite: test-rel05.4
+test_suite: test-rel-05.4

--- a/docs/specs/use-cases/rel05.4-uc003-sha256sum.yaml
+++ b/docs/specs/use-cases/rel05.4-uc003-sha256sum.yaml
@@ -50,4 +50,4 @@ success_criteria:
 out_of_scope:
   - SHA-224 and SHA-256/224 truncations are not implemented.
 
-test_suite: test-rel05.4
+test_suite: test-rel-05.4

--- a/docs/specs/use-cases/rel05.4-uc004-sha512sum.yaml
+++ b/docs/specs/use-cases/rel05.4-uc004-sha512sum.yaml
@@ -50,4 +50,4 @@ success_criteria:
 out_of_scope:
   - SHA-384 and SHA-512/256 truncations are not implemented.
 
-test_suite: test-rel05.4
+test_suite: test-rel-05.4

--- a/docs/specs/use-cases/rel06.0-uc001-mkdir.yaml
+++ b/docs/specs/use-cases/rel06.0-uc001-mkdir.yaml
@@ -51,4 +51,4 @@ out_of_scope:
   - SELinux or ACL-based permission handling beyond POSIX mode bits.
   - Behavior on filesystems that do not support standard POSIX permissions.
 
-test_suite: test-rel06.0
+test_suite: test-rel-06.0

--- a/docs/specs/use-cases/rel06.0-uc002-rmdir.yaml
+++ b/docs/specs/use-cases/rel06.0-uc002-rmdir.yaml
@@ -51,4 +51,4 @@ out_of_scope:
   - Recursive removal of non-empty directories; that is the domain of rm -r.
   - Behavior when the directory is a mount point.
 
-test_suite: test-rel06.0
+test_suite: test-rel-06.0

--- a/docs/specs/use-cases/rel06.0-uc003-mktemp.yaml
+++ b/docs/specs/use-cases/rel06.0-uc003-mktemp.yaml
@@ -55,4 +55,4 @@ out_of_scope:
   - Byte-for-byte stdout comparison; random suffixes make exact matching impossible.
   - Security properties of the random name generation beyond what the OS provides.
 
-test_suite: test-rel06.0
+test_suite: test-rel-06.0

--- a/docs/specs/use-cases/rel06.0-uc004-ln.yaml
+++ b/docs/specs/use-cases/rel06.0-uc004-ln.yaml
@@ -51,4 +51,4 @@ out_of_scope:
   - Cross-filesystem hard link restrictions; tests run within a single filesystem.
   - Linking to directories (hard links to directories are disallowed on most systems).
 
-test_suite: test-rel06.0
+test_suite: test-rel-06.0

--- a/docs/specs/use-cases/rel06.0-uc005-unlink.yaml
+++ b/docs/specs/use-cases/rel06.0-uc005-unlink.yaml
@@ -50,4 +50,4 @@ out_of_scope:
   - Unlinking symbolic links to directories; the test covers regular files and plain directories only.
   - Behavior when the file is open by another process (OS-dependent semantics).
 
-test_suite: test-rel06.0
+test_suite: test-rel-06.0

--- a/docs/specs/use-cases/rel06.1-uc001-env.yaml
+++ b/docs/specs/use-cases/rel06.1-uc001-env.yaml
@@ -51,4 +51,4 @@ out_of_scope:
   - Signal handling and the -S (split string) option are not tested.
   - Interaction with login shells or shell-specific environment inheritance is not tested.
 
-test_suite: test-rel06.1
+test_suite: test-rel-06.1

--- a/docs/specs/use-cases/rel06.1-uc002-printenv.yaml
+++ b/docs/specs/use-cases/rel06.1-uc002-printenv.yaml
@@ -52,4 +52,4 @@ out_of_scope:
     downstream tools (xargs -0).
   - Multiple variable arguments on a single invocation are tested only if gprintenv supports them.
 
-test_suite: test-rel06.1
+test_suite: test-rel-06.1

--- a/docs/specs/use-cases/rel06.1-uc003-id.yaml
+++ b/docs/specs/use-cases/rel06.1-uc003-id.yaml
@@ -53,4 +53,4 @@ out_of_scope:
   - Real vs effective ID distinction (-r flag) is tested only if the test environment
     supports setuid scenarios.
 
-test_suite: test-rel06.1
+test_suite: test-rel-06.1

--- a/docs/specs/use-cases/rel06.1-uc004-whoami.yaml
+++ b/docs/specs/use-cases/rel06.1-uc004-whoami.yaml
@@ -47,4 +47,4 @@ out_of_scope:
   - Extra arguments are rejected with an error; this is tested for exit code but not
     for exact error message wording.
 
-test_suite: test-rel06.1
+test_suite: test-rel-06.1

--- a/docs/specs/use-cases/rel06.1-uc005-groups.yaml
+++ b/docs/specs/use-cases/rel06.1-uc005-groups.yaml
@@ -51,4 +51,4 @@ out_of_scope:
     The exact format of the "user : group1 group2" prefix varies across platforms;
     the test compares against ggroups output, not a hardcoded format.
 
-test_suite: test-rel06.1
+test_suite: test-rel-06.1

--- a/docs/specs/use-cases/rel07.0-uc001-sort.yaml
+++ b/docs/specs/use-cases/rel07.0-uc001-sort.yaml
@@ -54,4 +54,4 @@ out_of_scope:
   - Parallel sort (--parallel) is excluded per the PRD.
   - Random sort (-R) is excluded per the PRD.
 
-test_suite: test-rel07.0
+test_suite: test-rel-07.0

--- a/docs/specs/use-cases/rel07.0-uc002-tr.yaml
+++ b/docs/specs/use-cases/rel07.0-uc002-tr.yaml
@@ -52,4 +52,4 @@ success_criteria:
 out_of_scope:
   - Multibyte character support is excluded per the PRD.
 
-test_suite: test-rel07.0
+test_suite: test-rel-07.0

--- a/docs/specs/use-cases/rel07.0-uc003-tail.yaml
+++ b/docs/specs/use-cases/rel07.0-uc003-tail.yaml
@@ -53,4 +53,4 @@ success_criteria:
 out_of_scope:
   - Follow mode (-f) is excluded per the PRD.
 
-test_suite: test-rel07.0
+test_suite: test-rel-07.0

--- a/docs/specs/use-cases/rel07.1-uc001-cp.yaml
+++ b/docs/specs/use-cases/rel07.1-uc001-cp.yaml
@@ -53,4 +53,4 @@ success_criteria:
 out_of_scope:
   - Reflink and sparse file support are excluded per the PRD.
 
-test_suite: test-rel07.1
+test_suite: test-rel-07.1

--- a/docs/specs/use-cases/rel07.1-uc002-mv.yaml
+++ b/docs/specs/use-cases/rel07.1-uc002-mv.yaml
@@ -51,4 +51,4 @@ success_criteria:
 out_of_scope:
   - Backup mode (--backup) is excluded per the PRD.
 
-test_suite: test-rel07.1
+test_suite: test-rel-07.1

--- a/docs/specs/use-cases/rel07.1-uc003-rm.yaml
+++ b/docs/specs/use-cases/rel07.1-uc003-rm.yaml
@@ -52,4 +52,4 @@ success_criteria:
 out_of_scope:
   - One-file-system mode is excluded per the PRD.
 
-test_suite: test-rel07.1
+test_suite: test-rel-07.1

--- a/docs/specs/use-cases/rel08.0-uc001-date.yaml
+++ b/docs/specs/use-cases/rel08.0-uc001-date.yaml
@@ -49,4 +49,4 @@ out_of_scope:
     two binaries execute at slightly different times. Tests use -d @EPOCH exclusively.
   - Relative date strings (yesterday, 2 days ago) are excluded per the PRD.
 
-test_suite: test-rel08.0
+test_suite: test-rel-08.0

--- a/docs/specs/use-cases/rel08.0-uc002-sleep.yaml
+++ b/docs/specs/use-cases/rel08.0-uc002-sleep.yaml
@@ -46,4 +46,4 @@ out_of_scope:
   - Long-duration sleeps are not tested (would make tests slow).
   - Signal interruption behavior is not tested in the differential harness.
 
-test_suite: test-rel08.0
+test_suite: test-rel-08.0

--- a/docs/specs/use-cases/rel08.0-uc003-touch.yaml
+++ b/docs/specs/use-cases/rel08.0-uc003-touch.yaml
@@ -47,4 +47,4 @@ out_of_scope:
   - Symlink timestamp modification (-h) is platform-dependent and not tested on all systems.
   - Nanosecond-precision timestamp comparison is not performed (filesystem granularity varies).
 
-test_suite: test-rel08.0
+test_suite: test-rel-08.0

--- a/docs/specs/use-cases/rel08.0-uc004-timeout.yaml
+++ b/docs/specs/use-cases/rel08.0-uc004-timeout.yaml
@@ -48,4 +48,4 @@ out_of_scope:
   - Interactive terminal behavior with --foreground is not tested in the differential harness.
   - Long-running timeout tests are excluded to keep test execution fast.
 
-test_suite: test-rel08.0
+test_suite: test-rel-08.0

--- a/docs/specs/use-cases/rel08.0-uc005-shuf.yaml
+++ b/docs/specs/use-cases/rel08.0-uc005-shuf.yaml
@@ -49,4 +49,4 @@ out_of_scope:
   - --random-source testing is excluded because it changes the output deterministically
     but depends on the random file content.
 
-test_suite: test-rel08.0
+test_suite: test-rel-08.0

--- a/docs/specs/use-cases/rel08.0-uc006-factor.yaml
+++ b/docs/specs/use-cases/rel08.0-uc006-factor.yaml
@@ -46,4 +46,4 @@ out_of_scope:
   - Numbers exceeding int64 range are not tested because Go's int64 and GNU factor's
     unsigned long long have different overflow behavior.
 
-test_suite: test-rel08.0
+test_suite: test-rel-08.0

--- a/docs/specs/use-cases/rel08.0-uc007-expr.yaml
+++ b/docs/specs/use-cases/rel08.0-uc007-expr.yaml
@@ -49,4 +49,4 @@ out_of_scope:
   - Integer overflow behavior at the int64 boundary is not tested differentially because
     GNU expr uses GMP for arbitrary precision.
 
-test_suite: test-rel08.0
+test_suite: test-rel-08.0

--- a/docs/specs/use-cases/rel08.1-uc001-split.yaml
+++ b/docs/specs/use-cases/rel08.1-uc001-split.yaml
@@ -48,4 +48,4 @@ out_of_scope:
   - "--filter mode is not tested via differential comparison because it executes shell commands."
   - "--verbose output is excluded per the PRD."
 
-test_suite: test-rel08.1
+test_suite: test-rel-08.1

--- a/docs/specs/use-cases/rel08.1-uc002-csplit.yaml
+++ b/docs/specs/use-cases/rel08.1-uc002-csplit.yaml
@@ -48,4 +48,4 @@ out_of_scope:
   - "--suppress-matched advanced behavior is excluded per the PRD."
   - "--keep-files on error is excluded per the PRD."
 
-test_suite: test-rel08.1
+test_suite: test-rel-08.1

--- a/docs/specs/use-cases/rel08.1-uc003-join.yaml
+++ b/docs/specs/use-cases/rel08.1-uc003-join.yaml
@@ -47,4 +47,4 @@ out_of_scope:
   - Locale-aware collation beyond LC_ALL=C is excluded per the PRD.
   - "--nocheck-order is excluded per the PRD."
 
-test_suite: test-rel08.1
+test_suite: test-rel-08.1

--- a/docs/specs/use-cases/rel08.1-uc004-fmt.yaml
+++ b/docs/specs/use-cases/rel08.1-uc004-fmt.yaml
@@ -50,4 +50,4 @@ out_of_scope:
   - Crown margin mode (-c) is excluded per the PRD.
   - Locale-aware line breaking is excluded per the PRD.
 
-test_suite: test-rel08.1
+test_suite: test-rel-08.1

--- a/docs/specs/use-cases/rel08.1-uc005-numfmt.yaml
+++ b/docs/specs/use-cases/rel08.1-uc005-numfmt.yaml
@@ -48,4 +48,4 @@ out_of_scope:
   - Locale-aware digit grouping is excluded per the PRD.
   - "--grouping is excluded per the PRD."
 
-test_suite: test-rel08.1
+test_suite: test-rel-08.1

--- a/docs/specs/use-cases/rel08.1-uc006-od.yaml
+++ b/docs/specs/use-cases/rel08.1-uc006-od.yaml
@@ -49,4 +49,4 @@ out_of_scope:
   - "--strings (-S) mode is excluded per the PRD."
   - "--endian byte-order control is excluded per the PRD."
 
-test_suite: test-rel08.1
+test_suite: test-rel-08.1

--- a/docs/specs/use-cases/rel08.1-uc007-printf.yaml
+++ b/docs/specs/use-cases/rel08.1-uc007-printf.yaml
@@ -49,4 +49,4 @@ out_of_scope:
   - "%q shell-escaped string is a bash extension excluded per the PRD."
   - "--help and --version as flags are excluded per the PRD."
 
-test_suite: test-rel08.1
+test_suite: test-rel-08.1

--- a/docs/specs/use-cases/rel09.0-uc001-sha224sum.yaml
+++ b/docs/specs/use-cases/rel09.0-uc001-sha224sum.yaml
@@ -50,4 +50,4 @@ success_criteria:
 out_of_scope:
   - SHA-256 digests are not implemented by this utility.
 
-test_suite: test-rel09.0
+test_suite: test-rel-09.0

--- a/docs/specs/use-cases/rel09.0-uc002-sha384sum.yaml
+++ b/docs/specs/use-cases/rel09.0-uc002-sha384sum.yaml
@@ -50,4 +50,4 @@ success_criteria:
 out_of_scope:
   - SHA-512 digests are not implemented by this utility.
 
-test_suite: test-rel09.0
+test_suite: test-rel-09.0

--- a/docs/specs/use-cases/rel09.0-uc003-b2sum.yaml
+++ b/docs/specs/use-cases/rel09.0-uc003-b2sum.yaml
@@ -52,4 +52,4 @@ out_of_scope:
   - BLAKE2s algorithm is not implemented.
   - Keyed hashing and BLAKE2 MAC mode are not implemented.
 
-test_suite: test-rel09.0
+test_suite: test-rel-09.0

--- a/docs/specs/use-cases/rel09.0-uc004-cksum.yaml
+++ b/docs/specs/use-cases/rel09.0-uc004-cksum.yaml
@@ -50,4 +50,4 @@ out_of_scope:
   - --check mode for CRC verification is not implemented.
   - --base64 encoding is not implemented.
 
-test_suite: test-rel09.0
+test_suite: test-rel-09.0

--- a/docs/specs/use-cases/rel09.0-uc005-sum.yaml
+++ b/docs/specs/use-cases/rel09.0-uc005-sum.yaml
@@ -48,4 +48,4 @@ success_criteria:
 out_of_scope:
   - Modern hash algorithms are not implemented; use sha256sum or cksum for that.
 
-test_suite: test-rel09.0
+test_suite: test-rel-09.0

--- a/docs/specs/use-cases/rel15.0-uc001-ts.yaml
+++ b/docs/specs/use-cases/rel15.0-uc001-ts.yaml
@@ -56,4 +56,4 @@ out_of_scope:
   - -m mode (monotonic clock) differential testing is noted in the test suite but excluded from the primary flow because the reference binary and Go binary may use different monotonic sources.
   - The use case does not cover cmd/ts code generation by the orchestrator; that is handled by the cobbler:stitch mage target.
 
-test_suite: test-rel15.0
+test_suite: test-rel-15.0

--- a/docs/specs/use-cases/rel15.0-uc002-stty.yaml
+++ b/docs/specs/use-cases/rel15.0-uc002-stty.yaml
@@ -37,4 +37,4 @@ success_criteria:
 out_of_scope:
   - Platform-specific features not available on macOS.
 
-test_suite: test-rel15.0
+test_suite: test-rel-15.0

--- a/docs/specs/use-cases/rel15.0-uc003-pr.yaml
+++ b/docs/specs/use-cases/rel15.0-uc003-pr.yaml
@@ -37,4 +37,4 @@ success_criteria:
 out_of_scope:
   - Platform-specific features not available on macOS.
 
-test_suite: test-rel15.0
+test_suite: test-rel-15.0

--- a/docs/specs/use-cases/rel15.0-uc004-ptx.yaml
+++ b/docs/specs/use-cases/rel15.0-uc004-ptx.yaml
@@ -37,4 +37,4 @@ success_criteria:
 out_of_scope:
   - Platform-specific features not available on macOS.
 
-test_suite: test-rel15.0
+test_suite: test-rel-15.0

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260513.0
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260612.0
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260513.0 h1:gGPoqeadkNvkBxUwdgNF3s11YFDnNFzAYk6Y7ykXjZk=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260513.0/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260612.0 h1:26PXYW6REuoPAg+9cZdX8fAeuqhxC259RLdcMIy+hY0=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260612.0/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/magefiles/orchestrator.go
+++ b/magefiles/orchestrator.go
@@ -28,9 +28,6 @@ type Prompt mg.Namespace
 // Stats groups the stats targets (LOC, tokens).
 type Stats mg.Namespace
 
-// Validate groups validation targets for agent tool use.
-type Validate mg.Namespace
-
 // Tests: run directly with go test:
 //   go test -tags=usecase -v -count=1 -timeout 1800s ./tests/rel01.0/...          # all
 //   go test -tags=usecase -v ./tests/rel01.0/uc001/                               # one UC
@@ -154,10 +151,4 @@ func (Prompt) Measure() error { return newOrch().DumpMeasurePrompt() }
 
 // Stitch prints the assembled stitch prompt to stdout.
 func (Prompt) Stitch() error { return newOrch().DumpStitchPrompt() }
-
-// --- Validate targets ---
-
-// Weights validates a proposed task's weight budget against MaxWeightPerTask.
-// Pass a string like 'srd005-wc R2.5, R2.6, R3.1, R3.2'.
-func (Validate) Weights(input string) error { return newOrch().ValidateTaskWeights(input) }
 


### PR DESCRIPTION
## Summary

Upgrades cobbler-scaffold from v0.20260513.0 to v0.20260612.0. Three upstream changes land in this repo: new constitutions (interface, issue-format, semantic-model), design.yaml indexing the semantic_model document type, and the standardized dashed test-suite ID convention enforced by the new mage analyze. Mechanical knock-on: 20 test-suite file renames, 34 internal id fields, 84 use-case test_suite refs, and SPECIFICATIONS.yaml updates.

## Changes

- `magefiles/go.mod` + `go.sum`: bumped scaffold dep to v0.20260612.0
- `magefiles/orchestrator.go`: regenerated from upstream template. Drops the local Validate namespace / validate:weights target — the underlying `ValidateTaskWeights` is still on the orchestrator API; if the CLI shortcut is wanted permanently it should be added to cobbler-scaffold's `orchestrator.go.tmpl`.
- `docs/constitutions/`: new `interface.yaml`, `issue-format.yaml`, `semantic-model.yaml`; `design.yaml` updated for semantic models and dashed test-suite IDs
- `docs/specs/test-suites/`: 20 files renamed `test-relX.Y.yaml` → `test-rel-X.Y.yaml` via `git mv` (history preserved); 34 internal `id:` fields updated
- `docs/specs/use-cases/`: 84 `test_suite:` refs updated to dashed form
- `docs/SPECIFICATIONS.yaml`: test_suite refs, Mermaid TS nodes, and the test_suites index updated
- `.cobbler/`: new `measure_context.yaml` and `stitch_context.yaml` from scaffold:push

## Stats

| | Before | After | Δ |
|---|---|---|---|
| Go LOC (prod) | 32,975 | 32,975 | +0 |
| Go LOC (test) | 25,278 | 25,278 | +0 |
| Doc words (srd) | 75,514 | 75,514 | +0 |
| Doc words (use_case) | 29,981 | 29,981 | +0 |
| Doc words (test_suite) | 25,462 | 25,462 | +0 |

Upgrade is docs/configs only — no Go LOC delta.

## Test plan

- [x] `mage analyze` — 0 hard errors, 867 pre-existing warnings (638 + 127 + 102, identical to pre-upgrade counts)
- [x] `go vet ./pkg/... ./cmd/...` — clean
- [x] `mage -l` — all targets resolve under the new orchestrator
- [ ] `mage analyze` warnings reviewed — pre-existing AC/success-criterion traceability debt, out of scope for this upgrade

## Notes

The new mage analyze headline reads `✅ No hard errors (867 warnings — see above)` instead of the old misleading `✅ All consistency checks passed`. The 867 warnings predate this upgrade — Run 43's reset left the AC and success-criterion traces incomplete; tackling them is the natural next post-generation cleanup.

Closes #5062