### PR TITLE
Link .claude and .opencode to coding-skills

### DIFF
--- a/.claude
+++ b/.claude
@@ -1,1 +1,1 @@
-../cobbler-scaffold/.claude
+../coding-skills/.claude


### PR DESCRIPTION
Repoint the skill directories at the dedicated coding-skills repository (relative symlinks to `../coding-skills/`) instead of cobbler-scaffold.

Pairs with petar-djukic/coding-skills#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)