### PR TITLE
GH-5685: Bump cobbler-scaffold v0.20260612.0 → v0.20260612.1

### DIFF
--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -4,7 +4,7 @@ go 1.25.7
 
 require (
 	github.com/magefile/mage v1.15.0
-	github.com/mesh-intelligence/cobbler-scaffold v0.20260612.0
+	github.com/mesh-intelligence/cobbler-scaffold v0.20260612.1
 )
 
 require (

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260612.0 h1:26PXYW6REuoPAg+9cZdX8fAeuqhxC259RLdcMIy+hY0=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260612.0/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260612.1 h1:ByAcl1pcwvPOhf35He34s5sUNuifXGavFguIAAfxm48=
+github.com/mesh-intelligence/cobbler-scaffold v0.20260612.1/go.mod h1:7ClERKqRLakydq2mwtElXc/uuNoiHD9SnKxndu8w5yg=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Summary

Bumps `magefiles/cobbler-scaffold` from `v0.20260612.0` to `v0.20260612.1`. The only upstream change in this version is GH-2145 / scaffold PR #2146, which adds a new `BareTouchpointEntries` warning to `mage analyze`. The check flags each individual touchpoint string in a use case that contains no `srd*-id` token — previously the analyze pass aggregated SRD citations across all touchpoints on a use case, letting prose-only touchpoints (e.g. `pkg/testutils — RunDiffTests, …`) slip through whenever any sibling touchpoint cited an SRD.

## Changes

- `magefiles/go.mod`, `magefiles/go.sum` — version pin only.
- No source, constitution, prompt, or template files touched.

## Stats

|  | Before (v0.20260612.0) | After (v0.20260612.1) | Δ |
|---|---|---|---|
| `mage analyze` hard errors | 0 | 0 | 0 |
| `mage analyze` warnings | 867 | 1042 | +175 (all `Bare touchpoint entries`) |
| `mage stats:loc` go prod | 32975 | 32975 | 0 |
| `mage stats:loc` go test | 25278 | 25278 | 0 |
| spec words (srd/uc/ts) | 75514 / 29981 / 25462 | 75514 / 29981 / 25462 | 0 |

The 175 new warnings are informational, not a regression. Follow-up: file a corpus refactor issue to convert prose-form touchpoints into structured form so the new check drains to zero.

## Test plan

- [x] `mage analyze` passes (0 hard errors)
- [x] `mage analyze` shows the new `Bare touchpoint entries` section
- [x] `mage stats:loc` totals unchanged from main baseline
- [x] No spec, prompt, or constitution files touched

Closes #5685